### PR TITLE
feat(admin-client): settings redesign + templates + policies catalogs

### DIFF
--- a/admin-client/e2e/fixtures/chip-test.html
+++ b/admin-client/e2e/fixtures/chip-test.html
@@ -1,0 +1,65 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/7.0.1/css/all.min.css" />
+    <title>Chip widget e2e fixture</title>
+    <style>
+      body { font-family: system-ui, sans-serif; padding: 24px; max-width: 720px; }
+      h2 { font-size: 1rem; margin: 24px 0 8px; }
+      [data-fixture] { padding: 12px; border: 1px solid #ccc; border-radius: 6px; }
+    </style>
+  </head>
+  <body>
+    <h1>chipMultiSelect e2e fixture</h1>
+
+    <h2>Unrestricted (free-form input + + button — for matchUpFormatCode etc.)</h2>
+    <div data-fixture="unrestricted"></div>
+
+    <h2>Pinned universe (provisioner caps restrict)</h2>
+    <div data-fixture="restricted"></div>
+
+    <h2>Full universe (factory enum, no caps)</h2>
+    <div data-fixture="full-universe"></div>
+
+    <script type="module">
+      import '../../src/pages/tournament/tabs/settingsTab/settingsPanel/settingsPanel.css';
+      import { chipMultiSelect } from '../../src/pages/tournament/tabs/settingsTab/settingsPanel/widgets.ts';
+
+      const events = [];
+      window.__chipEvents = events;
+
+      const unrestrictedHost = document.querySelector('[data-fixture="unrestricted"]');
+      unrestrictedHost.appendChild(
+        chipMultiSelect({
+          label: 'Draw Types (unrestricted)',
+          values: [],
+          onChange: (next) => events.push({ kind: 'unrestricted', next: [...next] }),
+        }),
+      );
+
+      const restrictedHost = document.querySelector('[data-fixture="restricted"]');
+      restrictedHost.appendChild(
+        chipMultiSelect({
+          label: 'Draw Types (restricted)',
+          values: ['LEGACY'],
+          pinnedUniverse: ['SINGLE_ELIMINATION', 'ROUND_ROBIN', 'COMPASS'],
+          onChange: (next) => events.push({ kind: 'restricted', next: [...next] }),
+        }),
+      );
+
+      const fullUniverseHost = document.querySelector('[data-fixture="full-universe"]');
+      fullUniverseHost.appendChild(
+        chipMultiSelect({
+          label: 'Creation Methods (full universe)',
+          values: [],
+          fullUniverse: ['AUTOMATED', 'MANUAL', 'DRAFT'],
+          onChange: (next) => events.push({ kind: 'full-universe', next: [...next] }),
+        }),
+      );
+
+      window.__chipFixtureReady = true;
+    </script>
+  </body>
+</html>

--- a/admin-client/e2e/journeys/05-allowed-selections-chips.spec.ts
+++ b/admin-client/e2e/journeys/05-allowed-selections-chips.spec.ts
@@ -1,0 +1,181 @@
+/**
+ * E2E coverage for the Allowed Selections chip widget.
+ *
+ * The widget powers the Settings panel → Allowed Selections topic (draw
+ * types, creation methods, scoring approaches, matchUp formats). It runs
+ * in two modes:
+ *   - unrestricted: text input + "+" button to add arbitrary values
+ *   - restricted:   one chip per provisioner-allowed value, click to toggle
+ *
+ * Both modes have been reported as "+ doesn't work" in the live app. This
+ * suite exercises them through a real browser (CSS + click-bubbling) via
+ * a fixture page rather than spinning up a full provider/tournament context.
+ *
+ * Fixture: e2e/fixtures/chip-test.html — Vite serves it on the fly and
+ * resolves the relative .ts/.css imports through the dev server.
+ */
+import { test, expect, type Page } from '@playwright/test';
+
+const FIXTURE_PATH = 'e2e/fixtures/chip-test.html';
+
+async function gotoFixture(page: Page): Promise<void> {
+  await page.goto(FIXTURE_PATH);
+  // Wait for the inline module to finish setting up the widgets.
+  await page.waitForFunction(() => (window as any).__chipFixtureReady === true);
+}
+
+async function readEvents(page: Page): Promise<Array<{ kind: string; next: string[] }>> {
+  return page.evaluate(() => (window as any).__chipEvents.slice());
+}
+
+test.describe('Allowed Selections — unrestricted (input + + button)', () => {
+  test('typing a value and clicking + emits the new value', async ({ page }) => {
+    await gotoFixture(page);
+
+    const fixture = page.locator('[data-fixture="unrestricted"]');
+    const input = fixture.locator('.sp-chip-add-input');
+    const addBtn = fixture.locator('.sp-chip-add-btn');
+
+    await input.fill('SINGLE_ELIMINATION');
+    // Sync state should pick up the typed value and mark the button "ready".
+    await expect(addBtn).toHaveClass(/is-ready/);
+
+    await addBtn.click();
+
+    const events = await readEvents(page);
+    expect(events.at(-1)).toEqual({ kind: 'unrestricted', next: ['SINGLE_ELIMINATION'] });
+
+    // After commit, a fresh chip plus a fresh input should be in the DOM.
+    await expect(fixture.locator('.sp-chip').filter({ hasText: 'SINGLE_ELIMINATION' })).toBeVisible();
+    await expect(fixture.locator('.sp-chip-add-input')).toHaveValue('');
+  });
+
+  test('pressing Enter on the input commits the value', async ({ page }) => {
+    await gotoFixture(page);
+
+    const fixture = page.locator('[data-fixture="unrestricted"]');
+    const input = fixture.locator('.sp-chip-add-input');
+
+    await input.fill('ROUND_ROBIN');
+    await input.press('Enter');
+
+    const events = await readEvents(page);
+    expect(events.at(-1)).toEqual({ kind: 'unrestricted', next: ['ROUND_ROBIN'] });
+  });
+
+  test('clicking + with empty input focuses the input and emits nothing', async ({ page }) => {
+    await gotoFixture(page);
+
+    const fixture = page.locator('[data-fixture="unrestricted"]');
+    const input = fixture.locator('.sp-chip-add-input');
+    const addBtn = fixture.locator('.sp-chip-add-btn');
+
+    await addBtn.click();
+
+    expect(await readEvents(page)).toHaveLength(0);
+    await expect(input).toBeFocused();
+  });
+
+  test('removing a chip via its x icon emits without the value', async ({ page }) => {
+    await gotoFixture(page);
+
+    const fixture = page.locator('[data-fixture="unrestricted"]');
+    const input = fixture.locator('.sp-chip-add-input');
+    const addBtn = fixture.locator('.sp-chip-add-btn');
+
+    await input.fill('COMPASS');
+    await addBtn.click();
+    await expect(fixture.locator('.sp-chip').filter({ hasText: 'COMPASS' })).toBeVisible();
+
+    await fixture.locator('.sp-chip').filter({ hasText: 'COMPASS' }).click();
+
+    const events = await readEvents(page);
+    expect(events.at(-1)).toEqual({ kind: 'unrestricted', next: [] });
+  });
+});
+
+test.describe('Allowed Selections — full universe (factory enum)', () => {
+  test('renders one chip per factory enum value, no free-form input', async ({ page }) => {
+    await gotoFixture(page);
+
+    const fixture = page.locator('[data-fixture="full-universe"]');
+    await expect(fixture.locator('.sp-chip')).toHaveCount(3);
+    await expect(fixture.locator('.sp-chip-add-input')).toHaveCount(0);
+  });
+
+  test('clicking an unselected chip selects it and emits the value', async ({ page }) => {
+    await gotoFixture(page);
+
+    const fixture = page.locator('[data-fixture="full-universe"]');
+    const chip = fixture.locator('.sp-chip').filter({ hasText: 'AUTOMATED' });
+    await expect(chip).not.toHaveClass(/is-selected/);
+    await chip.click();
+    await expect(chip).toHaveClass(/is-selected/);
+
+    const events = await readEvents(page);
+    expect(events.at(-1)).toEqual({ kind: 'full-universe', next: ['AUTOMATED'] });
+  });
+});
+
+test.describe('Allowed Selections — restricted (chip toggle)', () => {
+  test('clicking an unselected chip selects it and emits the value', async ({ page }) => {
+    await gotoFixture(page);
+
+    const fixture = page.locator('[data-fixture="restricted"]');
+    const chip = fixture.locator('.sp-chip').filter({ hasText: 'SINGLE_ELIMINATION' });
+
+    await expect(chip).not.toHaveClass(/is-selected/);
+    await chip.click();
+    await expect(chip).toHaveClass(/is-selected/);
+
+    const events = await readEvents(page);
+    expect(events.at(-1)?.kind).toBe('restricted');
+    expect(events.at(-1)?.next).toContain('SINGLE_ELIMINATION');
+  });
+
+  test('clicking a selected chip removes it from the selection', async ({ page }) => {
+    await gotoFixture(page);
+
+    const fixture = page.locator('[data-fixture="restricted"]');
+    const chip = fixture.locator('.sp-chip').filter({ hasText: 'ROUND_ROBIN' });
+
+    await chip.click();
+    await expect(chip).toHaveClass(/is-selected/);
+    await chip.click();
+    await expect(chip).not.toHaveClass(/is-selected/);
+
+    const events = await readEvents(page);
+    const last = events.at(-1)!;
+    expect(last.kind).toBe('restricted');
+    expect(last.next).not.toContain('ROUND_ROBIN');
+  });
+
+  test('out-of-cap orphan values render with the orphan modifier and toggle off', async ({ page }) => {
+    await gotoFixture(page);
+
+    const fixture = page.locator('[data-fixture="restricted"]');
+    const orphan = fixture.locator('.sp-chip.is-orphan').filter({ hasText: 'LEGACY' });
+
+    await expect(orphan).toHaveCount(1);
+    await orphan.click();
+
+    const events = await readEvents(page);
+    expect(events.at(-1)?.kind).toBe('restricted');
+    expect(events.at(-1)?.next).not.toContain('LEGACY');
+  });
+
+  test('clicks land on the chip even when the user clicks on the inner icon', async ({ page }) => {
+    // This is the regression that motivated `pointer-events: none` on chip
+    // children — Font Awesome glyphs were eating clicks in some host CSS.
+    await gotoFixture(page);
+
+    const fixture = page.locator('[data-fixture="restricted"]');
+    const chip = fixture.locator('.sp-chip').filter({ hasText: 'COMPASS' });
+
+    await chip.locator('i').click();
+    await expect(chip).toHaveClass(/is-selected/);
+
+    const events = await readEvents(page);
+    expect(events.at(-1)?.next).toContain('COMPASS');
+  });
+});

--- a/admin-client/package.json
+++ b/admin-client/package.json
@@ -21,7 +21,7 @@
   "dependencies": {
     "animate.css": "^4.1.1",
     "axios": "^1.13.0",
-    "courthive-components": "^1.0.1",
+    "courthive-components": "^1.1.1",
     "i18next": "^26.0.0",
     "jwt-decode": "^4.0.0",
     "navigo": "^8.11.1",

--- a/admin-client/src/components/framework/rootBlock.ts
+++ b/admin-client/src/components/framework/rootBlock.ts
@@ -2,7 +2,7 @@
  * Root application block for the admin client.
  * Creates navbar, main content area with page containers.
  */
-import { NONE, TMX_ADMIN, TMX_SYSTEM, TMX_PROVISIONER, TMX_SANCTIONING, TMX_SYNC, TMX_DRAWER } from 'constants/tmxConstants';
+import { NONE, TMX_ADMIN, TMX_SYSTEM, TMX_PROVISIONER, TMX_SANCTIONING, TMX_SYNC, TMX_TEMPLATES, TMX_POLICIES, TMX_DRAWER } from 'constants/tmxConstants';
 
 const flexColFlexGrow = 'flexcol flexgrow';
 
@@ -47,6 +47,20 @@ export function rootBlock(): HTMLElement {
   sync.id = TMX_SYNC;
   main.appendChild(sync);
 
+  // Templates page container (per-provider topology / tieFormat / composition)
+  const templates = document.createElement('div');
+  templates.className = flexColFlexGrow;
+  templates.style.display = NONE;
+  templates.id = TMX_TEMPLATES;
+  main.appendChild(templates);
+
+  // Policies page container (per-provider policy catalog)
+  const policies = document.createElement('div');
+  policies.className = flexColFlexGrow;
+  policies.style.display = NONE;
+  policies.id = TMX_POLICIES;
+  main.appendChild(policies);
+
   // Drawer
   const drawer = document.createElement('section');
   drawer.className = 'drawer drawer--left';
@@ -82,6 +96,8 @@ function createNavbar(): HTMLDivElement {
       <i id='h-admin' class="home-nav-icon fa-solid fa-shield-halved" title="Admin"></i>
       <i id='h-provisioner' class="home-nav-icon fa-solid fa-handshake" title="My Organization"></i>
       <i id='h-sanctioning' class="home-nav-icon fa-solid fa-stamp" title="Sanctioning"></i>
+      <i id='h-templates' class="home-nav-icon fa-solid fa-shapes" title="Templates"></i>
+      <i id='h-policies' class="home-nav-icon fa-solid fa-file-shield" title="Policies"></i>
       <i id='h-sync' class="home-nav-icon fa-solid fa-arrows-rotate" title="Tournament Sync"></i>
       <i id='h-stop-impersonating' class="home-nav-icon fa-solid fa-xmark" title="Stop impersonating" style="display:none; color: var(--tmx-accent-orange, #f5a623);"></i>
     </div>

--- a/admin-client/src/constants/tmxConstants.ts
+++ b/admin-client/src/constants/tmxConstants.ts
@@ -31,6 +31,14 @@ export const PROVISIONER_ROUTE = 'provisioner';
 export const TMX_SANCTIONING = 'tmxSanctioning';
 export const SANCTIONING = 'sanctioning';
 
+// Templates (per-provider topology / tieFormat / composition catalogs)
+export const TMX_TEMPLATES = 'tmxTemplates';
+export const TEMPLATES = 'templates';
+
+// Policies (per-provider policy catalog)
+export const TMX_POLICIES = 'tmxPolicies';
+export const POLICIES = 'policies';
+
 // Tournament Sync
 export const TMX_SYNC = 'tmxSync';
 export const SYNC = 'sync';

--- a/admin-client/src/initialState.ts
+++ b/admin-client/src/initialState.ts
@@ -2,6 +2,7 @@ import { initLoginToggle, getLoginState } from 'services/authentication/loginSta
 import { initTheme, initThemeToggle } from 'services/theme/themeService';
 import { version, buildCommit, buildTime } from 'config/version';
 import { loadRuntimeConfig } from 'services/runtimeConfig';
+import { wireNavVisibilityListeners } from 'services/navigation/navVisibility';
 import { routeAdmin } from 'router/router';
 
 import 'courthive-components/dist/courthive-components.css';
@@ -21,6 +22,7 @@ export function setupAdmin(): void {
   initTheme();
   initThemeToggle('themeToggle');
   initLoginToggle('login');
+  wireNavVisibilityListeners();
   getLoginState();
   // Fire-and-forget — the impersonate handler awaits the same promise if a
   // user clicks before this resolves, so there's no race.

--- a/admin-client/src/pages/policies/policiesPage.css
+++ b/admin-client/src/pages/policies/policiesPage.css
@@ -1,0 +1,32 @@
+.pol-host {
+  flex: 1;
+  min-height: 0;
+  display: flex;
+  flex-direction: column;
+}
+
+.pol-no-provider {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: 12px;
+  padding: 64px 24px;
+  color: var(--tmx-text-secondary, #666);
+  text-align: center;
+}
+
+.pol-no-provider i {
+  font-size: 2rem;
+  color: var(--tmx-text-muted, #aaa);
+}
+
+.pol-no-provider p {
+  margin: 0;
+}
+
+.pol-no-provider-sub {
+  font-size: 0.85rem;
+  color: var(--tmx-text-muted, #aaa);
+  max-width: 420px;
+}

--- a/admin-client/src/pages/policies/policyBridge.ts
+++ b/admin-client/src/pages/policies/policyBridge.ts
@@ -1,0 +1,162 @@
+/**
+ * Builtin policy catalog — sourced from `tods-competition-factory` fixtures.
+ * The Policies page seeds the courthive-components catalog with these
+ * read-only items; per-provider user policies come from the server's
+ * generic catalog endpoint (`/provider/:id/catalog/policy`).
+ *
+ * Builtin IDs are stable strings (`builtin-<slug>`) so the same builtin
+ * always shows up under the same id between sessions. User IDs are server
+ * UUIDs.
+ */
+import { fixtures, policyConstants } from 'tods-competition-factory';
+import type { PolicyCatalogItem } from 'courthive-components';
+
+const {
+  POLICY_TYPE_SCHEDULING,
+  POLICY_TYPE_SCORING,
+  POLICY_TYPE_SEEDING,
+  POLICY_TYPE_RANKING_POINTS,
+} = policyConstants;
+
+const {
+  policies: {
+    POLICY_RANKING_POINTS_ATP,
+    POLICY_RANKING_POINTS_BASIC,
+    POLICY_RANKING_POINTS_WTA,
+    POLICY_RANKING_POINTS_ITF_WTT,
+    POLICY_RANKING_POINTS_ITF_JUNIOR,
+    POLICY_RANKING_POINTS_TENNIS_EUROPE,
+    POLICY_RANKING_POINTS_USTA_JUNIOR,
+    POLICY_RANKING_POINTS_LTA,
+    POLICY_RANKING_POINTS_TENNIS_AUSTRALIA,
+    POLICY_RANKING_POINTS_TENNIS_CANADA,
+    POLICY_SCHEDULING_DEFAULT,
+    POLICY_SCORING_DEFAULT,
+    POLICY_SCORING_USTA,
+    POLICY_SEEDING_DEFAULT,
+    POLICY_SEEDING_ITF,
+  },
+} = fixtures as any;
+
+export const BUILTIN_POLICIES: PolicyCatalogItem[] = [
+  {
+    id: 'builtin-scheduling-default',
+    name: 'Default Scheduling',
+    policyType: POLICY_TYPE_SCHEDULING,
+    source: 'builtin',
+    description: 'Default match scheduling times, recovery periods, and daily limits',
+    policyData: POLICY_SCHEDULING_DEFAULT[POLICY_TYPE_SCHEDULING],
+  },
+  {
+    id: 'builtin-scoring-default',
+    name: 'Default Scoring',
+    policyType: POLICY_TYPE_SCORING,
+    source: 'builtin',
+    description: 'Default scoring formats and match completion rules',
+    policyData: POLICY_SCORING_DEFAULT[POLICY_TYPE_SCORING],
+  },
+  {
+    id: 'builtin-scoring-usta',
+    name: 'USTA Scoring',
+    policyType: POLICY_TYPE_SCORING,
+    source: 'builtin',
+    description: 'USTA-flavored scoring rules',
+    policyData: POLICY_SCORING_USTA[POLICY_TYPE_SCORING],
+  },
+  {
+    id: 'builtin-seeding-default',
+    name: 'Default Seeding',
+    policyType: POLICY_TYPE_SEEDING,
+    source: 'builtin',
+    description: 'Default seeding thresholds and positioning rules',
+    policyData: POLICY_SEEDING_DEFAULT[POLICY_TYPE_SEEDING],
+  },
+  {
+    id: 'builtin-seeding-itf',
+    name: 'ITF Seeding',
+    policyType: POLICY_TYPE_SEEDING,
+    source: 'builtin',
+    description: 'ITF seeding pattern',
+    policyData: POLICY_SEEDING_ITF[POLICY_TYPE_SEEDING],
+  },
+  {
+    id: 'builtin-ranking-points-basic',
+    name: 'Basic Ranking Points',
+    policyType: POLICY_TYPE_RANKING_POINTS,
+    source: 'builtin',
+    description: 'Simple finishing-position points — works for any event regardless of category or level',
+    policyData: POLICY_RANKING_POINTS_BASIC[POLICY_TYPE_RANKING_POINTS],
+  },
+  {
+    id: 'builtin-ranking-points-atp',
+    name: 'ATP Ranking Points (2026)',
+    policyType: POLICY_TYPE_RANKING_POINTS,
+    source: 'builtin',
+    description: 'PIF ATP Rankings — Grand Slams through ITF events, 15 tournament levels',
+    policyData: POLICY_RANKING_POINTS_ATP[POLICY_TYPE_RANKING_POINTS],
+  },
+  {
+    id: 'builtin-ranking-points-wta',
+    name: 'WTA Ranking Points (2026)',
+    policyType: POLICY_TYPE_RANKING_POINTS,
+    source: 'builtin',
+    description: 'PIF WTA Rankings — Grand Slams through WTA 125, with quality win bonuses',
+    policyData: POLICY_RANKING_POINTS_WTA[POLICY_TYPE_RANKING_POINTS],
+  },
+  {
+    id: 'builtin-ranking-points-itf-wtt',
+    name: 'ITF World Tennis Tour Points',
+    policyType: POLICY_TYPE_RANKING_POINTS,
+    source: 'builtin',
+    description: 'ITF World Tennis Tour — qualifying round points for $15K–$25K+H tournaments',
+    policyData: POLICY_RANKING_POINTS_ITF_WTT[POLICY_TYPE_RANKING_POINTS],
+  },
+  {
+    id: 'builtin-ranking-points-itf-junior',
+    name: 'ITF Junior Points',
+    policyType: POLICY_TYPE_RANKING_POINTS,
+    source: 'builtin',
+    description: 'ITF Junior World Tour points',
+    policyData: POLICY_RANKING_POINTS_ITF_JUNIOR[POLICY_TYPE_RANKING_POINTS],
+  },
+  {
+    id: 'builtin-ranking-points-tennis-europe',
+    name: 'Tennis Europe Points',
+    policyType: POLICY_TYPE_RANKING_POINTS,
+    source: 'builtin',
+    description: 'Tennis Europe Junior Tour points',
+    policyData: POLICY_RANKING_POINTS_TENNIS_EUROPE[POLICY_TYPE_RANKING_POINTS],
+  },
+  {
+    id: 'builtin-ranking-points-usta-junior',
+    name: 'USTA Junior Points',
+    policyType: POLICY_TYPE_RANKING_POINTS,
+    source: 'builtin',
+    description: 'USTA Junior National & Section ranking points',
+    policyData: POLICY_RANKING_POINTS_USTA_JUNIOR[POLICY_TYPE_RANKING_POINTS],
+  },
+  {
+    id: 'builtin-ranking-points-lta',
+    name: 'LTA Points',
+    policyType: POLICY_TYPE_RANKING_POINTS,
+    source: 'builtin',
+    description: 'Lawn Tennis Association ranking points',
+    policyData: POLICY_RANKING_POINTS_LTA[POLICY_TYPE_RANKING_POINTS],
+  },
+  {
+    id: 'builtin-ranking-points-tennis-australia',
+    name: 'Tennis Australia Points',
+    policyType: POLICY_TYPE_RANKING_POINTS,
+    source: 'builtin',
+    description: 'Tennis Australia ranking points',
+    policyData: POLICY_RANKING_POINTS_TENNIS_AUSTRALIA[POLICY_TYPE_RANKING_POINTS],
+  },
+  {
+    id: 'builtin-ranking-points-tennis-canada',
+    name: 'Tennis Canada Points',
+    policyType: POLICY_TYPE_RANKING_POINTS,
+    source: 'builtin',
+    description: 'Tennis Canada ranking points',
+    policyData: POLICY_RANKING_POINTS_TENNIS_CANADA[POLICY_TYPE_RANKING_POINTS],
+  },
+];

--- a/admin-client/src/pages/policies/renderPoliciesPage.ts
+++ b/admin-client/src/pages/policies/renderPoliciesPage.ts
@@ -1,0 +1,146 @@
+/**
+ * Policies page (admin-client) — per-provider policy catalog.
+ *
+ * Mirrors TMX's policies page but persists to the server (per-provider)
+ * via the generic catalog endpoint. The heavy lifting is the
+ * `createPolicyCatalog` component from courthive-components, which owns
+ * the catalog UI, search, grouping, and per-policy-type editors. We
+ * just feed it builtin + user policies and respond to its callbacks.
+ *
+ * Per-provider policies stored here can later be referenced from the
+ * provider Settings panel's Policies topic, replacing the current
+ * raw-JSON paste editor with a picker over the available catalog.
+ */
+import './policiesPage.css';
+import { createPolicyCatalog, type PolicyCatalogItem } from 'courthive-components';
+import { showTMXpolicies } from 'services/transitions/screenSlaver';
+import { getActiveProvider } from 'services/provider/providerState';
+import { removeAllChildNodes } from 'services/dom/transformers';
+import { tmxToast } from 'services/notifications/tmxToast';
+import {
+  listCatalog,
+  createCatalogItem,
+  updateCatalogItem,
+  deleteCatalogItem,
+  type CatalogItemDto,
+} from 'services/apis/catalogApi';
+import { BUILTIN_POLICIES } from './policyBridge';
+
+import { TMX_POLICIES } from 'constants/tmxConstants';
+
+let activeControl: { destroy?: () => void } | null = null;
+
+export async function renderPoliciesPage(): Promise<void> {
+  showTMXpolicies();
+
+  const provider = getActiveProvider();
+  const container = document.getElementById(TMX_POLICIES);
+  if (!container) return;
+
+  destroyActive();
+  removeAllChildNodes(container);
+
+  if (!provider) {
+    container.appendChild(buildNoProviderPanel());
+    return;
+  }
+
+  const userPolicies = await loadUserPolicies(provider.organisationId);
+
+  const host = document.createElement('div');
+  host.className = 'pol-host';
+  container.appendChild(host);
+
+  const control = createPolicyCatalog(
+    {
+      builtinPolicies: BUILTIN_POLICIES,
+      userPolicies,
+      onPolicyCreated: (item) => void onCreate(provider.organisationId, item),
+      onPolicySaved: (item) => void onSave(provider.organisationId, item),
+      onPolicyDeleted: (id) => void onDelete(provider.organisationId, id),
+    },
+    host,
+  );
+  activeControl = control as any;
+}
+
+async function loadUserPolicies(providerId: string): Promise<PolicyCatalogItem[]> {
+  try {
+    const res: any = await listCatalog(providerId, 'policy');
+    const rows = (res?.data?.items ?? []) as CatalogItemDto[];
+    return rows.map(rowToCatalogItem);
+  } catch {
+    tmxToast({ message: 'Failed to load policies', intent: 'is-danger' });
+    return [];
+  }
+}
+
+function rowToCatalogItem(row: CatalogItemDto): PolicyCatalogItem {
+  const meta = (row.metadata ?? {}) as { policyType?: string; description?: string };
+  return {
+    id: row.catalogId,
+    name: row.name,
+    policyType: meta.policyType ?? 'unknown',
+    source: 'user',
+    description: row.description ?? meta.description ?? '',
+    policyData: row.data as Record<string, unknown>,
+  };
+}
+
+async function onCreate(providerId: string, item: PolicyCatalogItem): Promise<void> {
+  try {
+    await createCatalogItem(providerId, 'policy', {
+      name: item.name,
+      description: item.description,
+      data: item.policyData,
+      metadata: { policyType: item.policyType },
+    });
+    tmxToast({ message: `Created "${item.name}"`, intent: 'is-success' });
+  } catch {
+    tmxToast({ message: 'Failed to create policy', intent: 'is-danger' });
+  }
+}
+
+async function onSave(providerId: string, item: PolicyCatalogItem): Promise<void> {
+  // PolicyCatalog emits onPolicySaved for both renames and content edits
+  // on user items. Builtins are read-only; their `id` starts with
+  // `builtin-`, so guard against accidentally writing them.
+  if (item.source === 'builtin' || item.id.startsWith('builtin-')) return;
+  try {
+    await updateCatalogItem(providerId, 'policy', item.id, {
+      name: item.name,
+      description: item.description,
+      data: item.policyData,
+      metadata: { policyType: item.policyType },
+    });
+    tmxToast({ message: `Saved "${item.name}"`, intent: 'is-success' });
+  } catch {
+    tmxToast({ message: 'Failed to save policy', intent: 'is-danger' });
+  }
+}
+
+async function onDelete(providerId: string, id: string): Promise<void> {
+  if (id.startsWith('builtin-')) return;
+  try {
+    await deleteCatalogItem(providerId, 'policy', id);
+    tmxToast({ message: 'Deleted policy', intent: 'is-success' });
+  } catch {
+    tmxToast({ message: 'Failed to delete policy', intent: 'is-danger' });
+  }
+}
+
+function destroyActive(): void {
+  activeControl?.destroy?.();
+  activeControl = null;
+}
+
+function buildNoProviderPanel(): HTMLElement {
+  const wrap = document.createElement('div');
+  wrap.className = 'pol-no-provider';
+  wrap.innerHTML = `
+    <i class="fa-solid fa-building"></i>
+    <p>Select a provider before editing policies.</p>
+    <p class="pol-no-provider-sub">Policies are scoped to a single provider; super-admins must impersonate a provider first.</p>
+  `;
+  return wrap;
+}

--- a/admin-client/src/pages/templates/renderTemplatesPage.ts
+++ b/admin-client/src/pages/templates/renderTemplatesPage.ts
@@ -1,0 +1,107 @@
+/**
+ * Templates page (admin-client) — per-provider catalogs of bracket
+ * topologies, tie formats, and compositions. Three sub-views switched
+ * via the nav chip row at the top.
+ *
+ * Mirrors TMX's templates page but persists to the server (per-provider)
+ * instead of IndexedDB. Topology IDs saved here are referenced by
+ * `allowedDrawTypes` in `providerConfigSettings`, so the Settings panel's
+ * Allowed Selections chip widget can surface provider-defined draw
+ * structures alongside the factory enum.
+ */
+import './templatesPage.css';
+import { showTMXtemplates } from 'services/transitions/screenSlaver';
+import { getActiveProvider } from 'services/provider/providerState';
+import { removeAllChildNodes } from 'services/dom/transformers';
+import { context } from 'services/context';
+import { mountTopologiesView } from './views/topologiesView';
+import { mountCompositionsView } from './views/compositionsView';
+import { mountTieFormatsView } from './views/tieFormatsView';
+
+import { TMX_TEMPLATES, TEMPLATES } from 'constants/tmxConstants';
+
+import type { ViewMount } from './views/viewTypes';
+
+type TemplateView = 'topologies' | 'tieFormats' | 'compositions';
+
+const VIEW_KEYS: Record<string, TemplateView> = {
+  topologies: 'topologies',
+  tieformats: 'tieFormats',
+  compositions: 'compositions',
+};
+
+const VIEW_LIST: { key: TemplateView; label: string }[] = [
+  { key: 'topologies', label: 'Topologies' },
+  { key: 'tieFormats', label: 'Tie Formats' },
+  { key: 'compositions', label: 'Compositions' },
+];
+
+let activeMount: ViewMount | null = null;
+
+export async function renderTemplatesPage(params?: { templateView?: string }): Promise<void> {
+  showTMXtemplates();
+
+  const provider = getActiveProvider();
+  const container = document.getElementById(TMX_TEMPLATES);
+  if (!container) return;
+
+  destroyActive();
+  removeAllChildNodes(container);
+
+  if (!provider) {
+    container.appendChild(buildNoProviderPanel());
+    return;
+  }
+
+  const activeView: TemplateView = params?.templateView
+    ? VIEW_KEYS[params.templateView.toLowerCase()] ?? 'topologies'
+    : 'topologies';
+
+  const chipsRow = document.createElement('div');
+  chipsRow.className = 'tpl-nav-chips';
+  for (const view of VIEW_LIST) {
+    const chip = document.createElement('button');
+    chip.type = 'button';
+    chip.className = 'tpl-nav-chip';
+    if (view.key === activeView) chip.classList.add('active');
+    chip.textContent = view.label;
+    chip.addEventListener('click', () => {
+      context.router?.navigate(`/${TEMPLATES}/${view.key.toLowerCase()}`);
+    });
+    chipsRow.appendChild(chip);
+  }
+
+  const viewHost = document.createElement('div');
+  viewHost.className = 'tpl-view-host';
+
+  container.appendChild(chipsRow);
+  container.appendChild(viewHost);
+
+  switch (activeView) {
+    case 'topologies':
+      activeMount = mountTopologiesView(viewHost, provider);
+      break;
+    case 'compositions':
+      activeMount = mountCompositionsView(viewHost, provider);
+      break;
+    case 'tieFormats':
+      activeMount = mountTieFormatsView(viewHost, provider);
+      break;
+  }
+}
+
+function destroyActive(): void {
+  activeMount?.destroy();
+  activeMount = null;
+}
+
+function buildNoProviderPanel(): HTMLElement {
+  const wrap = document.createElement('div');
+  wrap.className = 'tpl-no-provider';
+  wrap.innerHTML = `
+    <i class="fa-solid fa-building"></i>
+    <p>Select a provider before editing templates.</p>
+    <p class="tpl-no-provider-sub">Templates are scoped to a single provider; super-admins must impersonate a provider first.</p>
+  `;
+  return wrap;
+}

--- a/admin-client/src/pages/templates/templatesPage.css
+++ b/admin-client/src/pages/templates/templatesPage.css
@@ -1,0 +1,352 @@
+/**
+ * Templates page — two-pane layout (catalog + builder).
+ * Mirrors the Settings panel visual language so admin-client feels
+ * consistent across pages.
+ */
+
+/* ── Top nav chips (Topologies / Tie Formats / Compositions) ─── */
+
+.tpl-nav-chips {
+  display: flex;
+  gap: 6px;
+  padding: 12px 16px 0;
+}
+
+.tpl-nav-chip {
+  padding: 6px 14px;
+  border: 1px solid var(--tmx-border-primary, #e0e0e0);
+  border-radius: 999px;
+  background: var(--tmx-bg-elevated, #fff);
+  color: var(--tmx-text-primary, #222);
+  font: inherit;
+  font-size: 0.85rem;
+  cursor: pointer;
+  transition: background-color 120ms ease, border-color 120ms ease, color 120ms ease;
+}
+
+.tpl-nav-chip:hover {
+  border-color: var(--tmx-accent-blue, #2d7ff9);
+}
+
+.tpl-nav-chip.active {
+  background: var(--tmx-accent-blue, #2d7ff9);
+  border-color: var(--tmx-accent-blue, #2d7ff9);
+  color: #fff;
+}
+
+.tpl-view-host {
+  flex: 1;
+  min-height: 0;
+  display: flex;
+  flex-direction: column;
+}
+
+.tpl-layout {
+  display: grid;
+  grid-template-columns: 280px 1fr;
+  gap: 16px;
+  padding: 16px;
+  height: 100%;
+  min-height: 0;
+  flex: 1;
+}
+
+.tpl-no-provider {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: 12px;
+  padding: 64px 24px;
+  color: var(--tmx-text-secondary, #666);
+  text-align: center;
+}
+
+.tpl-no-provider i {
+  font-size: 2rem;
+  color: var(--tmx-text-muted, #aaa);
+}
+
+.tpl-no-provider p {
+  margin: 0;
+}
+
+.tpl-no-provider-sub {
+  font-size: 0.85rem;
+  color: var(--tmx-text-muted, #aaa);
+  max-width: 420px;
+}
+
+/* ── Catalog (left pane) ─────────────────────────────────────────── */
+
+.tpl-catalog-panel {
+  display: flex;
+  flex-direction: column;
+  border-right: 1px solid var(--tmx-border-primary, #e0e0e0);
+  padding-right: 12px;
+  min-height: 0;
+}
+
+.tpl-catalog-header {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 4px 4px 12px;
+  border-bottom: 1px solid var(--tmx-border-primary, #e0e0e0);
+}
+
+.tpl-catalog-header h3 {
+  margin: 0;
+  flex: 1;
+  font-size: 0.95rem;
+  font-weight: 600;
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  color: var(--tmx-text-primary, #222);
+}
+
+.tpl-new-btn {
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+  padding: 4px 10px;
+  border: 1px solid var(--tmx-accent-blue, #2d7ff9);
+  border-radius: 4px;
+  background: var(--tmx-accent-blue, #2d7ff9);
+  color: #fff;
+  font: inherit;
+  font-size: 0.8rem;
+  cursor: pointer;
+}
+
+.tpl-new-btn:hover {
+  filter: brightness(1.05);
+}
+
+.tpl-catalog-body {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+  overflow-y: auto;
+  padding: 8px 4px;
+  min-height: 0;
+}
+
+.tpl-catalog-section {
+  margin-top: 8px;
+  font-size: 0.7rem;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  color: var(--tmx-text-muted, #999);
+  padding: 4px;
+}
+
+.tpl-catalog-section:first-child {
+  margin-top: 0;
+}
+
+.tpl-catalog-empty-hint {
+  padding: 8px;
+  font-size: 0.8rem;
+  color: var(--tmx-text-muted, #999);
+  font-style: italic;
+}
+
+.tpl-catalog-card {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+  /* Reserve a tiny right-side gutter so the lock-icon marker on builtin
+     cards never crowds the name text. */
+  padding: 8px 24px 8px 10px;
+  border: 1px solid var(--tmx-border-primary, #e0e0e0);
+  border-radius: 6px;
+  background: var(--tmx-bg-elevated, #fff);
+  color: var(--tmx-text-primary, #222);
+  font: inherit;
+  text-align: left;
+  cursor: pointer;
+  position: relative;
+  transition:
+    background-color 120ms ease,
+    border-color 120ms ease;
+}
+
+.tpl-catalog-card:hover {
+  border-color: var(--tmx-accent-blue, #2d7ff9);
+}
+
+.tpl-catalog-card.is-selected {
+  border-color: var(--tmx-accent-blue, #2d7ff9);
+  background: var(--tmx-panel-blue-bg, #e6f0fe);
+}
+
+.tpl-catalog-card__name {
+  font-size: 0.9rem;
+  font-weight: 500;
+}
+
+.tpl-catalog-card__desc {
+  font-size: 0.75rem;
+  color: var(--tmx-text-secondary, #666);
+}
+
+/* Builtin marker — tiny icon-only badge that doesn't crowd the name. */
+.tpl-catalog-card__marker {
+  position: absolute;
+  top: 6px;
+  right: 6px;
+  width: 16px;
+  height: 16px;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  color: var(--tmx-text-muted, #999);
+  font-size: 0.65rem;
+  pointer-events: auto;
+  cursor: help;
+}
+
+.tpl-catalog-card.is-selected .tpl-catalog-card__marker {
+  color: var(--tmx-accent-blue, #2d7ff9);
+}
+
+/* ── Builder (right pane) ────────────────────────────────────────── */
+
+.tpl-builder-panel {
+  display: flex;
+  flex-direction: column;
+  position: relative;
+  min-height: 0;
+}
+
+.tpl-builder-host {
+  flex: 1;
+  min-height: 0;
+  position: relative;
+}
+
+.tpl-builder-host:empty {
+  display: none;
+}
+
+.tpl-builder-empty {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: 8px;
+  padding: 64px 24px;
+  color: var(--tmx-text-secondary, #666);
+  text-align: center;
+}
+
+.tpl-builder-empty i {
+  font-size: 1.5rem;
+  color: var(--tmx-text-muted, #aaa);
+}
+
+.tpl-builder-empty p {
+  margin: 0;
+  font-size: 0.9rem;
+}
+
+.tpl-delete-btn {
+  position: absolute;
+  bottom: 12px;
+  right: 12px;
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+  padding: 6px 12px;
+  border: 1px solid var(--tmx-panel-red-border, #d32f2f);
+  border-radius: 4px;
+  background: var(--tmx-bg-elevated, #fff);
+  color: var(--tmx-panel-red-border, #d32f2f);
+  font: inherit;
+  font-size: 0.8rem;
+  cursor: pointer;
+  z-index: 5;
+}
+
+.tpl-delete-btn:hover {
+  background: var(--tmx-panel-red-bg, #fff0f0);
+}
+
+/* ── JSON editor (used by Tie Formats view) ──────────────────────── */
+
+.tpl-json-editor {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+  padding: 16px;
+  height: 100%;
+  min-height: 0;
+}
+
+.tpl-json-textarea {
+  width: 100%;
+  box-sizing: border-box;
+  font-family: var(--tmx-font-mono, ui-monospace, SFMono-Regular, Menlo, Consolas, monospace);
+  font-size: 0.8rem;
+  line-height: 1.4;
+  padding: 8px 10px;
+  border: 1px solid var(--tmx-border-primary, #ccc);
+  border-radius: 4px;
+  background: var(--tmx-bg-elevated, #fff);
+  color: var(--tmx-text-primary, #222);
+  resize: vertical;
+  outline: 0;
+}
+
+.tpl-json-textarea:focus {
+  border-color: var(--tmx-accent-blue, #2d7ff9);
+}
+
+.tpl-json-error {
+  padding: 6px 10px;
+  border: 1px solid var(--tmx-panel-red-border, #d32f2f);
+  background: var(--tmx-panel-red-bg, rgba(211, 47, 47, 0.08));
+  color: var(--tmx-panel-red-border, #d32f2f);
+  font-size: 0.8rem;
+  font-family: var(--tmx-font-mono, ui-monospace, monospace);
+  border-radius: 4px;
+}
+
+.tpl-json-actions {
+  display: flex;
+  gap: 8px;
+}
+
+.tpl-save-btn {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  padding: 6px 14px;
+  border: 1px solid var(--tmx-accent-blue, #2d7ff9);
+  border-radius: 4px;
+  background: var(--tmx-accent-blue, #2d7ff9);
+  color: #fff;
+  font: inherit;
+  font-size: 0.85rem;
+  font-weight: 500;
+  cursor: pointer;
+}
+
+.tpl-save-btn:hover {
+  filter: brightness(1.05);
+}
+
+@media (max-width: 900px) {
+  .tpl-layout {
+    grid-template-columns: 1fr;
+  }
+
+  .tpl-catalog-panel {
+    border-right: none;
+    border-bottom: 1px solid var(--tmx-border-primary, #e0e0e0);
+    padding-right: 0;
+    padding-bottom: 12px;
+  }
+}

--- a/admin-client/src/pages/templates/views/catalogShell.ts
+++ b/admin-client/src/pages/templates/views/catalogShell.ts
@@ -1,0 +1,197 @@
+/**
+ * Shared two-pane shell for Templates sub-views. Provides:
+ *   - left catalog panel with grouped "Yours" / "Builtin" sections
+ *   - right builder host
+ *   - empty-state for the builder
+ *   - delete-button overlay (on the builder host) for user items
+ *
+ * The shell knows nothing about the data shape. Each view passes a list
+ * of `CatalogItem`s and a click handler.
+ */
+import type { CatalogItem } from './viewTypes';
+
+export interface CatalogShellOpts {
+  title: string;
+  titleIcon: string;
+  newButtonLabel: string;
+  newButtonTitle?: string;
+  onNew: () => void;
+  builderEmptyHint: string;
+  builderEmptyIcon: string;
+}
+
+export interface CatalogShell {
+  root: HTMLElement;
+  builderHost: HTMLElement;
+  renderCatalog(
+    items: CatalogItem[],
+    selectedId: string | null,
+    onSelect: (item: CatalogItem) => void,
+  ): void;
+  clearBuilder(): void;
+  attachDeleteButton(handler: () => void): void;
+  destroy(): void;
+}
+
+export function buildCatalogShell(opts: CatalogShellOpts): CatalogShell {
+  const root = document.createElement('div');
+  root.className = 'tpl-layout';
+
+  // Left
+  const catalogPanel = document.createElement('div');
+  catalogPanel.className = 'tpl-catalog-panel';
+
+  const catalogHeader = document.createElement('div');
+  catalogHeader.className = 'tpl-catalog-header';
+  catalogHeader.innerHTML = `<h3><i class="fa-solid ${opts.titleIcon}"></i> ${escapeHtml(opts.title)}</h3>`;
+
+  const newBtn = document.createElement('button');
+  newBtn.type = 'button';
+  newBtn.className = 'tpl-new-btn';
+  newBtn.innerHTML = `<i class="fa-solid fa-plus"></i> ${escapeHtml(opts.newButtonLabel)}`;
+  if (opts.newButtonTitle) newBtn.title = opts.newButtonTitle;
+  newBtn.addEventListener('click', opts.onNew);
+  catalogHeader.appendChild(newBtn);
+
+  catalogPanel.appendChild(catalogHeader);
+
+  const catalogBody = document.createElement('div');
+  catalogBody.className = 'tpl-catalog-body';
+  catalogPanel.appendChild(catalogBody);
+
+  // Right
+  const builderPanel = document.createElement('div');
+  builderPanel.className = 'tpl-builder-panel';
+
+  const builderHost = document.createElement('div');
+  builderHost.className = 'tpl-builder-host';
+  builderPanel.appendChild(builderHost);
+
+  const emptyMessage = document.createElement('div');
+  emptyMessage.className = 'tpl-builder-empty';
+  emptyMessage.innerHTML = `
+    <i class="fa-solid ${opts.builderEmptyIcon}"></i>
+    <p>${opts.builderEmptyHint}</p>
+  `;
+  builderPanel.appendChild(emptyMessage);
+
+  root.appendChild(catalogPanel);
+  root.appendChild(builderPanel);
+
+  function renderCatalog(
+    items: CatalogItem[],
+    selectedId: string | null,
+    onSelect: (item: CatalogItem) => void,
+  ): void {
+    catalogBody.innerHTML = '';
+
+    const userItems = items.filter((i) => i.source === 'user');
+    const builtinItems = items.filter((i) => i.source === 'builtin');
+
+    if (userItems.length) {
+      appendSection(catalogBody, 'Yours', userItems, selectedId, onSelect);
+    } else {
+      const emptyHint = document.createElement('div');
+      emptyHint.className = 'tpl-catalog-empty-hint';
+      emptyHint.textContent = "You haven't saved any items yet.";
+      catalogBody.appendChild(emptyHint);
+    }
+    if (builtinItems.length) {
+      appendSection(catalogBody, 'Builtin', builtinItems, selectedId, onSelect);
+    }
+  }
+
+  function clearBuilder(): void {
+    while (builderHost.firstChild) builderHost.removeChild(builderHost.firstChild);
+    emptyMessage.style.display = '';
+  }
+
+  function attachDeleteButton(handler: () => void): void {
+    const btn = document.createElement('button');
+    btn.type = 'button';
+    btn.className = 'tpl-delete-btn';
+    btn.innerHTML = '<i class="fa-solid fa-trash"></i> Delete';
+    btn.addEventListener('click', handler);
+    builderHost.appendChild(btn);
+    emptyMessage.style.display = 'none';
+  }
+
+  function destroy(): void {
+    while (root.firstChild) root.removeChild(root.firstChild);
+    root.remove();
+  }
+
+  // Anything appended into builderHost by the view itself implies we
+  // have content, so hide the empty message. Views that mount their
+  // own controls call into this via the hook below.
+  const observer = new MutationObserver(() => {
+    if (builderHost.children.length > 0) emptyMessage.style.display = 'none';
+    else emptyMessage.style.display = '';
+  });
+  observer.observe(builderHost, { childList: true });
+
+  return {
+    root,
+    builderHost,
+    renderCatalog,
+    clearBuilder,
+    attachDeleteButton,
+    destroy: () => {
+      observer.disconnect();
+      destroy();
+    },
+  };
+}
+
+function appendSection(
+  parent: HTMLElement,
+  label: string,
+  items: CatalogItem[],
+  selectedId: string | null,
+  onSelect: (item: CatalogItem) => void,
+): void {
+  const heading = document.createElement('div');
+  heading.className = 'tpl-catalog-section';
+  heading.textContent = label;
+  parent.appendChild(heading);
+
+  for (const item of items) {
+    const card = document.createElement('button');
+    card.type = 'button';
+    card.className = 'tpl-catalog-card';
+    if (item.id === selectedId) card.classList.add('is-selected');
+    card.dataset.itemId = item.id;
+    card.dataset.source = item.source;
+
+    if (item.source === 'builtin') {
+      const marker = document.createElement('span');
+      marker.className = 'tpl-catalog-card__marker';
+      marker.title = 'Builtin (read-only — fork to customize)';
+      marker.innerHTML = '<i class="fa-solid fa-lock" aria-hidden="true"></i>';
+      marker.setAttribute('aria-label', 'Builtin');
+      card.appendChild(marker);
+    }
+
+    const name = document.createElement('div');
+    name.className = 'tpl-catalog-card__name';
+    name.textContent = item.name;
+    card.appendChild(name);
+
+    if (item.description) {
+      const desc = document.createElement('div');
+      desc.className = 'tpl-catalog-card__desc';
+      desc.textContent = item.description;
+      card.appendChild(desc);
+    }
+
+    card.addEventListener('click', () => onSelect(item));
+    parent.appendChild(card);
+  }
+}
+
+function escapeHtml(s: string): string {
+  return s.replace(
+    /[&<>"']/g,
+    (c) => ({ '&': '&amp;', '<': '&lt;', '>': '&gt;', '"': '&quot;', "'": '&#39;' })[c]!,
+  );
+}

--- a/admin-client/src/pages/templates/views/compositionsView.ts
+++ b/admin-client/src/pages/templates/views/compositionsView.ts
@@ -1,0 +1,131 @@
+/**
+ * Templates → Compositions view. Two-pane: catalog (left) + the
+ * `createCompositionEditor` from courthive-components (right).
+ *
+ * Compositions don't have ecosystem builtins the way topologies do
+ * (`standardTemplates`), so the catalog only shows user items. A "New"
+ * button mounts an empty editor; saving via the editor's `onSave`
+ * callback persists to the server catalog.
+ */
+import { createCompositionEditor, type SavedComposition } from 'courthive-components';
+import { tmxToast } from 'services/notifications/tmxToast';
+import {
+  listCatalog,
+  createCatalogItem,
+  updateCatalogItem,
+  deleteCatalogItem,
+  type CatalogItemDto,
+} from 'services/apis/catalogApi';
+
+import type { ProviderValue } from 'types/tmx';
+import type { ViewMount, CatalogItem } from './viewTypes';
+import { buildCatalogShell } from './catalogShell';
+
+interface CompositionCatalogItem extends CatalogItem {
+  composition: SavedComposition;
+}
+
+export function mountCompositionsView(host: HTMLElement, provider: ProviderValue): ViewMount {
+  let editorInstance: { destroy: () => void; getComposition: () => SavedComposition } | null = null;
+  let userItems: CatalogItemDto[] = [];
+  let selectedItemId: string | null = null;
+  let destroyed = false;
+
+  const shell = buildCatalogShell({
+    title: 'Compositions',
+    titleIcon: 'fa-table-cells',
+    newButtonLabel: 'New',
+    newButtonTitle: 'Start a fresh composition',
+    onNew: () => {
+      selectedItemId = null;
+      rebuildCatalog();
+      mountEditor(null);
+    },
+    builderEmptyHint: 'Pick a composition from the catalog or click <strong>New</strong>.',
+    builderEmptyIcon: 'fa-arrow-left',
+  });
+  host.appendChild(shell.root);
+
+  function items(): CompositionCatalogItem[] {
+    return userItems.map((row) => ({
+      id: row.catalogId,
+      name: row.name,
+      description: row.description ?? null,
+      source: 'user',
+      composition: row.data as SavedComposition,
+    }));
+  }
+
+  function rebuildCatalog(): void {
+    shell.renderCatalog(items(), selectedItemId, (item) => {
+      selectedItemId = item.id;
+      rebuildCatalog();
+      mountEditor(item as CompositionCatalogItem);
+    });
+  }
+
+  function mountEditor(item: CompositionCatalogItem | null): void {
+    shell.clearBuilder();
+
+    editorInstance = createCompositionEditor(shell.builderHost, {
+      composition: item?.composition.configuration as any,
+      compositionName: item?.composition.compositionName ?? '',
+      onSave: (saved) => void onSave(item, saved),
+    });
+
+    if (item) shell.attachDeleteButton(() => void onDelete(item));
+  }
+
+  async function onSave(
+    current: CompositionCatalogItem | null,
+    saved: SavedComposition,
+  ): Promise<void> {
+    const proposedName = saved.compositionName?.trim() || current?.name || '';
+    const name = window.prompt('Composition name:', proposedName);
+    if (!name) return;
+    const data: SavedComposition = { ...saved, compositionName: name };
+    try {
+      if (current) {
+        await updateCatalogItem(provider.organisationId, 'composition', current.id, { name, data });
+        tmxToast({ message: `Saved "${name}"`, intent: 'is-success' });
+      } else {
+        await createCatalogItem(provider.organisationId, 'composition', { name, data });
+        tmxToast({ message: `Created "${name}"`, intent: 'is-success' });
+      }
+      await refresh();
+    } catch {
+      tmxToast({ message: 'Failed to save composition', intent: 'is-danger' });
+    }
+  }
+
+  async function onDelete(item: CompositionCatalogItem): Promise<void> {
+    if (!window.confirm(`Delete composition "${item.name}"?`)) return;
+    try {
+      await deleteCatalogItem(provider.organisationId, 'composition', item.id);
+      selectedItemId = null;
+      shell.clearBuilder();
+      await refresh();
+      tmxToast({ message: `Deleted "${item.name}"`, intent: 'is-success' });
+    } catch {
+      tmxToast({ message: 'Failed to delete composition', intent: 'is-danger' });
+    }
+  }
+
+  async function refresh(): Promise<void> {
+    if (destroyed) return;
+    const res: any = await listCatalog(provider.organisationId, 'composition');
+    userItems = res?.data?.items ?? [];
+    rebuildCatalog();
+  }
+
+  void refresh();
+
+  return {
+    destroy: () => {
+      destroyed = true;
+      editorInstance?.destroy();
+      editorInstance = null;
+      shell.destroy();
+    },
+  };
+}

--- a/admin-client/src/pages/templates/views/tieFormatsView.ts
+++ b/admin-client/src/pages/templates/views/tieFormatsView.ts
@@ -1,0 +1,207 @@
+/**
+ * Templates → Tie Formats view. Two-pane: catalog (left) + JSON editor (right).
+ *
+ * `courthive-components` does not currently export a tieFormat editor —
+ * TMX uses its own `editTieFormat` overlay. Until that's ported into
+ * courthive-components (separate workstream), this view ships a JSON
+ * editor: name + description + JSON body. Round-trip through the same
+ * generic catalog endpoint as compositions.
+ */
+import { tmxToast } from 'services/notifications/tmxToast';
+import {
+  listCatalog,
+  createCatalogItem,
+  updateCatalogItem,
+  deleteCatalogItem,
+  type CatalogItemDto,
+} from 'services/apis/catalogApi';
+
+import type { ProviderValue } from 'types/tmx';
+import type { ViewMount, CatalogItem } from './viewTypes';
+import { buildCatalogShell } from './catalogShell';
+
+interface TieFormatCatalogItem extends CatalogItem {
+  tieFormat: any;
+}
+
+export function mountTieFormatsView(host: HTMLElement, provider: ProviderValue): ViewMount {
+  let userItems: CatalogItemDto[] = [];
+  let selectedItemId: string | null = null;
+  let destroyed = false;
+
+  const shell = buildCatalogShell({
+    title: 'Tie Formats',
+    titleIcon: 'fa-people-arrows',
+    newButtonLabel: 'New',
+    newButtonTitle: 'Start a fresh tie format',
+    onNew: () => {
+      selectedItemId = null;
+      rebuildCatalog();
+      mountEditor(null);
+    },
+    builderEmptyHint: 'Pick a tie format from the catalog or click <strong>New</strong>.',
+    builderEmptyIcon: 'fa-arrow-left',
+  });
+  host.appendChild(shell.root);
+
+  function items(): TieFormatCatalogItem[] {
+    return userItems.map((row) => ({
+      id: row.catalogId,
+      name: row.name,
+      description: row.description ?? null,
+      source: 'user',
+      tieFormat: row.data,
+    }));
+  }
+
+  function rebuildCatalog(): void {
+    shell.renderCatalog(items(), selectedItemId, (item) => {
+      selectedItemId = item.id;
+      rebuildCatalog();
+      mountEditor(item as TieFormatCatalogItem);
+    });
+  }
+
+  function mountEditor(item: TieFormatCatalogItem | null): void {
+    shell.clearBuilder();
+    const editor = buildTieFormatEditor({
+      initialName: item?.name ?? '',
+      initialDescription: item?.description ?? '',
+      initialJson: item ? JSON.stringify(item.tieFormat, null, 2) : '',
+      onSave: (payload) => void onSave(item, payload),
+    });
+    shell.builderHost.appendChild(editor);
+
+    if (item) shell.attachDeleteButton(() => void onDelete(item));
+  }
+
+  async function onSave(
+    current: TieFormatCatalogItem | null,
+    payload: { name: string; description: string; data: any },
+  ): Promise<void> {
+    try {
+      if (current) {
+        await updateCatalogItem(provider.organisationId, 'tieFormat', current.id, payload);
+        tmxToast({ message: `Saved "${payload.name}"`, intent: 'is-success' });
+      } else {
+        await createCatalogItem(provider.organisationId, 'tieFormat', payload);
+        tmxToast({ message: `Created "${payload.name}"`, intent: 'is-success' });
+      }
+      await refresh();
+    } catch {
+      tmxToast({ message: 'Failed to save tie format', intent: 'is-danger' });
+    }
+  }
+
+  async function onDelete(item: TieFormatCatalogItem): Promise<void> {
+    if (!window.confirm(`Delete tie format "${item.name}"?`)) return;
+    try {
+      await deleteCatalogItem(provider.organisationId, 'tieFormat', item.id);
+      selectedItemId = null;
+      shell.clearBuilder();
+      await refresh();
+      tmxToast({ message: `Deleted "${item.name}"`, intent: 'is-success' });
+    } catch {
+      tmxToast({ message: 'Failed to delete tie format', intent: 'is-danger' });
+    }
+  }
+
+  async function refresh(): Promise<void> {
+    if (destroyed) return;
+    const res: any = await listCatalog(provider.organisationId, 'tieFormat');
+    userItems = res?.data?.items ?? [];
+    rebuildCatalog();
+  }
+
+  void refresh();
+
+  return {
+    destroy: () => {
+      destroyed = true;
+      shell.destroy();
+    },
+  };
+}
+
+interface JsonEditorOpts {
+  initialName: string;
+  initialDescription: string;
+  initialJson: string;
+  onSave: (payload: { name: string; description: string; data: any }) => void;
+}
+
+function buildTieFormatEditor(opts: JsonEditorOpts): HTMLElement {
+  const wrap = document.createElement('div');
+  wrap.className = 'tpl-json-editor';
+
+  const nameRow = document.createElement('label');
+  nameRow.className = 'sp-field';
+  nameRow.innerHTML = '<span class="sp-field-label">Name</span>';
+  const nameInput = document.createElement('input');
+  nameInput.type = 'text';
+  nameInput.className = 'sp-field-input';
+  nameInput.value = opts.initialName;
+  nameInput.placeholder = 'e.g. ITF Davis Cup';
+  nameRow.appendChild(nameInput);
+  wrap.appendChild(nameRow);
+
+  const descRow = document.createElement('label');
+  descRow.className = 'sp-field';
+  descRow.innerHTML = '<span class="sp-field-label">Description</span>';
+  const descInput = document.createElement('input');
+  descInput.type = 'text';
+  descInput.className = 'sp-field-input';
+  descInput.value = opts.initialDescription;
+  descInput.placeholder = 'Optional';
+  descRow.appendChild(descInput);
+  wrap.appendChild(descRow);
+
+  const jsonRow = document.createElement('label');
+  jsonRow.className = 'sp-field';
+  jsonRow.innerHTML = '<span class="sp-field-label">Tie Format (JSON)</span>';
+  const ta = document.createElement('textarea');
+  ta.className = 'tpl-json-textarea';
+  ta.rows = 18;
+  ta.spellcheck = false;
+  ta.value = opts.initialJson;
+  ta.placeholder = '{\n  "collectionDefinitions": [...]\n}';
+  jsonRow.appendChild(ta);
+  wrap.appendChild(jsonRow);
+
+  const error = document.createElement('div');
+  error.className = 'tpl-json-error';
+  error.style.display = 'none';
+  wrap.appendChild(error);
+
+  const actions = document.createElement('div');
+  actions.className = 'tpl-json-actions';
+  const saveBtn = document.createElement('button');
+  saveBtn.type = 'button';
+  saveBtn.className = 'tpl-save-btn';
+  saveBtn.innerHTML = '<i class="fa-solid fa-floppy-disk"></i> Save';
+  saveBtn.addEventListener('click', () => {
+    const name = nameInput.value.trim();
+    if (!name) {
+      showError('Name is required.');
+      return;
+    }
+    let parsed: any;
+    try {
+      parsed = ta.value.trim() ? JSON.parse(ta.value) : {};
+    } catch (err) {
+      showError(err instanceof Error ? err.message : 'Invalid JSON.');
+      return;
+    }
+    error.style.display = 'none';
+    opts.onSave({ name, description: descInput.value.trim(), data: parsed });
+  });
+  actions.appendChild(saveBtn);
+  wrap.appendChild(actions);
+
+  function showError(msg: string): void {
+    error.textContent = msg;
+    error.style.display = '';
+  }
+
+  return wrap;
+}

--- a/admin-client/src/pages/templates/views/topologiesView.ts
+++ b/admin-client/src/pages/templates/views/topologiesView.ts
@@ -1,0 +1,154 @@
+/**
+ * Templates → Topologies view. Two-pane: catalog (left) + builder (right).
+ * Persists to the server's per-provider topology catalog.
+ *
+ * Topology IDs saved here are referenced by `allowedDrawTypes` in
+ * `providerConfigSettings`, so the Settings panel's Allowed Selections
+ * chip widget can surface provider-defined draw structures alongside
+ * the factory enum.
+ */
+import { TopologyBuilderControl, standardTemplates } from 'courthive-components';
+import { tmxToast } from 'services/notifications/tmxToast';
+import {
+  listTopologies,
+  createTopology,
+  updateTopology,
+  deleteTopology,
+  type TopologyDto,
+} from 'services/apis/topologyApi';
+
+import type { TopologyState, TopologyTemplate } from 'courthive-components';
+import type { ProviderValue } from 'types/tmx';
+import type { ViewMount, CatalogItem } from './viewTypes';
+import { buildCatalogShell } from './catalogShell';
+
+interface TopologyCatalogItem extends CatalogItem {
+  state: TopologyTemplate['state'];
+}
+
+export function mountTopologiesView(host: HTMLElement, provider: ProviderValue): ViewMount {
+  let builderControl: TopologyBuilderControl | null = null;
+  let userTopologies: TopologyDto[] = [];
+  let selectedItemId: string | null = null;
+  let destroyed = false;
+
+  const shell = buildCatalogShell({
+    title: 'Topologies',
+    titleIcon: 'fa-shapes',
+    newButtonLabel: 'New',
+    newButtonTitle: 'Start a fresh topology',
+    onNew: () => {
+      selectedItemId = null;
+      rebuildCatalog();
+      mountBuilder(null);
+    },
+    builderEmptyHint: 'Pick a topology from the catalog or click <strong>New</strong>.',
+    builderEmptyIcon: 'fa-arrow-left',
+  });
+  host.appendChild(shell.root);
+
+  function items(): TopologyCatalogItem[] {
+    const userItems: TopologyCatalogItem[] = userTopologies.map((t) => ({
+      id: t.topologyId,
+      name: t.name,
+      description: t.description ?? null,
+      source: 'user',
+      state: t.state,
+    }));
+    const builtinItems: TopologyCatalogItem[] = standardTemplates.map((t, i) => ({
+      id: `builtin-${i}`,
+      name: t.name,
+      description: t.description,
+      source: 'builtin',
+      state: t.state,
+    }));
+    return [...userItems, ...builtinItems];
+  }
+
+  function rebuildCatalog(): void {
+    shell.renderCatalog(items(), selectedItemId, (item) => {
+      selectedItemId = item.id;
+      rebuildCatalog();
+      mountBuilder(item as TopologyCatalogItem);
+    });
+  }
+
+  function mountBuilder(item: TopologyCatalogItem | null): void {
+    shell.clearBuilder();
+    const isBuiltin = item?.source === 'builtin';
+    const initialState = item ? { ...item.state, templateName: item.name } : undefined;
+
+    builderControl = new TopologyBuilderControl({
+      initialState,
+      hideGenerate: true,
+      onSaveTemplate: (state) => void onSave(item, state, isBuiltin),
+      onClear: () => {
+        selectedItemId = null;
+        shell.clearBuilder();
+        rebuildCatalog();
+      },
+    });
+    builderControl.render(shell.builderHost);
+
+    if (item && item.source === 'user') {
+      shell.attachDeleteButton(() => void onDelete(item));
+    }
+  }
+
+  async function onSave(
+    current: TopologyCatalogItem | null,
+    state: TopologyState,
+    isBuiltin: boolean,
+  ): Promise<void> {
+    const proposedName = state.templateName?.trim() || current?.name || '';
+    const name = window.prompt('Topology name:', proposedName);
+    if (!name) return;
+    const persistedState = { ...state, selectedNodeId: null, selectedEdgeId: null };
+    try {
+      if (current && current.source === 'user') {
+        await updateTopology(provider.organisationId, current.id, { name, state: persistedState });
+        tmxToast({ message: `Saved "${name}"`, intent: 'is-success' });
+      } else {
+        await createTopology(provider.organisationId, { name, state: persistedState });
+        tmxToast({
+          message: isBuiltin ? `Forked builtin to "${name}"` : `Saved "${name}"`,
+          intent: 'is-success',
+        });
+      }
+      await refresh();
+    } catch {
+      tmxToast({ message: 'Failed to save topology', intent: 'is-danger' });
+    }
+  }
+
+  async function onDelete(item: TopologyCatalogItem): Promise<void> {
+    if (!window.confirm(`Delete topology "${item.name}"?`)) return;
+    try {
+      await deleteTopology(provider.organisationId, item.id);
+      selectedItemId = null;
+      shell.clearBuilder();
+      await refresh();
+      tmxToast({ message: `Deleted "${item.name}"`, intent: 'is-success' });
+    } catch {
+      tmxToast({ message: 'Failed to delete topology', intent: 'is-danger' });
+    }
+  }
+
+  async function refresh(): Promise<void> {
+    if (destroyed) return;
+    const res: any = await listTopologies(provider.organisationId);
+    userTopologies = res?.data?.topologies ?? [];
+    rebuildCatalog();
+  }
+
+  void refresh();
+
+  return {
+    destroy: () => {
+      destroyed = true;
+      builderControl?.destroy();
+      builderControl = null;
+      shell.destroy();
+    },
+  };
+}

--- a/admin-client/src/pages/templates/views/viewTypes.ts
+++ b/admin-client/src/pages/templates/views/viewTypes.ts
@@ -1,0 +1,17 @@
+/**
+ * Shared types for Templates page sub-views (topologies, compositions,
+ * tieFormats). Each view exports `mount<Foo>View(host, provider)` returning
+ * a `ViewMount` with a destructor so the page orchestrator can cleanly
+ * tear down on tab switch.
+ */
+
+export interface ViewMount {
+  destroy(): void;
+}
+
+export interface CatalogItem {
+  id: string;
+  name: string;
+  description?: string | null;
+  source: 'builtin' | 'user';
+}

--- a/admin-client/src/pages/tournament/tabs/settingsTab/adminGrid.ts
+++ b/admin-client/src/pages/tournament/tabs/settingsTab/adminGrid.ts
@@ -1,10 +1,9 @@
 import { TabulatorFull as Tabulator } from 'tabulator-tables';
 import { calendarAudit, getCalendar, getTournamentInfo } from 'services/apis/servicesApi';
-import { openSettingsEditor } from 'components/providerConfig/openSettingsEditor';
+import { renderSettingsPanel } from './settingsPanel';
 import { manageTournamentAccess } from 'components/manageTournamentAccess';
 import { destroyTable } from 'pages/tournament/destroyTable';
 import { tmxToast } from 'services/notifications/tmxToast';
-import { context } from 'services/context';
 import { t } from 'i18n';
 
 import type { ProviderValue } from 'types/tmx';
@@ -25,9 +24,9 @@ export function renderAdminGrid(container: HTMLElement, params?: AdminGridParams
 
   if (provider) {
     renderProviderInfoPanel(grid, provider, isSuperAdmin);
-    renderQuickActionsPanel(grid, { provider, isSuperAdmin });
     renderCalendarPanel(grid, provider, isSuperAdmin);
     renderTournamentDetailPanel(grid);
+    renderSettingsPanel(grid, { provider, isSuperAdmin });
   } else {
     renderNoProviderPanel(grid, isSuperAdmin);
   }
@@ -38,7 +37,7 @@ export function renderAdminGrid(container: HTMLElement, params?: AdminGridParams
 function renderProviderInfoPanel(grid: HTMLElement, provider: ProviderValue, isSuperAdmin?: boolean): void {
   const panel = document.createElement('div');
   panel.className = 'settings-panel panel-blue';
-  panel.style.gridColumn = '1 / 3';
+  panel.style.gridColumn = '1 / -1';
 
   const image = provider.onlineResources?.find(
     (r) => r.name === 'providerImage' && r.resourceType === 'URL' && r.resourceSubType === 'IMAGE',
@@ -296,56 +295,6 @@ function renderTournamentInfo(container: HTMLElement, info: any, tournamentId: s
       });
     }, 0);
   }
-}
-
-function renderQuickActionsPanel(
-  grid: HTMLElement,
-  params: { provider: ProviderValue; isSuperAdmin?: boolean },
-): void {
-  const { provider, isSuperAdmin } = params;
-  const panel = document.createElement('div');
-  panel.className = 'settings-panel panel-purple';
-  panel.style.gridColumn = '3 / 5';
-
-  const actions: string[] = isSuperAdmin
-    ? [
-        `<div class="quick-action" id="qa-system-providers"><i class="fa-solid fa-server"></i> ${t('admin.manageProviders')}</div>`,
-        `<div class="quick-action" id="qa-system-users"><i class="fa-solid fa-users"></i> ${t('admin.manageUsers')}</div>`,
-      ]
-    : [];
-  // Provider admin (or super-admin while impersonating) can edit settings
-  // for the active provider. Server-side gate: PROVIDER_ADMIN of this
-  // provider OR SUPER_ADMIN. The button is shown to anyone here; an
-  // unauthorized user gets a clear ForbiddenException on save.
-  actions.push(
-    `<div class="quick-action" id="qa-edit-settings"><i class="fa-solid fa-sliders"></i> ${t('providerConfig.editSettingsButton')}</div>`,
-  );
-  actions.push(
-    `<div class="quick-action" id="qa-back-system"><i class="fa-solid fa-arrow-left"></i> ${t('admin.backToSystem')}</div>`,
-  );
-
-  panel.innerHTML = `
-    <h3><i class="fa-solid fa-bolt"></i> ${t('admin.quickActions')}</h3>
-    <div class="quick-actions-list">${actions.join('')}</div>
-  `;
-
-  grid.appendChild(panel);
-
-  setTimeout(() => {
-    document
-      .getElementById('qa-system-providers')
-      ?.addEventListener('click', () => context.router?.navigate('/system/providers'));
-    document
-      .getElementById('qa-system-users')
-      ?.addEventListener('click', () => context.router?.navigate('/system/users'));
-    document.getElementById('qa-back-system')?.addEventListener('click', () => context.router?.navigate('/system'));
-    document.getElementById('qa-edit-settings')?.addEventListener('click', () => {
-      openSettingsEditor({
-        providerId: provider.organisationId,
-        providerName: provider.organisationName,
-      });
-    });
-  }, 0);
 }
 
 function renderNoProviderPanel(grid: HTMLElement, isSuperAdmin?: boolean): void {

--- a/admin-client/src/pages/tournament/tabs/settingsTab/settingsPanel/__tests__/widgets.test.ts
+++ b/admin-client/src/pages/tournament/tabs/settingsTab/settingsPanel/__tests__/widgets.test.ts
@@ -1,0 +1,230 @@
+/**
+ * @vitest-environment happy-dom
+ */
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { chipMultiSelect } from '../widgets';
+
+function mount(opts: Parameters<typeof chipMultiSelect>[0]): HTMLElement {
+  const container = document.createElement('div');
+  document.body.appendChild(container);
+  container.appendChild(chipMultiSelect(opts));
+  return container;
+}
+
+beforeEach(() => {
+  document.body.innerHTML = '';
+});
+
+describe('chipMultiSelect — restricted universe (caps defines allowed list)', () => {
+  it('renders one chip per universe value plus a hint', () => {
+    const container = mount({
+      label: 'Test',
+      values: [],
+      pinnedUniverse: ['A', 'B', 'C'],
+      onChange: () => undefined,
+    });
+    const chips = container.querySelectorAll('.sp-chip');
+    expect(chips.length).toBe(3);
+    expect(container.querySelector('.sp-chips-hint')).toBeTruthy();
+  });
+
+  it('toggling an unselected chip emits the selected value', () => {
+    const onChange = vi.fn();
+    const container = mount({
+      label: 'Test',
+      values: [],
+      pinnedUniverse: ['A', 'B'],
+      onChange,
+    });
+    const chipA = container.querySelector<HTMLButtonElement>('.sp-chip')!;
+    chipA.click();
+    expect(onChange).toHaveBeenCalledTimes(1);
+    expect(onChange.mock.calls[0][0]).toEqual(['A']);
+  });
+
+  it('toggling an already-selected chip removes it', () => {
+    const onChange = vi.fn();
+    const container = mount({
+      label: 'Test',
+      values: ['A'],
+      pinnedUniverse: ['A', 'B'],
+      onChange,
+    });
+    const chipA = container.querySelector<HTMLButtonElement>('.sp-chip.is-selected')!;
+    chipA.click();
+    expect(onChange).toHaveBeenCalledTimes(1);
+    expect(onChange.mock.calls[0][0]).toEqual([]);
+  });
+
+  it('marks orphan values selected outside the universe', () => {
+    const container = mount({
+      label: 'Test',
+      values: ['LEGACY'],
+      pinnedUniverse: ['A', 'B'],
+      onChange: () => undefined,
+    });
+    const orphan = container.querySelector('.sp-chip.is-orphan');
+    expect(orphan?.textContent).toContain('LEGACY');
+  });
+});
+
+describe('chipMultiSelect — fullUniverse (factory enum, no caps)', () => {
+  it('renders one chip per fullUniverse value plus a hint', () => {
+    const container = mount({
+      label: 'Draw Types',
+      values: [],
+      fullUniverse: ['SINGLE_ELIMINATION', 'ROUND_ROBIN', 'COMPASS'],
+      onChange: () => undefined,
+    });
+    const chips = container.querySelectorAll('.sp-chip');
+    expect(chips.length).toBe(3);
+    expect(container.querySelector('.sp-chips-hint')).toBeTruthy();
+    // No free-form add input when a closed universe is supplied.
+    expect(container.querySelector('.sp-chip-add-input')).toBeFalsy();
+  });
+
+  it('toggling an unselected chip emits the selected value', () => {
+    const onChange = vi.fn();
+    const container = mount({
+      label: 'Draw Types',
+      values: [],
+      fullUniverse: ['SINGLE_ELIMINATION', 'ROUND_ROBIN'],
+      onChange,
+    });
+    const chip = container.querySelector<HTMLButtonElement>('.sp-chip')!;
+    chip.click();
+    expect(onChange).toHaveBeenCalledTimes(1);
+    expect(onChange.mock.calls[0][0]).toEqual(['SINGLE_ELIMINATION']);
+  });
+
+  it('orphan values outside the fullUniverse render with the orphan modifier', () => {
+    const container = mount({
+      label: 'Draw Types',
+      values: ['LEGACY_TYPE'],
+      fullUniverse: ['SINGLE_ELIMINATION', 'ROUND_ROBIN'],
+      onChange: () => undefined,
+    });
+    const orphan = container.querySelector('.sp-chip.is-orphan');
+    expect(orphan?.textContent).toContain('LEGACY_TYPE');
+  });
+
+  it('pinnedUniverse takes precedence over fullUniverse', () => {
+    const container = mount({
+      label: 'Draw Types',
+      values: [],
+      pinnedUniverse: ['ROUND_ROBIN'],
+      fullUniverse: ['SINGLE_ELIMINATION', 'ROUND_ROBIN', 'COMPASS'],
+      onChange: () => undefined,
+    });
+    const chips = container.querySelectorAll('.sp-chip');
+    expect(chips.length).toBe(1);
+    expect(chips[0].textContent).toContain('ROUND_ROBIN');
+  });
+});
+
+describe('chipMultiSelect — unrestricted universe (no caps, no fullUniverse)', () => {
+  it('renders only selected chips and an add input', () => {
+    const container = mount({
+      label: 'Test',
+      values: ['X'],
+      onChange: () => undefined,
+    });
+    expect(container.querySelectorAll('.sp-chip').length).toBe(1);
+    expect(container.querySelector('.sp-chip-add-input')).toBeTruthy();
+    expect(container.querySelector('.sp-chip-add-btn')).toBeTruthy();
+  });
+
+  it('typing in the input enables the ready state on the add button', () => {
+    const container = mount({
+      label: 'Test',
+      values: [],
+      onChange: () => undefined,
+    });
+    const input = container.querySelector<HTMLInputElement>('.sp-chip-add-input')!;
+    const btn = container.querySelector<HTMLButtonElement>('.sp-chip-add-btn')!;
+
+    expect(btn.classList.contains('is-ready')).toBe(false);
+    input.value = 'NEW';
+    input.dispatchEvent(new Event('input'));
+    expect(btn.classList.contains('is-ready')).toBe(true);
+  });
+
+  it('clicking + with text in the input emits the new value', () => {
+    const onChange = vi.fn();
+    const container = mount({
+      label: 'Test',
+      values: [],
+      onChange,
+    });
+    const input = container.querySelector<HTMLInputElement>('.sp-chip-add-input')!;
+    const btn = container.querySelector<HTMLButtonElement>('.sp-chip-add-btn')!;
+
+    input.value = 'ADDED';
+    input.dispatchEvent(new Event('input'));
+    btn.click();
+
+    expect(onChange).toHaveBeenCalledTimes(1);
+    expect(onChange.mock.calls[0][0]).toEqual(['ADDED']);
+  });
+
+  it('clicking + with empty input focuses the input rather than no-op', () => {
+    const container = mount({
+      label: 'Test',
+      values: [],
+      onChange: () => undefined,
+    });
+    const input = container.querySelector<HTMLInputElement>('.sp-chip-add-input')!;
+    const btn = container.querySelector<HTMLButtonElement>('.sp-chip-add-btn')!;
+
+    btn.click();
+    expect(document.activeElement).toBe(input);
+  });
+
+  it('Enter on the input commits the value', () => {
+    const onChange = vi.fn();
+    const container = mount({
+      label: 'Test',
+      values: [],
+      onChange,
+    });
+    const input = container.querySelector<HTMLInputElement>('.sp-chip-add-input')!;
+    input.value = 'VIA_ENTER';
+    input.dispatchEvent(new KeyboardEvent('keydown', { key: 'Enter', cancelable: true, bubbles: true }));
+    expect(onChange).toHaveBeenCalledTimes(1);
+    expect(onChange.mock.calls[0][0]).toEqual(['VIA_ENTER']);
+  });
+
+  it('adding a duplicate value is a no-op', () => {
+    const onChange = vi.fn();
+    const container = mount({
+      label: 'Test',
+      values: ['DUP'],
+      onChange,
+    });
+    const input = container.querySelector<HTMLInputElement>('.sp-chip-add-input')!;
+    const btn = container.querySelector<HTMLButtonElement>('.sp-chip-add-btn')!;
+
+    input.value = 'DUP';
+    input.dispatchEvent(new Event('input'));
+    btn.click();
+    expect(onChange).not.toHaveBeenCalled();
+  });
+
+  it('after add, the input is back in the DOM (rebuild kept the field)', () => {
+    const container = mount({
+      label: 'Test',
+      values: [],
+      onChange: () => undefined,
+    });
+    const inputBefore = container.querySelector<HTMLInputElement>('.sp-chip-add-input')!;
+    inputBefore.value = 'A';
+    inputBefore.dispatchEvent(new Event('input'));
+    const btn = container.querySelector<HTMLButtonElement>('.sp-chip-add-btn')!;
+    btn.click();
+    // The previous input element is no longer in the DOM; a fresh one
+    // is rendered as part of the rebuild.
+    const inputAfter = container.querySelector<HTMLInputElement>('.sp-chip-add-input');
+    expect(inputAfter).toBeTruthy();
+    expect(inputAfter).not.toBe(inputBefore);
+  });
+});

--- a/admin-client/src/pages/tournament/tabs/settingsTab/settingsPanel/constants.ts
+++ b/admin-client/src/pages/tournament/tabs/settingsTab/settingsPanel/constants.ts
@@ -1,0 +1,24 @@
+/**
+ * Canonical option lists for the Settings panel's constant-backed
+ * selects. Mirrors values in the factory's constants modules — kept
+ * inline here so the admin-client bundle doesn't pull the whole
+ * factory just for a handful of strings.
+ */
+
+export const EVENT_TYPE_OPTIONS = ['SINGLES', 'DOUBLES', 'TEAM'] as const;
+
+export const GENDER_OPTIONS = ['MALE', 'FEMALE', 'MIXED', 'ANY'] as const;
+
+export const DRAW_TYPE_OPTIONS = [
+  'SINGLE_ELIMINATION',
+  'ROUND_ROBIN',
+  'ROUND_ROBIN_WITH_PLAYOFF',
+  'COMPASS',
+  'FEED_IN_CHAMPIONSHIP',
+  'FIRST_MATCH_LOSER_CONSOLATION',
+  'FIRST_ROUND_LOSER_CONSOLATION',
+  'CURTIS_CONSOLATION',
+  'AD_HOC',
+] as const;
+
+export const CREATION_METHOD_OPTIONS = ['AUTOMATED', 'MANUAL', 'DRAFT'] as const;

--- a/admin-client/src/pages/tournament/tabs/settingsTab/settingsPanel/constants.ts
+++ b/admin-client/src/pages/tournament/tabs/settingsTab/settingsPanel/constants.ts
@@ -22,3 +22,10 @@ export const DRAW_TYPE_OPTIONS = [
 ] as const;
 
 export const CREATION_METHOD_OPTIONS = ['AUTOMATED', 'MANUAL', 'DRAFT'] as const;
+
+export const SCORING_APPROACH_OPTIONS = [
+  'dynamicSets',
+  'freeScore',
+  'dialPad',
+  'inlineScoring',
+] as const;

--- a/admin-client/src/pages/tournament/tabs/settingsTab/settingsPanel/index.ts
+++ b/admin-client/src/pages/tournament/tabs/settingsTab/settingsPanel/index.ts
@@ -15,6 +15,8 @@
  */
 import './settingsPanel.css';
 import { getRawProviderConfig, updateProviderSettings } from 'services/apis/providerConfigApi';
+import { listTopologies, type TopologyDto } from 'services/apis/topologyApi';
+import { listCatalog, type CatalogItemDto } from 'services/apis/catalogApi';
 import { tmxToast } from 'services/notifications/tmxToast';
 import { t } from 'i18n';
 import type { ProviderValue } from 'types/tmx';
@@ -33,6 +35,17 @@ interface PanelState {
   original: ProviderConfigSettings;
   /** Mutable working copy — topics edit this. */
   draft: ProviderConfigSettings;
+  /**
+   * Provider-defined topologies, loaded alongside config. Topology IDs
+   * mix into the Allowed Selections "Draw Types" chip universe so a TD
+   * can pick from factory enum + provider topologies.
+   */
+  topologies: TopologyDto[];
+  /**
+   * Provider-defined policies from the policy catalog. Surfaces in the
+   * Policies topic as picker options alongside factory builtins.
+   */
+  policies: CatalogItemDto[];
   activeTopic: TopicId;
   errorMessage?: string;
   validationIssues?: ValidationIssue[];
@@ -50,6 +63,8 @@ export function renderSettingsPanel(grid: HTMLElement, params: RenderSettingsPan
     caps: {},
     original: {},
     draft: {},
+    topologies: [],
+    policies: [],
     activeTopic: TOPICS[0].id,
   };
 
@@ -172,7 +187,15 @@ export function renderSettingsPanel(grid: HTMLElement, params: RenderSettingsPan
 
 async function loadConfig(providerId: string, state: PanelState, onLoaded: () => void): Promise<void> {
   try {
-    const res: any = await getRawProviderConfig(providerId);
+    // Fetch config + topologies + policies in parallel; all three feed the editor.
+    const [configRes, topologiesRes, policiesRes] = await Promise.all([
+      getRawProviderConfig(providerId),
+      // Topology and policy catalogs are best-effort — a stale endpoint or
+      // missing permission shouldn't block the rest of the editor.
+      listTopologies(providerId).catch(() => ({ data: { topologies: [] } })),
+      listCatalog(providerId, 'policy').catch(() => ({ data: { items: [] } })),
+    ]);
+    const res: any = configRes;
     if (res?.data?.error) {
       state.status = 'error';
       state.errorMessage = res.data.error;
@@ -180,6 +203,8 @@ async function loadConfig(providerId: string, state: PanelState, onLoaded: () =>
       state.caps = (res?.data?.caps ?? {}) as ProviderConfigCaps;
       state.original = (res?.data?.settings ?? {}) as ProviderConfigSettings;
       state.draft = deepClone(state.original);
+      state.topologies = ((topologiesRes as any)?.data?.topologies ?? []) as TopologyDto[];
+      state.policies = ((policiesRes as any)?.data?.items ?? []) as CatalogItemDto[];
       state.status = 'ready';
     }
   } catch (err) {
@@ -232,7 +257,13 @@ function rerenderContent(contentHost: HTMLElement, state: PanelState, onChange: 
     contentHost.appendChild(buildValidationBanner(state.validationIssues));
   }
   const topic = TOPICS.find((t) => t.id === state.activeTopic) ?? TOPICS[0];
-  const ctx: TopicContext = { caps: state.caps, draft: state.draft, onChange };
+  const ctx: TopicContext = {
+    caps: state.caps,
+    draft: state.draft,
+    topologies: state.topologies,
+    policies: state.policies,
+    onChange,
+  };
   topic.render(contentHost, ctx);
 }
 

--- a/admin-client/src/pages/tournament/tabs/settingsTab/settingsPanel/index.ts
+++ b/admin-client/src/pages/tournament/tabs/settingsTab/settingsPanel/index.ts
@@ -1,0 +1,104 @@
+/**
+ * Provider settings panel — full-width in-page editor that replaces the
+ * old Quick Actions → Edit Settings modal. Two-column layout: topic nav
+ * on the left, structured editor on the right. Persists to
+ * `providerConfigSettings` via the existing `updateProviderSettings`
+ * API.
+ *
+ * Phase 1: layout + topic nav skeleton with placeholder topic content.
+ * Per-topic editors and save plumbing land in subsequent phases — see
+ * `Mentat/planning/ADMIN_SETTINGS_PAGE_REDESIGN.md`.
+ */
+import './settingsPanel.css';
+import type { ProviderValue } from 'types/tmx';
+
+export interface SettingsPanelTopic {
+  id: string;
+  label: string;
+  icon: string;
+}
+
+const TOPICS: SettingsPanelTopic[] = [
+  { id: 'permissions', label: 'Permissions', icon: 'fa-shield-halved' },
+  { id: 'allowed', label: 'Allowed Universes', icon: 'fa-list-check' },
+  { id: 'policies', label: 'Policies', icon: 'fa-scale-balanced' },
+  { id: 'defaults', label: 'Defaults', icon: 'fa-sliders' },
+  { id: 'print', label: 'Print Configuration', icon: 'fa-print' },
+  { id: 'categories', label: 'Categories', icon: 'fa-layer-group' },
+];
+
+interface RenderSettingsPanelParams {
+  provider: ProviderValue;
+  isSuperAdmin?: boolean;
+}
+
+export function renderSettingsPanel(grid: HTMLElement, params: RenderSettingsPanelParams): void {
+  const panel = document.createElement('div');
+  panel.className = 'settings-panel panel-gray sp-panel';
+  panel.style.gridColumn = '1 / -1';
+  // Stash provider context on the panel so per-topic editors mounted
+  // later can read it without prop-drilling.
+  panel.dataset.providerId = params.provider.organisationId;
+  if (params.isSuperAdmin) panel.dataset.superAdmin = 'true';
+
+  const header = document.createElement('h3');
+  header.innerHTML = '<i class="fa-solid fa-sliders"></i> Settings';
+  panel.appendChild(header);
+
+  const layout = document.createElement('div');
+  layout.className = 'sp-layout';
+
+  layout.appendChild(buildNav());
+  layout.appendChild(buildContent());
+
+  panel.appendChild(layout);
+  grid.appendChild(panel);
+}
+
+function buildNav(): HTMLElement {
+  const nav = document.createElement('nav');
+  nav.className = 'sp-nav';
+  nav.setAttribute('aria-label', 'Settings topics');
+
+  let activeId = TOPICS[0].id;
+
+  for (const topic of TOPICS) {
+    const item = document.createElement('button');
+    item.type = 'button';
+    item.className = 'sp-nav-item';
+    item.dataset.topic = topic.id;
+    item.setAttribute('aria-pressed', String(topic.id === activeId));
+    if (topic.id === activeId) item.classList.add('is-active');
+    item.innerHTML = `<i class="fa-solid ${topic.icon}"></i><span>${topic.label}</span>`;
+    item.addEventListener('click', () => {
+      activeId = topic.id;
+      nav.querySelectorAll<HTMLButtonElement>('.sp-nav-item').forEach((btn) => {
+        const isActive = btn.dataset.topic === activeId;
+        btn.classList.toggle('is-active', isActive);
+        btn.setAttribute('aria-pressed', String(isActive));
+      });
+      const event = new CustomEvent('sp:topic-change', { detail: activeId, bubbles: true });
+      nav.dispatchEvent(event);
+    });
+    nav.appendChild(item);
+  }
+
+  return nav;
+}
+
+function buildContent(): HTMLElement {
+  const content = document.createElement('div');
+  content.className = 'sp-content';
+  content.setAttribute('aria-live', 'polite');
+
+  const placeholder = document.createElement('div');
+  placeholder.className = 'sp-placeholder';
+  placeholder.innerHTML = `
+    <i class="fa-solid fa-wrench"></i>
+    <p>Settings editors are being rebuilt.</p>
+    <p class="sp-placeholder-sub">Per-topic structured forms land in the next phases — see the admin-client settings redesign plan for details.</p>
+  `;
+  content.appendChild(placeholder);
+
+  return content;
+}

--- a/admin-client/src/pages/tournament/tabs/settingsTab/settingsPanel/index.ts
+++ b/admin-client/src/pages/tournament/tabs/settingsTab/settingsPanel/index.ts
@@ -1,43 +1,43 @@
 /**
- * Provider settings panel — full-width in-page editor that replaces the
- * old Quick Actions → Edit Settings modal. Two-column layout: topic nav
- * on the left, structured editor on the right. Persists to
+ * Provider settings panel — full-width in-page editor that replaces
+ * the old Quick Actions → Edit Settings modal. Two-column layout:
+ * topic nav on the left, structured editor on the right. Persists to
  * `providerConfigSettings` via the existing `updateProviderSettings`
  * API.
  *
- * Phase 1: layout + topic nav skeleton with placeholder topic content.
- * Per-topic editors and save plumbing land in subsequent phases — see
- * `Mentat/planning/ADMIN_SETTINGS_PAGE_REDESIGN.md`.
+ * Phase 1: layout + topic nav skeleton.
+ * Phase 2 (this): fetch raw config on mount, switch content per topic
+ *   via the registry in `topics.ts`, render read-only summaries.
+ * Phase 3: per-topic editors (multi-select chips, structured policy
+ *   forms, embedded composition editor, etc.).
+ *
+ * See `Mentat/planning/ADMIN_SETTINGS_PAGE_REDESIGN.md`.
  */
 import './settingsPanel.css';
+import { getRawProviderConfig } from 'services/apis/providerConfigApi';
+import { tmxToast } from 'services/notifications/tmxToast';
+import { t } from 'i18n';
 import type { ProviderValue } from 'types/tmx';
-
-export interface SettingsPanelTopic {
-  id: string;
-  label: string;
-  icon: string;
-}
-
-const TOPICS: SettingsPanelTopic[] = [
-  { id: 'permissions', label: 'Permissions', icon: 'fa-shield-halved' },
-  { id: 'allowed', label: 'Allowed Universes', icon: 'fa-list-check' },
-  { id: 'policies', label: 'Policies', icon: 'fa-scale-balanced' },
-  { id: 'defaults', label: 'Defaults', icon: 'fa-sliders' },
-  { id: 'print', label: 'Print Configuration', icon: 'fa-print' },
-  { id: 'categories', label: 'Categories', icon: 'fa-layer-group' },
-];
+import type { ProviderConfigCaps, ProviderConfigSettings } from 'types/providerConfig';
+import { TOPICS, type TopicContext, type TopicId } from './topics';
 
 interface RenderSettingsPanelParams {
   provider: ProviderValue;
   isSuperAdmin?: boolean;
 }
 
+interface PanelState {
+  status: 'loading' | 'ready' | 'error';
+  caps: ProviderConfigCaps;
+  settings: ProviderConfigSettings;
+  activeTopic: TopicId;
+  errorMessage?: string;
+}
+
 export function renderSettingsPanel(grid: HTMLElement, params: RenderSettingsPanelParams): void {
   const panel = document.createElement('div');
   panel.className = 'settings-panel panel-gray sp-panel';
   panel.style.gridColumn = '1 / -1';
-  // Stash provider context on the panel so per-topic editors mounted
-  // later can read it without prop-drilling.
   panel.dataset.providerId = params.provider.organisationId;
   if (params.isSuperAdmin) panel.dataset.superAdmin = 'true';
 
@@ -47,58 +47,115 @@ export function renderSettingsPanel(grid: HTMLElement, params: RenderSettingsPan
 
   const layout = document.createElement('div');
   layout.className = 'sp-layout';
-
-  layout.appendChild(buildNav());
-  layout.appendChild(buildContent());
-
   panel.appendChild(layout);
+
+  const navHost = document.createElement('nav');
+  navHost.className = 'sp-nav';
+  navHost.setAttribute('aria-label', 'Settings topics');
+  layout.appendChild(navHost);
+
+  const contentHost = document.createElement('div');
+  contentHost.className = 'sp-content';
+  contentHost.setAttribute('aria-live', 'polite');
+  layout.appendChild(contentHost);
+
   grid.appendChild(panel);
+
+  const state: PanelState = {
+    status: 'loading',
+    caps: {},
+    settings: {},
+    activeTopic: TOPICS[0].id,
+  };
+
+  buildNav(navHost, state, (next) => {
+    state.activeTopic = next;
+    rerenderContent(contentHost, state);
+  });
+  rerenderContent(contentHost, state);
+
+  void loadConfig(params.provider.organisationId, state, () => {
+    rerenderContent(contentHost, state);
+    // Repaint nav so any per-topic indicators (configured/empty) reflect
+    // freshly-loaded data once Phase 3 introduces them.
+    navHost.querySelectorAll<HTMLButtonElement>('.sp-nav-item').forEach((btn) => {
+      const isActive = btn.dataset.topic === state.activeTopic;
+      btn.classList.toggle('is-active', isActive);
+      btn.setAttribute('aria-pressed', String(isActive));
+    });
+  });
 }
 
-function buildNav(): HTMLElement {
-  const nav = document.createElement('nav');
-  nav.className = 'sp-nav';
-  nav.setAttribute('aria-label', 'Settings topics');
+async function loadConfig(providerId: string, state: PanelState, onChange: () => void): Promise<void> {
+  try {
+    const res: any = await getRawProviderConfig(providerId);
+    if (res?.data?.error) {
+      state.status = 'error';
+      state.errorMessage = res.data.error;
+    } else {
+      state.caps = (res?.data?.caps ?? {}) as ProviderConfigCaps;
+      state.settings = (res?.data?.settings ?? {}) as ProviderConfigSettings;
+      state.status = 'ready';
+    }
+  } catch (err) {
+    state.status = 'error';
+    state.errorMessage = err instanceof Error ? err.message : t('system.loadError');
+    tmxToast({ message: t('system.loadError'), intent: 'is-danger' });
+  }
+  onChange();
+}
 
-  let activeId = TOPICS[0].id;
-
+function buildNav(navHost: HTMLElement, state: PanelState, onSelect: (id: TopicId) => void): void {
   for (const topic of TOPICS) {
     const item = document.createElement('button');
     item.type = 'button';
     item.className = 'sp-nav-item';
     item.dataset.topic = topic.id;
-    item.setAttribute('aria-pressed', String(topic.id === activeId));
-    if (topic.id === activeId) item.classList.add('is-active');
+    const isActive = topic.id === state.activeTopic;
+    item.classList.toggle('is-active', isActive);
+    item.setAttribute('aria-pressed', String(isActive));
     item.innerHTML = `<i class="fa-solid ${topic.icon}"></i><span>${topic.label}</span>`;
-    item.addEventListener('click', () => {
-      activeId = topic.id;
-      nav.querySelectorAll<HTMLButtonElement>('.sp-nav-item').forEach((btn) => {
-        const isActive = btn.dataset.topic === activeId;
-        btn.classList.toggle('is-active', isActive);
-        btn.setAttribute('aria-pressed', String(isActive));
-      });
-      const event = new CustomEvent('sp:topic-change', { detail: activeId, bubbles: true });
-      nav.dispatchEvent(event);
-    });
-    nav.appendChild(item);
+    item.addEventListener('click', () => onSelect(topic.id));
+    navHost.appendChild(item);
   }
-
-  return nav;
 }
 
-function buildContent(): HTMLElement {
-  const content = document.createElement('div');
-  content.className = 'sp-content';
-  content.setAttribute('aria-live', 'polite');
+function rerenderContent(contentHost: HTMLElement, state: PanelState): void {
+  contentHost.innerHTML = '';
+  if (state.status === 'loading') {
+    contentHost.appendChild(buildLoading());
+    return;
+  }
+  if (state.status === 'error') {
+    contentHost.appendChild(buildError(state.errorMessage));
+    return;
+  }
+  const topic = TOPICS.find((t) => t.id === state.activeTopic) ?? TOPICS[0];
+  const ctx: TopicContext = { caps: state.caps, settings: state.settings };
+  topic.render(contentHost, ctx);
+}
 
-  const placeholder = document.createElement('div');
-  placeholder.className = 'sp-placeholder';
-  placeholder.innerHTML = `
-    <i class="fa-solid fa-wrench"></i>
-    <p>Settings editors are being rebuilt.</p>
-    <p class="sp-placeholder-sub">Per-topic structured forms land in the next phases — see the admin-client settings redesign plan for details.</p>
+function buildLoading(): HTMLElement {
+  const wrap = document.createElement('div');
+  wrap.className = 'sp-placeholder';
+  wrap.innerHTML = `
+    <i class="fa-solid fa-spinner fa-spin"></i>
+    <p>Loading settings…</p>
   `;
-  content.appendChild(placeholder);
+  return wrap;
+}
 
-  return content;
+function buildError(message?: string): HTMLElement {
+  const wrap = document.createElement('div');
+  wrap.className = 'sp-placeholder sp-error';
+  wrap.innerHTML = `
+    <i class="fa-solid fa-triangle-exclamation"></i>
+    <p>Could not load settings.</p>
+    ${message ? `<p class="sp-placeholder-sub">${escapeHtml(message)}</p>` : ''}
+  `;
+  return wrap;
+}
+
+function escapeHtml(s: string): string {
+  return s.replace(/[&<>"']/g, (c) => ({ '&': '&amp;', '<': '&lt;', '>': '&gt;', '"': '&quot;', "'": '&#39;' })[c]!);
 }

--- a/admin-client/src/pages/tournament/tabs/settingsTab/settingsPanel/index.ts
+++ b/admin-client/src/pages/tournament/tabs/settingsTab/settingsPanel/index.ts
@@ -6,19 +6,19 @@
  * API.
  *
  * Phase 1: layout + topic nav skeleton.
- * Phase 2 (this): fetch raw config on mount, switch content per topic
- *   via the registry in `topics.ts`, render read-only summaries.
- * Phase 3: per-topic editors (multi-select chips, structured policy
- *   forms, embedded composition editor, etc.).
+ * Phase 2: fetch raw config on mount + topic switching.
+ * Phase 3a (this): mutable draft, dirty tracking, panel-level Save,
+ *   real editors for Defaults + Permissions. Other topics stay as
+ *   read-only summaries until 3b–d.
  *
  * See `Mentat/planning/ADMIN_SETTINGS_PAGE_REDESIGN.md`.
  */
 import './settingsPanel.css';
-import { getRawProviderConfig } from 'services/apis/providerConfigApi';
+import { getRawProviderConfig, updateProviderSettings } from 'services/apis/providerConfigApi';
 import { tmxToast } from 'services/notifications/tmxToast';
 import { t } from 'i18n';
 import type { ProviderValue } from 'types/tmx';
-import type { ProviderConfigCaps, ProviderConfigSettings } from 'types/providerConfig';
+import type { ProviderConfigCaps, ProviderConfigSettings, ValidationIssue } from 'types/providerConfig';
 import { TOPICS, type TopicContext, type TopicId } from './topics';
 
 interface RenderSettingsPanelParams {
@@ -27,11 +27,15 @@ interface RenderSettingsPanelParams {
 }
 
 interface PanelState {
-  status: 'loading' | 'ready' | 'error';
+  status: 'loading' | 'ready' | 'error' | 'saving';
   caps: ProviderConfigCaps;
-  settings: ProviderConfigSettings;
+  /** Last-known persisted shape — used as the dirty-comparison baseline. */
+  original: ProviderConfigSettings;
+  /** Mutable working copy — topics edit this. */
+  draft: ProviderConfigSettings;
   activeTopic: TopicId;
   errorMessage?: string;
+  validationIssues?: ValidationIssue[];
 }
 
 export function renderSettingsPanel(grid: HTMLElement, params: RenderSettingsPanelParams): void {
@@ -41,9 +45,17 @@ export function renderSettingsPanel(grid: HTMLElement, params: RenderSettingsPan
   panel.dataset.providerId = params.provider.organisationId;
   if (params.isSuperAdmin) panel.dataset.superAdmin = 'true';
 
-  const header = document.createElement('h3');
-  header.innerHTML = '<i class="fa-solid fa-sliders"></i> Settings';
-  panel.appendChild(header);
+  const state: PanelState = {
+    status: 'loading',
+    caps: {},
+    original: {},
+    draft: {},
+    activeTopic: TOPICS[0].id,
+  };
+
+  const headerEl = document.createElement('div');
+  headerEl.className = 'sp-panel-header';
+  panel.appendChild(headerEl);
 
   const layout = document.createElement('div');
   layout.className = 'sp-layout';
@@ -61,32 +73,104 @@ export function renderSettingsPanel(grid: HTMLElement, params: RenderSettingsPan
 
   grid.appendChild(panel);
 
-  const state: PanelState = {
-    status: 'loading',
-    caps: {},
-    settings: {},
-    activeTopic: TOPICS[0].id,
+  const ui = {
+    saveBtn: null as HTMLButtonElement | null,
+    dirtyDot: null as HTMLElement | null,
   };
 
-  buildNav(navHost, state, (next) => {
-    state.activeTopic = next;
-    rerenderContent(contentHost, state);
-  });
-  rerenderContent(contentHost, state);
+  const onChange = () => {
+    refreshDirty();
+  };
+
+  const onSelectTopic = (id: TopicId) => {
+    state.activeTopic = id;
+    updateNavActive(navHost, state.activeTopic);
+    rerenderContent(contentHost, state, onChange);
+  };
+
+  const onSave = async () => {
+    if (state.status !== 'ready' && state.status !== 'error') return;
+    if (!isDirty(state)) return;
+    state.status = 'saving';
+    refreshHeader();
+    try {
+      const res: any = await updateProviderSettings(params.provider.organisationId, state.draft);
+      if (res?.data?.code === 'SETTINGS_INVALID') {
+        state.validationIssues = res.data.issues as ValidationIssue[];
+        state.status = 'ready';
+        tmxToast({ message: t('providerConfig.invalid'), intent: 'is-danger' });
+        rerenderContent(contentHost, state, onChange);
+        refreshHeader();
+        return;
+      }
+      if (res?.data?.error) {
+        state.status = 'ready';
+        tmxToast({ message: res.data.error, intent: 'is-danger' });
+        refreshHeader();
+        return;
+      }
+      // Saved — make the current draft the new baseline.
+      state.original = deepClone(state.draft);
+      state.validationIssues = undefined;
+      state.status = 'ready';
+      tmxToast({ message: t('providerConfig.settingsSaved'), intent: 'is-success' });
+      rerenderContent(contentHost, state, onChange);
+      refreshHeader();
+    } catch (err) {
+      state.status = 'ready';
+      tmxToast({ message: t('providerConfig.saveFailed'), intent: 'is-danger' });
+      refreshHeader();
+       
+      console.error('[settingsPanel] save failed', err);
+    }
+  };
+
+  const refreshHeader = () => {
+    headerEl.innerHTML = '';
+    const title = document.createElement('h3');
+    title.innerHTML = '<i class="fa-solid fa-sliders"></i> Settings';
+    headerEl.appendChild(title);
+
+    ui.dirtyDot = document.createElement('span');
+    ui.dirtyDot.className = 'sp-dirty-dot';
+    ui.dirtyDot.title = 'Unsaved changes';
+    if (!isDirty(state)) ui.dirtyDot.style.visibility = 'hidden';
+    headerEl.appendChild(ui.dirtyDot);
+
+    const spacer = document.createElement('div');
+    spacer.style.flex = '1';
+    headerEl.appendChild(spacer);
+
+    ui.saveBtn = document.createElement('button');
+    ui.saveBtn.type = 'button';
+    ui.saveBtn.className = 'sp-save-btn';
+    ui.saveBtn.disabled = !isDirty(state) || state.status === 'saving' || state.status === 'loading';
+    ui.saveBtn.innerHTML =
+      state.status === 'saving'
+        ? '<i class="fa-solid fa-spinner fa-spin"></i> Saving…'
+        : '<i class="fa-solid fa-floppy-disk"></i> Save';
+    ui.saveBtn.addEventListener('click', () => void onSave());
+    headerEl.appendChild(ui.saveBtn);
+  };
+
+  const refreshDirty = () => {
+    if (!ui.dirtyDot || !ui.saveBtn) return;
+    const dirty = isDirty(state);
+    ui.dirtyDot.style.visibility = dirty ? 'visible' : 'hidden';
+    ui.saveBtn.disabled = !dirty || state.status === 'saving' || state.status === 'loading';
+  };
+
+  buildNav(navHost, state.activeTopic, onSelectTopic);
+  refreshHeader();
+  rerenderContent(contentHost, state, onChange);
 
   void loadConfig(params.provider.organisationId, state, () => {
-    rerenderContent(contentHost, state);
-    // Repaint nav so any per-topic indicators (configured/empty) reflect
-    // freshly-loaded data once Phase 3 introduces them.
-    navHost.querySelectorAll<HTMLButtonElement>('.sp-nav-item').forEach((btn) => {
-      const isActive = btn.dataset.topic === state.activeTopic;
-      btn.classList.toggle('is-active', isActive);
-      btn.setAttribute('aria-pressed', String(isActive));
-    });
+    rerenderContent(contentHost, state, onChange);
+    refreshHeader();
   });
 }
 
-async function loadConfig(providerId: string, state: PanelState, onChange: () => void): Promise<void> {
+async function loadConfig(providerId: string, state: PanelState, onLoaded: () => void): Promise<void> {
   try {
     const res: any = await getRawProviderConfig(providerId);
     if (res?.data?.error) {
@@ -94,7 +178,8 @@ async function loadConfig(providerId: string, state: PanelState, onChange: () =>
       state.errorMessage = res.data.error;
     } else {
       state.caps = (res?.data?.caps ?? {}) as ProviderConfigCaps;
-      state.settings = (res?.data?.settings ?? {}) as ProviderConfigSettings;
+      state.original = (res?.data?.settings ?? {}) as ProviderConfigSettings;
+      state.draft = deepClone(state.original);
       state.status = 'ready';
     }
   } catch (err) {
@@ -102,16 +187,16 @@ async function loadConfig(providerId: string, state: PanelState, onChange: () =>
     state.errorMessage = err instanceof Error ? err.message : t('system.loadError');
     tmxToast({ message: t('system.loadError'), intent: 'is-danger' });
   }
-  onChange();
+  onLoaded();
 }
 
-function buildNav(navHost: HTMLElement, state: PanelState, onSelect: (id: TopicId) => void): void {
+function buildNav(navHost: HTMLElement, activeId: TopicId, onSelect: (id: TopicId) => void): void {
   for (const topic of TOPICS) {
     const item = document.createElement('button');
     item.type = 'button';
     item.className = 'sp-nav-item';
     item.dataset.topic = topic.id;
-    const isActive = topic.id === state.activeTopic;
+    const isActive = topic.id === activeId;
     item.classList.toggle('is-active', isActive);
     item.setAttribute('aria-pressed', String(isActive));
     item.innerHTML = `<i class="fa-solid ${topic.icon}"></i><span>${topic.label}</span>`;
@@ -120,7 +205,20 @@ function buildNav(navHost: HTMLElement, state: PanelState, onSelect: (id: TopicI
   }
 }
 
-function rerenderContent(contentHost: HTMLElement, state: PanelState): void {
+/**
+ * The Phase 2 bug: nav highlight only set at construction. Now the
+ * panel calls this on every topic switch so the active item tracks
+ * the current selection.
+ */
+function updateNavActive(navHost: HTMLElement, activeId: TopicId): void {
+  navHost.querySelectorAll<HTMLButtonElement>('.sp-nav-item').forEach((btn) => {
+    const isActive = btn.dataset.topic === activeId;
+    btn.classList.toggle('is-active', isActive);
+    btn.setAttribute('aria-pressed', String(isActive));
+  });
+}
+
+function rerenderContent(contentHost: HTMLElement, state: PanelState, onChange: () => void): void {
   contentHost.innerHTML = '';
   if (state.status === 'loading') {
     contentHost.appendChild(buildLoading());
@@ -130,8 +228,11 @@ function rerenderContent(contentHost: HTMLElement, state: PanelState): void {
     contentHost.appendChild(buildError(state.errorMessage));
     return;
   }
+  if (state.validationIssues?.length) {
+    contentHost.appendChild(buildValidationBanner(state.validationIssues));
+  }
   const topic = TOPICS.find((t) => t.id === state.activeTopic) ?? TOPICS[0];
-  const ctx: TopicContext = { caps: state.caps, settings: state.settings };
+  const ctx: TopicContext = { caps: state.caps, draft: state.draft, onChange };
   topic.render(contentHost, ctx);
 }
 
@@ -154,6 +255,24 @@ function buildError(message?: string): HTMLElement {
     ${message ? `<p class="sp-placeholder-sub">${escapeHtml(message)}</p>` : ''}
   `;
   return wrap;
+}
+
+function buildValidationBanner(issues: ValidationIssue[]): HTMLElement {
+  const wrap = document.createElement('div');
+  wrap.className = 'sp-validation';
+  wrap.innerHTML = `
+    <strong><i class="fa-solid fa-circle-exclamation"></i> Server validation rejected the save</strong>
+    <ul>${issues.map((i) => `<li><code>${escapeHtml(i.path)}</code>: ${escapeHtml(i.message)}</li>`).join('')}</ul>
+  `;
+  return wrap;
+}
+
+function isDirty(state: PanelState): boolean {
+  return JSON.stringify(state.original) !== JSON.stringify(state.draft);
+}
+
+function deepClone<T>(value: T): T {
+  return JSON.parse(JSON.stringify(value)) as T;
 }
 
 function escapeHtml(s: string): string {

--- a/admin-client/src/pages/tournament/tabs/settingsTab/settingsPanel/settingsPanel.css
+++ b/admin-client/src/pages/tournament/tabs/settingsTab/settingsPanel/settingsPanel.css
@@ -1,0 +1,115 @@
+/**
+ * Provider settings panel — two-column layout (topic nav + content).
+ * Mirrors the policy-catalog visual language but uses TMX theme
+ * variables (--tmx-*) so it sits comfortably alongside the other
+ * settings panels.
+ */
+
+.sp-panel {
+  /* parent .settings-panel already supplies padding; we want the
+     internal layout to feel breathing-room dense, so push gap on
+     internal grid rather than on the outer panel. */
+}
+
+.sp-layout {
+  display: grid;
+  grid-template-columns: 240px 1fr;
+  gap: 16px;
+  margin-top: 12px;
+  min-height: 320px;
+}
+
+.sp-nav {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+  border-right: 1px solid var(--tmx-border-primary, #e0e0e0);
+  padding-right: 12px;
+}
+
+.sp-nav-item {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  padding: 10px 12px;
+  border: 1px solid transparent;
+  border-radius: 6px;
+  background: transparent;
+  color: var(--tmx-text-primary, #222);
+  font: inherit;
+  font-size: 0.9rem;
+  cursor: pointer;
+  text-align: left;
+  transition: background-color 120ms ease, border-color 120ms ease;
+}
+
+.sp-nav-item:hover {
+  background: var(--tmx-bg-elevated, rgba(0, 0, 0, 0.03));
+}
+
+.sp-nav-item:focus-visible {
+  outline: 2px solid var(--tmx-accent-blue, #2d7ff9);
+  outline-offset: 1px;
+}
+
+.sp-nav-item.is-active {
+  background: var(--tmx-panel-blue-bg, #e6f0fe);
+  border-color: var(--tmx-panel-blue-border, #2d7ff9);
+  color: var(--tmx-accent-blue, #2d7ff9);
+  font-weight: 600;
+}
+
+.sp-nav-item i {
+  width: 16px;
+  text-align: center;
+  font-size: 0.85rem;
+}
+
+.sp-content {
+  padding: 8px 12px;
+  min-width: 0;
+}
+
+.sp-placeholder {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: 12px;
+  padding: 48px 24px;
+  color: var(--tmx-text-secondary, #666);
+  text-align: center;
+}
+
+.sp-placeholder i {
+  font-size: 2rem;
+  color: var(--tmx-text-muted, #aaa);
+}
+
+.sp-placeholder p {
+  margin: 0;
+  font-size: 0.95rem;
+}
+
+.sp-placeholder-sub {
+  font-size: 0.8rem !important;
+  color: var(--tmx-text-muted, #aaa);
+  max-width: 420px;
+}
+
+@media (max-width: 900px) {
+  .sp-layout {
+    grid-template-columns: 1fr;
+  }
+  .sp-nav {
+    flex-direction: row;
+    overflow-x: auto;
+    border-right: none;
+    border-bottom: 1px solid var(--tmx-border-primary, #e0e0e0);
+    padding-right: 0;
+    padding-bottom: 8px;
+  }
+  .sp-nav-item {
+    white-space: nowrap;
+  }
+}

--- a/admin-client/src/pages/tournament/tabs/settingsTab/settingsPanel/settingsPanel.css
+++ b/admin-client/src/pages/tournament/tabs/settingsTab/settingsPanel/settingsPanel.css
@@ -521,6 +521,25 @@
   color: var(--tmx-text-muted, #999);
 }
 
+/* ── Print Configuration topic ── */
+
+.sp-print-controls {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  margin-bottom: 12px;
+}
+
+.sp-print-controls .sp-field-input {
+  max-width: 220px;
+}
+
+.sp-print-editor-host {
+  /* The embedded createPrintCompositionEditor brings its own chrome
+     and styles; we just need to give it room. */
+  margin-top: 4px;
+}
+
 @media (max-width: 900px) {
   .sp-layout {
     grid-template-columns: 1fr;

--- a/admin-client/src/pages/tournament/tabs/settingsTab/settingsPanel/settingsPanel.css
+++ b/admin-client/src/pages/tournament/tabs/settingsTab/settingsPanel/settingsPanel.css
@@ -578,6 +578,151 @@
   color: var(--tmx-accent-blue, #2d7ff9);
 }
 
+/* ── Policy cards ── */
+
+.sp-policy-card {
+  border: 1px solid var(--tmx-border-primary, #e0e0e0);
+  border-radius: 6px;
+  padding: 12px;
+  margin-bottom: 12px;
+  background: var(--tmx-bg-elevated, rgba(0, 0, 0, 0.02));
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+}
+
+.sp-policy-card-header {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 12px;
+}
+
+.sp-policy-card-heading {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+  min-width: 0;
+}
+
+.sp-policy-card-title-row {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+
+.sp-policy-card-title {
+  margin: 0;
+  font-size: 0.95rem;
+  font-weight: 600;
+  color: var(--tmx-text-primary, #222);
+}
+
+.sp-policy-status {
+  font-size: 0.7rem;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+  font-weight: 600;
+  color: var(--tmx-text-muted, #999);
+  padding: 2px 6px;
+  border-radius: 8px;
+  border: 1px solid var(--tmx-border-primary, #e0e0e0);
+  background: var(--tmx-bg-secondary, transparent);
+}
+
+.sp-policy-status.is-configured {
+  color: var(--tmx-accent-blue, #2d7ff9);
+  border-color: var(--tmx-accent-blue, #2d7ff9);
+  background: var(--tmx-panel-blue-bg, rgba(45, 127, 249, 0.08));
+}
+
+.sp-policy-card-description {
+  margin: 0;
+  font-size: 0.8rem;
+  color: var(--tmx-text-secondary, #666);
+}
+
+.sp-policy-reset-btn {
+  flex-shrink: 0;
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+  padding: 4px 8px;
+  border: 1px solid var(--tmx-border-primary, #e0e0e0);
+  border-radius: 4px;
+  background: transparent;
+  color: var(--tmx-text-secondary, #666);
+  font: inherit;
+  font-size: 0.75rem;
+  cursor: pointer;
+}
+
+.sp-policy-reset-btn:hover {
+  color: var(--tmx-panel-red-border, #d32f2f);
+  border-color: var(--tmx-panel-red-border, #d32f2f);
+}
+
+.sp-policy-json {
+  border: 1px solid var(--tmx-border-primary, #e0e0e0);
+  border-radius: 4px;
+  background: var(--tmx-bg-primary, #fff);
+}
+
+.sp-policy-json-summary {
+  cursor: pointer;
+  list-style: none;
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  padding: 6px 10px;
+  font-size: 0.8rem;
+  color: var(--tmx-text-secondary, #666);
+  user-select: none;
+}
+
+.sp-policy-json-summary::-webkit-details-marker {
+  display: none;
+}
+
+.sp-policy-json-summary::before {
+  content: '▸';
+  display: inline-block;
+  transition: transform 120ms ease;
+  width: 10px;
+}
+
+.sp-policy-json[open] > .sp-policy-json-summary::before {
+  transform: rotate(90deg);
+}
+
+.sp-policy-json-input {
+  width: 100%;
+  box-sizing: border-box;
+  border: 0;
+  border-top: 1px solid var(--tmx-border-primary, #e0e0e0);
+  background: var(--tmx-bg-primary, #fff);
+  color: var(--tmx-text-primary, #222);
+  font-family: var(--tmx-font-mono, ui-monospace, SFMono-Regular, Menlo, Consolas, monospace);
+  font-size: 0.8rem;
+  line-height: 1.4;
+  padding: 8px 10px;
+  resize: vertical;
+  outline: 0;
+}
+
+.sp-policy-json-input:focus {
+  background: var(--tmx-bg-elevated, #f8f8f8);
+}
+
+.sp-policy-json-error {
+  padding: 6px 10px;
+  border-top: 1px solid var(--tmx-panel-red-border, #d32f2f);
+  background: var(--tmx-panel-red-bg, rgba(211, 47, 47, 0.08));
+  color: var(--tmx-panel-red-border, #d32f2f);
+  font-size: 0.75rem;
+  font-family: var(--tmx-font-mono, ui-monospace, monospace);
+}
+
 @media (max-width: 900px) {
   .sp-layout {
     grid-template-columns: 1fr;

--- a/admin-client/src/pages/tournament/tabs/settingsTab/settingsPanel/settingsPanel.css
+++ b/admin-client/src/pages/tournament/tabs/settingsTab/settingsPanel/settingsPanel.css
@@ -540,6 +540,44 @@
   margin-top: 4px;
 }
 
+/* ── Categories code chip button ── */
+
+.sp-category-code-btn {
+  display: inline-flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 8px;
+  width: 100%;
+  padding: 6px 10px;
+  border: 1px solid var(--tmx-border-primary, #ccc);
+  border-radius: 4px;
+  background: var(--tmx-bg-elevated, #fff);
+  color: var(--tmx-text-secondary, #666);
+  font: inherit;
+  font-size: 0.9rem;
+  cursor: pointer;
+  text-align: left;
+}
+
+.sp-category-code-btn.is-set {
+  color: var(--tmx-text-primary, #222);
+  background: var(--tmx-panel-blue-bg, #e6f0fe);
+  border-color: var(--tmx-panel-blue-border, #2d7ff9);
+}
+
+.sp-category-code-btn:hover {
+  border-color: var(--tmx-accent-blue, #2d7ff9);
+}
+
+.sp-category-code-btn i {
+  font-size: 0.75rem;
+  color: var(--tmx-text-muted, #999);
+}
+
+.sp-category-code-btn.is-set i {
+  color: var(--tmx-accent-blue, #2d7ff9);
+}
+
 @media (max-width: 900px) {
   .sp-layout {
     grid-template-columns: 1fr;

--- a/admin-client/src/pages/tournament/tabs/settingsTab/settingsPanel/settingsPanel.css
+++ b/admin-client/src/pages/tournament/tabs/settingsTab/settingsPanel/settingsPanel.css
@@ -368,6 +368,14 @@
 
 .sp-chip i {
   font-size: 0.7rem;
+  /* Make sure clicks always bubble to the button — Font Awesome's
+     icon glyph can otherwise eat the click target depending on how
+     the consuming app's CSS resets pointer events. */
+  pointer-events: none;
+}
+
+.sp-chip > * {
+  pointer-events: none;
 }
 
 .sp-chip.is-selected {
@@ -419,7 +427,7 @@
 .sp-chip-add-btn {
   border: 0;
   background: transparent;
-  color: var(--tmx-text-secondary, #666);
+  color: var(--tmx-text-muted, #aaa);
   cursor: pointer;
   padding: 2px 6px;
   border-radius: 999px;
@@ -428,6 +436,14 @@
 
 .sp-chip-add-btn:hover {
   color: var(--tmx-accent-blue, #2d7ff9);
+}
+
+.sp-chip-add-btn.is-ready {
+  color: var(--tmx-accent-blue, #2d7ff9);
+}
+
+.sp-chip-add-btn i {
+  pointer-events: none;
 }
 
 /* ── Row editor ── */

--- a/admin-client/src/pages/tournament/tabs/settingsTab/settingsPanel/settingsPanel.css
+++ b/admin-client/src/pages/tournament/tabs/settingsTab/settingsPanel/settingsPanel.css
@@ -678,65 +678,22 @@
   border-color: var(--tmx-panel-red-border, #d32f2f);
 }
 
-.sp-policy-json {
-  border: 1px solid var(--tmx-border-primary, #e0e0e0);
-  border-radius: 4px;
-  background: var(--tmx-bg-primary, #fff);
-}
-
-.sp-policy-json-summary {
-  cursor: pointer;
-  list-style: none;
+.sp-policy-orphan-hint {
   display: flex;
-  align-items: center;
-  gap: 6px;
-  padding: 6px 10px;
-  font-size: 0.8rem;
-  color: var(--tmx-text-secondary, #666);
-  user-select: none;
-}
-
-.sp-policy-json-summary::-webkit-details-marker {
-  display: none;
-}
-
-.sp-policy-json-summary::before {
-  content: '▸';
-  display: inline-block;
-  transition: transform 120ms ease;
-  width: 10px;
-}
-
-.sp-policy-json[open] > .sp-policy-json-summary::before {
-  transform: rotate(90deg);
-}
-
-.sp-policy-json-input {
-  width: 100%;
-  box-sizing: border-box;
-  border: 0;
-  border-top: 1px solid var(--tmx-border-primary, #e0e0e0);
-  background: var(--tmx-bg-primary, #fff);
+  align-items: flex-start;
+  gap: 8px;
+  padding: 8px 10px;
+  border: 1px solid var(--tmx-panel-orange-border, #f59e0b);
+  background: var(--tmx-panel-orange-bg, rgba(245, 158, 11, 0.08));
   color: var(--tmx-text-primary, #222);
-  font-family: var(--tmx-font-mono, ui-monospace, SFMono-Regular, Menlo, Consolas, monospace);
+  border-radius: 4px;
   font-size: 0.8rem;
   line-height: 1.4;
-  padding: 8px 10px;
-  resize: vertical;
-  outline: 0;
 }
 
-.sp-policy-json-input:focus {
-  background: var(--tmx-bg-elevated, #f8f8f8);
-}
-
-.sp-policy-json-error {
-  padding: 6px 10px;
-  border-top: 1px solid var(--tmx-panel-red-border, #d32f2f);
-  background: var(--tmx-panel-red-bg, rgba(211, 47, 47, 0.08));
-  color: var(--tmx-panel-red-border, #d32f2f);
-  font-size: 0.75rem;
-  font-family: var(--tmx-font-mono, ui-monospace, monospace);
+.sp-policy-orphan-hint i {
+  color: var(--tmx-panel-orange-border, #f59e0b);
+  margin-top: 2px;
 }
 
 @media (max-width: 900px) {

--- a/admin-client/src/pages/tournament/tabs/settingsTab/settingsPanel/settingsPanel.css
+++ b/admin-client/src/pages/tournament/tabs/settingsTab/settingsPanel/settingsPanel.css
@@ -324,6 +324,203 @@
   flex: 1;
 }
 
+/* ── Chip multi-select ── */
+
+.sp-field-wide {
+  max-width: none;
+}
+
+.sp-field-label-row {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+
+.sp-chips {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 6px;
+  align-items: center;
+  padding: 8px 0;
+}
+
+.sp-chip {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  padding: 4px 10px;
+  border: 1px solid var(--tmx-border-primary, #ccc);
+  border-radius: 999px;
+  background: var(--tmx-bg-elevated, #fff);
+  color: var(--tmx-text-secondary, #666);
+  font: inherit;
+  font-size: 0.8rem;
+  cursor: pointer;
+  transition:
+    background-color 120ms ease,
+    border-color 120ms ease,
+    color 120ms ease;
+}
+
+.sp-chip:hover {
+  border-color: var(--tmx-accent-blue, #2d7ff9);
+}
+
+.sp-chip i {
+  font-size: 0.7rem;
+}
+
+.sp-chip.is-selected {
+  background: var(--tmx-accent-blue, #2d7ff9);
+  border-color: var(--tmx-accent-blue, #2d7ff9);
+  color: #fff;
+}
+
+.sp-chip.is-selected:hover {
+  filter: brightness(1.05);
+}
+
+.sp-chip.is-orphan {
+  background: var(--tmx-panel-orange-bg, #fff4e0);
+  border-color: var(--tmx-panel-orange-border, #f59e0b);
+  color: var(--tmx-text-primary, #222);
+}
+
+.sp-chip.is-orphan i {
+  color: var(--tmx-panel-orange-border, #f59e0b);
+}
+
+.sp-chips-hint {
+  width: 100%;
+  font-size: 0.75rem;
+  color: var(--tmx-text-muted, #999);
+  margin-top: 4px;
+}
+
+.sp-chip-add {
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+  border: 1px dashed var(--tmx-border-primary, #ccc);
+  border-radius: 999px;
+  padding: 2px 4px 2px 10px;
+}
+
+.sp-chip-add-input {
+  border: 0;
+  outline: 0;
+  background: transparent;
+  font: inherit;
+  font-size: 0.8rem;
+  width: 140px;
+  color: var(--tmx-text-primary, #222);
+}
+
+.sp-chip-add-btn {
+  border: 0;
+  background: transparent;
+  color: var(--tmx-text-secondary, #666);
+  cursor: pointer;
+  padding: 2px 6px;
+  border-radius: 999px;
+  font-size: 0.75rem;
+}
+
+.sp-chip-add-btn:hover {
+  color: var(--tmx-accent-blue, #2d7ff9);
+}
+
+/* ── Row editor ── */
+
+.sp-row-editor {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+.sp-row-table {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+  border: 1px solid var(--tmx-border-primary, #e0e0e0);
+  border-radius: 6px;
+  padding: 8px;
+  background: var(--tmx-bg-elevated, rgba(0, 0, 0, 0.02));
+}
+
+.sp-row-header,
+.sp-row {
+  display: grid;
+  grid-template-columns: 1fr 1fr 36px;
+  gap: 8px;
+  align-items: center;
+}
+
+.sp-row-cell-header {
+  font-size: 0.75rem;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+  font-weight: 600;
+  color: var(--tmx-text-secondary, #555);
+  padding: 0 4px;
+}
+
+.sp-row-cell {
+  min-width: 0;
+}
+
+.sp-row-cell-delete {
+  display: flex;
+  justify-content: center;
+}
+
+.sp-row-del-btn {
+  background: transparent;
+  border: 0;
+  color: var(--tmx-text-muted, #999);
+  cursor: pointer;
+  padding: 6px;
+  border-radius: 4px;
+}
+
+.sp-row-del-btn:hover {
+  color: var(--tmx-panel-red-border, #d32f2f);
+  background: var(--tmx-panel-red-bg, #fff0f0);
+}
+
+.sp-row-empty {
+  padding: 12px;
+  font-size: 0.85rem;
+  color: var(--tmx-text-secondary, #666);
+  text-align: center;
+  font-style: italic;
+}
+
+.sp-row-add-btn {
+  align-self: flex-start;
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  padding: 5px 12px;
+  border: 1px solid var(--tmx-border-primary, #ccc);
+  border-radius: 4px;
+  background: var(--tmx-bg-elevated, #fff);
+  color: var(--tmx-text-primary, #222);
+  font: inherit;
+  font-size: 0.8rem;
+  cursor: pointer;
+}
+
+.sp-row-add-btn:hover {
+  border-color: var(--tmx-accent-blue, #2d7ff9);
+  color: var(--tmx-accent-blue, #2d7ff9);
+}
+
+.sp-row-hint {
+  font-size: 0.75rem;
+  color: var(--tmx-text-muted, #999);
+}
+
 @media (max-width: 900px) {
   .sp-layout {
     grid-template-columns: 1fr;

--- a/admin-client/src/pages/tournament/tabs/settingsTab/settingsPanel/settingsPanel.css
+++ b/admin-client/src/pages/tournament/tabs/settingsTab/settingsPanel/settingsPanel.css
@@ -167,6 +167,163 @@
   color: var(--tmx-text-secondary, #666);
 }
 
+/* ── Panel header (title + dirty dot + save button) ── */
+
+.sp-panel-header {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  margin: 0 0 4px 0;
+}
+
+.sp-panel-header h3 {
+  margin: 0;
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  font-size: 1rem;
+  font-weight: 600;
+}
+
+.sp-dirty-dot {
+  width: 8px;
+  height: 8px;
+  border-radius: 50%;
+  background: var(--tmx-accent-blue, #2d7ff9);
+  display: inline-block;
+}
+
+.sp-save-btn {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  padding: 6px 14px;
+  border: 1px solid var(--tmx-accent-blue, #2d7ff9);
+  border-radius: 4px;
+  background: var(--tmx-accent-blue, #2d7ff9);
+  color: #fff;
+  font: inherit;
+  font-size: 0.85rem;
+  font-weight: 500;
+  cursor: pointer;
+}
+
+.sp-save-btn:disabled {
+  background: var(--tmx-bg-elevated, #f0f0f0);
+  border-color: var(--tmx-border-primary, #ccc);
+  color: var(--tmx-text-muted, #999);
+  cursor: not-allowed;
+}
+
+.sp-save-btn:not(:disabled):hover {
+  filter: brightness(1.05);
+}
+
+/* ── Validation banner ── */
+
+.sp-validation {
+  background: var(--tmx-panel-red-bg, #fff0f0);
+  border: 1px solid var(--tmx-panel-red-border, #d32f2f);
+  color: var(--tmx-text-primary, #222);
+  padding: 10px 12px;
+  border-radius: 6px;
+  margin-bottom: 12px;
+  font-size: 0.85rem;
+}
+
+.sp-validation strong {
+  display: block;
+  margin-bottom: 6px;
+}
+
+.sp-validation ul {
+  list-style: disc;
+  margin: 0;
+  padding-left: 20px;
+}
+
+/* ── Field (label + input) ── */
+
+.sp-field {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+  margin-bottom: 12px;
+  max-width: 320px;
+}
+
+.sp-field-label {
+  font-size: 0.8rem;
+  color: var(--tmx-text-secondary, #555);
+  font-weight: 500;
+}
+
+.sp-field-input {
+  padding: 6px 8px;
+  border: 1px solid var(--tmx-border-primary, #ccc);
+  border-radius: 4px;
+  background: var(--tmx-bg-elevated, #fff);
+  color: var(--tmx-text-primary, #222);
+  font: inherit;
+  font-size: 0.9rem;
+}
+
+.sp-field-input:focus {
+  outline: 2px solid var(--tmx-accent-blue, #2d7ff9);
+  outline-offset: 0;
+  border-color: var(--tmx-accent-blue, #2d7ff9);
+}
+
+/* ── Permissions grid ── */
+
+.sp-perm-group {
+  margin-bottom: 18px;
+}
+
+.sp-perm-group-title {
+  margin: 0 0 8px 0;
+  font-size: 0.8rem;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+  color: var(--tmx-text-secondary, #555);
+}
+
+.sp-perm-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(220px, 1fr));
+  gap: 6px 16px;
+}
+
+.sp-perm-item {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 4px 0;
+  font-size: 0.85rem;
+  cursor: pointer;
+}
+
+.sp-perm-item input[type='checkbox'] {
+  margin: 0;
+  width: 14px;
+  height: 14px;
+}
+
+.sp-perm-item.is-locked {
+  cursor: not-allowed;
+  color: var(--tmx-text-muted, #999);
+}
+
+.sp-perm-item.is-locked .fa-lock {
+  font-size: 0.7rem;
+  color: var(--tmx-text-muted, #999);
+}
+
+.sp-perm-label {
+  flex: 1;
+}
+
 @media (max-width: 900px) {
   .sp-layout {
     grid-template-columns: 1fr;

--- a/admin-client/src/pages/tournament/tabs/settingsTab/settingsPanel/settingsPanel.css
+++ b/admin-client/src/pages/tournament/tabs/settingsTab/settingsPanel/settingsPanel.css
@@ -97,6 +97,76 @@
   max-width: 420px;
 }
 
+.sp-error i {
+  color: var(--tmx-panel-red-border, #d32f2f);
+}
+
+.sp-topic {
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+}
+
+.sp-topic-header {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+  border-bottom: 1px solid var(--tmx-border-primary, #e0e0e0);
+  padding-bottom: 12px;
+}
+
+.sp-topic-header h4 {
+  margin: 0;
+  font-size: 1.05rem;
+  font-weight: 600;
+  color: var(--tmx-text-primary, #222);
+}
+
+.sp-topic-description {
+  margin: 0;
+  font-size: 0.85rem;
+  color: var(--tmx-text-secondary, #666);
+}
+
+.sp-topic-body {
+  font-size: 0.9rem;
+  color: var(--tmx-text-primary, #222);
+}
+
+.sp-summary-list {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+
+.sp-summary-list li {
+  padding: 6px 10px;
+  border-radius: 4px;
+  background: var(--tmx-bg-elevated, rgba(0, 0, 0, 0.02));
+  border: 1px solid var(--tmx-border-primary, #e0e0e0);
+}
+
+.sp-summary-list li code {
+  font-family: var(--tmx-font-mono, ui-monospace, monospace);
+  font-size: 0.8rem;
+  background: var(--tmx-bg-secondary, rgba(0, 0, 0, 0.04));
+  padding: 1px 6px;
+  border-radius: 3px;
+}
+
+.sp-summary-list li code + code {
+  margin-left: 4px;
+}
+
+.sp-summary-empty {
+  margin: 0;
+  font-size: 0.85rem;
+  color: var(--tmx-text-secondary, #666);
+}
+
 @media (max-width: 900px) {
   .sp-layout {
     grid-template-columns: 1fr;

--- a/admin-client/src/pages/tournament/tabs/settingsTab/settingsPanel/topics.ts
+++ b/admin-client/src/pages/tournament/tabs/settingsTab/settingsPanel/topics.ts
@@ -17,6 +17,7 @@ import type {
 } from 'types/providerConfig';
 import {
   createPrintCompositionEditor,
+  getAgeCategoryModal,
   type PrintCompositionConfig,
   type PrintCompositionEditorHandle,
   type PrintType,
@@ -27,7 +28,7 @@ import {
   EVENT_TYPE_OPTIONS,
   GENDER_OPTIONS,
 } from './constants';
-import { chipMultiSelect, rowEditor } from './widgets';
+import { chipMultiSelect } from './widgets';
 
 export type TopicId = 'permissions' | 'allowed' | 'policies' | 'defaults' | 'print' | 'categories';
 
@@ -377,37 +378,145 @@ function configuredFlag(map: Record<string, unknown>, type: string): string {
 function renderCategories(host: HTMLElement, ctx: TopicContext): void {
   const root = topicShell(
     'Categories',
-    'Restrict event categories. Empty list = all caps-allowed categories available. Each row needs an age category code; the name is optional.',
+    'Restrict event categories. Empty list = all caps-allowed categories available. Click the code chip to open the Age Category editor.',
   );
   host.appendChild(root);
   const body = root.querySelector<HTMLElement>('.sp-topic-body')!;
 
   const universe = ctx.caps.policies?.allowedCategories ?? [];
-  const hint = universe.length
-    ? `Provisioner-allowed: ${universe.map((c) => c.ageCategoryCode).join(', ')}`
-    : undefined;
+  const rows: AllowedCategory[] = [...(ctx.draft.policies?.allowedCategories ?? [])];
 
-  body.appendChild(
-    rowEditor<AllowedCategory>({
-      rows: ctx.draft.policies?.allowedCategories ?? [],
-      columns: [
-        { key: 'ageCategoryCode', label: 'Age Category Code', placeholder: 'e.g., U18', required: true },
-        { key: 'categoryName', label: 'Display Name', placeholder: 'e.g., Under 18' },
-      ],
-      isEmpty: (row) => !row.ageCategoryCode?.trim(),
-      emptyRow: () => ({ ageCategoryCode: '', categoryName: '' }),
-      hint,
-      onChange: (next) => {
-        ctx.draft.policies = { ...(ctx.draft.policies ?? {}) };
-        if (next.length) {
-          ctx.draft.policies.allowedCategories = next;
-        } else {
-          delete ctx.draft.policies.allowedCategories;
-        }
-        ctx.onChange();
+  const tableHost = document.createElement('div');
+  tableHost.className = 'sp-row-editor';
+  body.appendChild(tableHost);
+
+  const table = document.createElement('div');
+  table.className = 'sp-row-table';
+  tableHost.appendChild(table);
+
+  const addBtn = document.createElement('button');
+  addBtn.type = 'button';
+  addBtn.className = 'sp-row-add-btn';
+  addBtn.innerHTML = '<i class="fa-solid fa-plus"></i> Add category';
+  addBtn.addEventListener('click', () => {
+    rows.push({ ageCategoryCode: '', categoryName: '' });
+    emit();
+    rebuild();
+    // Auto-launch the editor for the new (empty) row.
+    openCodeEditor(rows.length - 1);
+  });
+  tableHost.appendChild(addBtn);
+
+  if (universe.length) {
+    const hint = document.createElement('div');
+    hint.className = 'sp-row-hint';
+    hint.textContent = `Provisioner-allowed: ${universe.map((c) => c.ageCategoryCode).join(', ')}`;
+    tableHost.appendChild(hint);
+  }
+
+  function emit(): void {
+    const cleaned = rows.filter((r) => r.ageCategoryCode?.trim());
+    ctx.draft.policies = { ...(ctx.draft.policies ?? {}) };
+    if (cleaned.length) {
+      ctx.draft.policies.allowedCategories = cleaned;
+    } else {
+      delete ctx.draft.policies.allowedCategories;
+    }
+    ctx.onChange();
+  }
+
+  function openCodeEditor(idx: number): void {
+    const current = rows[idx];
+    getAgeCategoryModal({
+      existingAgeCategoryCode: current?.ageCategoryCode || undefined,
+      callback: (result: { ageCategoryCode: string; [key: string]: any }) => {
+        if (!result?.ageCategoryCode) return;
+        rows[idx] = {
+          ...rows[idx],
+          ageCategoryCode: result.ageCategoryCode,
+        };
+        emit();
+        rebuild();
       },
-    }),
-  );
+    });
+  }
+
+  function rebuild(): void {
+    table.innerHTML = '';
+
+    const headerRow = document.createElement('div');
+    headerRow.className = 'sp-row-header';
+    const codeHead = document.createElement('div');
+    codeHead.className = 'sp-row-cell-header';
+    codeHead.textContent = 'Age Category Code *';
+    const nameHead = document.createElement('div');
+    nameHead.className = 'sp-row-cell-header';
+    nameHead.textContent = 'Display Name';
+    headerRow.appendChild(codeHead);
+    headerRow.appendChild(nameHead);
+    headerRow.appendChild(document.createElement('div'));
+    table.appendChild(headerRow);
+
+    if (rows.length === 0) {
+      const empty = document.createElement('div');
+      empty.className = 'sp-row-empty';
+      empty.textContent = 'No categories. Click Add category to start.';
+      table.appendChild(empty);
+      return;
+    }
+
+    rows.forEach((row, idx) => {
+      const tr = document.createElement('div');
+      tr.className = 'sp-row';
+
+      // Code column — chip-style button that opens the age-category modal.
+      const codeCell = document.createElement('div');
+      codeCell.className = 'sp-row-cell';
+      const codeBtn = document.createElement('button');
+      codeBtn.type = 'button';
+      codeBtn.className = 'sp-category-code-btn' + (row.ageCategoryCode ? ' is-set' : '');
+      codeBtn.innerHTML = row.ageCategoryCode
+        ? `<span>${escapeHtml(row.ageCategoryCode)}</span><i class="fa-solid fa-pen-to-square"></i>`
+        : '<span><em>Choose code…</em></span><i class="fa-solid fa-arrow-right"></i>';
+      codeBtn.addEventListener('click', () => openCodeEditor(idx));
+      codeCell.appendChild(codeBtn);
+      tr.appendChild(codeCell);
+
+      // Display name — free text.
+      const nameCell = document.createElement('div');
+      nameCell.className = 'sp-row-cell';
+      const nameInput = document.createElement('input');
+      nameInput.type = 'text';
+      nameInput.className = 'sp-field-input';
+      nameInput.placeholder = 'e.g., Under 18';
+      nameInput.value = row.categoryName ?? '';
+      nameInput.addEventListener('input', () => {
+        rows[idx] = { ...rows[idx], categoryName: nameInput.value };
+        emit();
+      });
+      nameCell.appendChild(nameInput);
+      tr.appendChild(nameCell);
+
+      const delCell = document.createElement('div');
+      delCell.className = 'sp-row-cell-delete';
+      const delBtn = document.createElement('button');
+      delBtn.type = 'button';
+      delBtn.className = 'sp-row-del-btn';
+      delBtn.innerHTML = '<i class="fa-solid fa-trash"></i>';
+      delBtn.title = 'Remove category';
+      delBtn.addEventListener('click', () => {
+        rows.splice(idx, 1);
+        emit();
+        rebuild();
+      });
+      delCell.appendChild(delBtn);
+      tr.appendChild(delCell);
+
+      table.appendChild(tr);
+    });
+  }
+
+  rebuild();
 }
 
 // ── Helpers ────────────────────────────────────────────────────────────────

--- a/admin-client/src/pages/tournament/tabs/settingsTab/settingsPanel/topics.ts
+++ b/admin-client/src/pages/tournament/tabs/settingsTab/settingsPanel/topics.ts
@@ -15,6 +15,7 @@ import type {
   ProviderConfigCaps,
   ProviderConfigSettings,
 } from 'types/providerConfig';
+import { BUILTIN_POLICIES } from 'pages/policies/policyBridge';
 import {
   createPrintCompositionEditor,
   getAgeCategoryModal,
@@ -27,10 +28,24 @@ import {
   DRAW_TYPE_OPTIONS,
   EVENT_TYPE_OPTIONS,
   GENDER_OPTIONS,
+  SCORING_APPROACH_OPTIONS,
 } from './constants';
 import { chipMultiSelect } from './widgets';
 
 export type TopicId = 'permissions' | 'allowed' | 'policies' | 'defaults' | 'print' | 'categories';
+
+export interface TopologyEntry {
+  topologyId: string;
+  name: string;
+}
+
+export interface PolicyEntry {
+  catalogId: string;
+  name: string;
+  description?: string | null;
+  data: Record<string, any>;
+  metadata?: { policyType?: string };
+}
 
 export interface TopicContext {
   caps: ProviderConfigCaps;
@@ -41,6 +56,19 @@ export interface TopicContext {
    * draft, so mutations don't touch the original.
    */
   draft: ProviderConfigSettings;
+  /**
+   * Provider-defined topologies. The Allowed Selections "Draw Types"
+   * chip widget mixes their IDs into the universe so a TD can pick a
+   * provider-defined draw structure alongside the factory enum.
+   */
+  topologies: TopologyEntry[];
+  /**
+   * Provider-defined policies from the policy catalog. The Policies
+   * topic uses these as picker options alongside factory builtins so
+   * the admin doesn't paste raw JSON; selecting an item snapshots its
+   * `policyData` into `draft.policies[<key>]`.
+   */
+  policies: PolicyEntry[];
   onChange: () => void;
 }
 
@@ -189,17 +217,24 @@ function setDefault(
 function renderAllowed(host: HTMLElement, ctx: TopicContext): void {
   const root = topicShell(
     'Allowed Selections',
-    'Narrow the provisioner-allowed universe. Click a chip to toggle. Empty list = inherit caps unchanged.',
+    'Narrow the provisioner-allowed universe. Click a chip to toggle. Empty selection = all factory values allowed.',
   );
   host.appendChild(root);
   const body = root.querySelector<HTMLElement>('.sp-topic-body')!;
 
+  // Draw Types universe = factory enum + this provider's saved topologies.
+  // Topology IDs are opaque UUIDs; we pass a `labels` map so the chips
+  // render the human topology names.
+  const topologyIds = ctx.topologies.map((t) => t.topologyId);
+  const drawTypeLabels: Record<string, string> = {};
+  for (const t of ctx.topologies) drawTypeLabels[t.topologyId] = `${t.name} (custom)`;
   body.appendChild(
     chipMultiSelect({
       label: 'Draw Types',
       values: ctx.draft.permissions?.allowedDrawTypes ?? [],
       pinnedUniverse: ctx.caps.permissions?.allowedDrawTypes,
-      placeholder: 'Add draw type…',
+      fullUniverse: [...DRAW_TYPE_OPTIONS, ...topologyIds],
+      labels: drawTypeLabels,
       onChange: (next) => setPermArray(ctx, 'allowedDrawTypes', next),
     }),
   );
@@ -208,7 +243,7 @@ function renderAllowed(host: HTMLElement, ctx: TopicContext): void {
       label: 'Creation Methods',
       values: ctx.draft.permissions?.allowedCreationMethods ?? [],
       pinnedUniverse: ctx.caps.permissions?.allowedCreationMethods,
-      placeholder: 'Add creation method…',
+      fullUniverse: CREATION_METHOD_OPTIONS,
       onChange: (next) => setPermArray(ctx, 'allowedCreationMethods', next),
     }),
   );
@@ -217,16 +252,19 @@ function renderAllowed(host: HTMLElement, ctx: TopicContext): void {
       label: 'Scoring Approaches',
       values: ctx.draft.permissions?.allowedScoringApproaches ?? [],
       pinnedUniverse: ctx.caps.permissions?.allowedScoringApproaches,
-      placeholder: 'Add scoring approach…',
+      fullUniverse: SCORING_APPROACH_OPTIONS,
       onChange: (next) => setPermArray(ctx, 'allowedScoringApproaches', next),
     }),
   );
+  // matchUpFormats use the matchUpFormatCode grammar, not a closed enum.
+  // Free-form text input is the only viable mode here until the factory
+  // matchUpFormatCode editor is wired in. (See matchUpFormatCode skill.)
   body.appendChild(
     chipMultiSelect({
       label: 'MatchUp Formats',
       values: ctx.draft.policies?.allowedMatchUpFormats ?? [],
       pinnedUniverse: ctx.caps.policies?.allowedMatchUpFormats,
-      placeholder: 'Add matchUp format code…',
+      placeholder: 'e.g. SET3-S:6/TB7',
       onChange: (next) => setPolicyArray(ctx, 'allowedMatchUpFormats', next),
     }),
   );
@@ -260,6 +298,8 @@ type PolicyKey = 'schedulingPolicy' | 'scoringPolicy' | 'seedingPolicy';
 
 interface PolicyDescriptor {
   key: PolicyKey;
+  /** courthive-components policy-type tag, used to filter catalog entries. */
+  policyType: string;
   label: string;
   description: string;
 }
@@ -267,17 +307,20 @@ interface PolicyDescriptor {
 const POLICY_DESCRIPTORS: PolicyDescriptor[] = [
   {
     key: 'schedulingPolicy',
+    policyType: 'scheduling',
     label: 'Scheduling',
     description:
       'Average match times, recovery windows between matches, daily match limits per participant.',
   },
   {
     key: 'scoringPolicy',
+    policyType: 'scoring',
     label: 'Scoring',
     description: 'Allowed matchUp formats, default format selection, ready-to-score conditions.',
   },
   {
     key: 'seedingPolicy',
+    policyType: 'seeding',
     label: 'Seeding',
     description: 'Seed positioning patterns and thresholds for the number of seeds per draw size.',
   },
@@ -286,17 +329,30 @@ const POLICY_DESCRIPTORS: PolicyDescriptor[] = [
 function renderPolicies(host: HTMLElement, ctx: TopicContext): void {
   const root = topicShell(
     'Policies',
-    'Static configuration the factory engines consume. Each policy has an editable name and a JSON body — structured forms per policy type land when the schemas are pinned.',
+    'Pick a policy from your catalog or a factory builtin. To add a new policy, head to the Policies page (↞ shield icon).',
   );
   host.appendChild(root);
   const body = root.querySelector<HTMLElement>('.sp-topic-body')!;
 
   for (const desc of POLICY_DESCRIPTORS) {
-    body.appendChild(buildPolicyCard(ctx, desc));
+    body.appendChild(buildPolicyPickerCard(ctx, desc));
   }
 }
 
-function buildPolicyCard(ctx: TopicContext, desc: PolicyDescriptor): HTMLElement {
+interface PolicyOption {
+  /** UI value: stable id for the dropdown. */
+  optionId: string;
+  /** Display label. */
+  label: string;
+  /** Source group for the optgroup. */
+  source: 'user' | 'builtin';
+  /** The policyData payload that gets snapshotted into the draft. */
+  data: Record<string, any>;
+  /** Human policyName to stamp into the saved draft. */
+  name: string;
+}
+
+function buildPolicyPickerCard(ctx: TopicContext, desc: PolicyDescriptor): HTMLElement {
   const card = document.createElement('section');
   card.className = 'sp-policy-card';
 
@@ -324,124 +380,146 @@ function buildPolicyCard(ctx: TopicContext, desc: PolicyDescriptor): HTMLElement
 
   head.appendChild(heading);
 
-  const resetBtn = document.createElement('button');
-  resetBtn.type = 'button';
-  resetBtn.className = 'sp-policy-reset-btn';
-  resetBtn.innerHTML = '<i class="fa-solid fa-rotate-left"></i> Reset';
-  resetBtn.title = 'Remove this policy from the draft';
-  head.appendChild(resetBtn);
+  const clearBtn = document.createElement('button');
+  clearBtn.type = 'button';
+  clearBtn.className = 'sp-policy-reset-btn';
+  clearBtn.innerHTML = '<i class="fa-solid fa-xmark"></i> Clear';
+  clearBtn.title = 'Use factory defaults (no policy override)';
+  head.appendChild(clearBtn);
 
   card.appendChild(head);
 
-  const nameField = document.createElement('label');
-  nameField.className = 'sp-field';
-  const nameLabel = document.createElement('span');
-  nameLabel.className = 'sp-field-label';
-  nameLabel.textContent = 'Policy name';
-  const nameInput = document.createElement('input');
-  nameInput.type = 'text';
-  nameInput.className = 'sp-field-input';
-  nameInput.placeholder = 'Optional human-readable label';
-  nameField.appendChild(nameLabel);
-  nameField.appendChild(nameInput);
-  card.appendChild(nameField);
+  // ── Build the option list (user catalog + builtins of the right type) ─
 
-  // Collapsible JSON editor for the rest of the policy.
-  const jsonWrap = document.createElement('details');
-  jsonWrap.className = 'sp-policy-json';
+  const userOptions: PolicyOption[] = ctx.policies
+    .filter((p) => p.metadata?.policyType === desc.policyType)
+    .map((p) => ({
+      optionId: `user:${p.catalogId}`,
+      label: p.name,
+      source: 'user',
+      data: p.data ?? {},
+      name: p.name,
+    }));
 
-  const summary = document.createElement('summary');
-  summary.className = 'sp-policy-json-summary';
-  summary.innerHTML = '<i class="fa-solid fa-code"></i> Advanced (JSON)';
-  jsonWrap.appendChild(summary);
+  const builtinOptions: PolicyOption[] = BUILTIN_POLICIES.filter(
+    (p) => p.policyType === desc.policyType,
+  ).map((p) => ({
+    optionId: `builtin:${p.id}`,
+    label: p.name,
+    source: 'builtin',
+    data: (p.policyData as Record<string, any>) ?? {},
+    name: p.name,
+  }));
 
-  const ta = document.createElement('textarea');
-  ta.className = 'sp-policy-json-input';
-  ta.rows = 6;
-  ta.spellcheck = false;
-  ta.placeholder = '{\n  "...": "..."\n}';
-  jsonWrap.appendChild(ta);
+  // ── Picker ────────────────────────────────────────────────────────────
 
-  const jsonError = document.createElement('div');
-  jsonError.className = 'sp-policy-json-error';
-  jsonError.style.display = 'none';
-  jsonWrap.appendChild(jsonError);
+  const pickerField = document.createElement('label');
+  pickerField.className = 'sp-field';
+  const pickerLabel = document.createElement('span');
+  pickerLabel.className = 'sp-field-label';
+  pickerLabel.textContent = 'Selection';
+  pickerField.appendChild(pickerLabel);
 
-  card.appendChild(jsonWrap);
+  const select = document.createElement('select');
+  select.className = 'sp-field-input';
+  appendOption(select, '', '— not set (factory defaults) —');
 
-  // ── Wire state ────────────────────────────────────────────────────────
+  if (userOptions.length) {
+    const group = document.createElement('optgroup');
+    group.label = 'Yours';
+    for (const opt of userOptions) appendOptionToParent(group, opt.optionId, opt.label);
+    select.appendChild(group);
+  }
+  if (builtinOptions.length) {
+    const group = document.createElement('optgroup');
+    group.label = 'Builtin';
+    for (const opt of builtinOptions) appendOptionToParent(group, opt.optionId, opt.label);
+    select.appendChild(group);
+  }
 
-  const refresh = () => {
-    const policy = (ctx.draft.policies?.[desc.key] ?? undefined) as Record<string, any> | undefined;
-    const isSet = policy && Object.keys(policy).length > 0;
+  pickerField.appendChild(select);
+  card.appendChild(pickerField);
+
+  // Hint shown when the current draft policy doesn't match any catalog
+  // option (e.g. legacy inline JSON paste, or the catalog item it was
+  // sourced from has been deleted/renamed).
+  const orphanHint = document.createElement('div');
+  orphanHint.className = 'sp-policy-orphan-hint';
+  orphanHint.style.display = 'none';
+  card.appendChild(orphanHint);
+
+  // ── State sync ─────────────────────────────────────────────────────────
+
+  function findMatchingOption(): PolicyOption | null {
+    const policy = ctx.draft.policies?.[desc.key] as Record<string, any> | undefined;
+    if (!policy) return null;
+    const policyName = policy.policyName as string | undefined;
+    const all = [...userOptions, ...builtinOptions];
+    // Match by name first (the data is snapshotted in, so structural equality
+    // would also work but is heavier; name is good enough for picker UX).
+    if (policyName) {
+      const named = all.find((o) => o.name === policyName);
+      if (named) return named;
+    }
+    return null;
+  }
+
+  function refresh(): void {
+    const policy = ctx.draft.policies?.[desc.key] as Record<string, any> | undefined;
+    const isSet = !!policy && Object.keys(policy).length > 0;
     status.textContent = isSet ? 'configured' : 'using defaults';
-    status.classList.toggle('is-configured', !!isSet);
+    status.classList.toggle('is-configured', isSet);
 
-    nameInput.value = (policy?.policyName as string) ?? '';
+    const matched = findMatchingOption();
+    select.value = matched?.optionId ?? '';
 
-    // Body view excludes policyName so the JSON editor only shows the rest.
-    const { policyName: _omit, ...rest } = (policy ?? {}) as Record<string, any>;
-    void _omit;
-    ta.value = Object.keys(rest).length ? JSON.stringify(rest, null, 2) : '';
-    jsonError.style.display = 'none';
-  };
+    if (isSet && !matched) {
+      const policyName = (policy?.policyName as string) ?? '(unnamed)';
+      orphanHint.style.display = '';
+      orphanHint.innerHTML =
+        `<i class="fa-solid fa-circle-info"></i> Active policy "${escapeHtml(policyName)}" isn't in your catalog. ` +
+        `Pick a catalog entry to replace it, or click Clear to remove.`;
+    } else {
+      orphanHint.style.display = 'none';
+    }
+  }
 
-  const writePolicy = (next: Record<string, any> | undefined) => {
+  function pick(optionId: string): void {
+    const all = [...userOptions, ...builtinOptions];
+    const opt = all.find((o) => o.optionId === optionId);
     ctx.draft.policies = { ...(ctx.draft.policies ?? {}) };
-    if (next && Object.keys(next).length > 0) {
-      (ctx.draft.policies as any)[desc.key] = next;
+    if (opt) {
+      // Snapshot the catalog item's data inline so the merge function /
+      // factory engine can consume it without dereferencing. policyName
+      // becomes the catalog item's display name so we can match again
+      // on next load.
+      (ctx.draft.policies as any)[desc.key] = { policyName: opt.name, ...opt.data };
     } else {
       delete (ctx.draft.policies as any)[desc.key];
     }
     ctx.onChange();
     refresh();
-  };
-
-  nameInput.addEventListener('input', () => {
-    const current = ((ctx.draft.policies?.[desc.key] ?? {}) as Record<string, any>) || {};
-    const next = { ...current };
-    if (nameInput.value.trim()) {
-      next.policyName = nameInput.value;
-    } else {
-      delete next.policyName;
-    }
-    writePolicy(next);
-  });
-
-  ta.addEventListener('input', () => {
-    const raw = ta.value.trim();
-    if (raw === '') {
-      // Clear the body but preserve policyName if set.
-      const current = ((ctx.draft.policies?.[desc.key] ?? {}) as Record<string, any>) || {};
-      const policyName = current.policyName;
-      writePolicy(policyName ? { policyName } : undefined);
-      return;
-    }
-    try {
-      const parsed = JSON.parse(raw);
-      if (typeof parsed !== 'object' || parsed === null || Array.isArray(parsed)) {
-        showJsonError('Policy body must be a JSON object.');
-        return;
-      }
-      jsonError.style.display = 'none';
-      const current = ((ctx.draft.policies?.[desc.key] ?? {}) as Record<string, any>) || {};
-      const policyName = current.policyName;
-      const next = policyName ? { policyName, ...parsed } : { ...parsed };
-      writePolicy(next);
-    } catch (err) {
-      showJsonError(err instanceof Error ? err.message : 'Invalid JSON.');
-    }
-  });
-
-  resetBtn.addEventListener('click', () => writePolicy(undefined));
-
-  function showJsonError(message: string): void {
-    jsonError.textContent = message;
-    jsonError.style.display = '';
   }
+
+  select.addEventListener('change', () => pick(select.value));
+  clearBtn.addEventListener('click', () => pick(''));
 
   refresh();
   return card;
+}
+
+function appendOption(select: HTMLSelectElement, value: string, label: string): void {
+  const o = document.createElement('option');
+  o.value = value;
+  o.textContent = label;
+  select.appendChild(o);
+}
+
+function appendOptionToParent(parent: HTMLOptGroupElement, value: string, label: string): void {
+  const o = document.createElement('option');
+  o.value = value;
+  o.textContent = label;
+  parent.appendChild(o);
 }
 
 const PRINT_TYPES: PrintType[] = ['draw', 'schedule', 'playerList', 'courtCard', 'signInSheet', 'matchCard'];

--- a/admin-client/src/pages/tournament/tabs/settingsTab/settingsPanel/topics.ts
+++ b/admin-client/src/pages/tournament/tabs/settingsTab/settingsPanel/topics.ts
@@ -256,23 +256,192 @@ function setPolicyArray(ctx: TopicContext, key: 'allowedMatchUpFormats', next: s
   ctx.onChange();
 }
 
+type PolicyKey = 'schedulingPolicy' | 'scoringPolicy' | 'seedingPolicy';
+
+interface PolicyDescriptor {
+  key: PolicyKey;
+  label: string;
+  description: string;
+}
+
+const POLICY_DESCRIPTORS: PolicyDescriptor[] = [
+  {
+    key: 'schedulingPolicy',
+    label: 'Scheduling',
+    description:
+      'Average match times, recovery windows between matches, daily match limits per participant.',
+  },
+  {
+    key: 'scoringPolicy',
+    label: 'Scoring',
+    description: 'Allowed matchUp formats, default format selection, ready-to-score conditions.',
+  },
+  {
+    key: 'seedingPolicy',
+    label: 'Seeding',
+    description: 'Seed positioning patterns and thresholds for the number of seeds per draw size.',
+  },
+];
+
 function renderPolicies(host: HTMLElement, ctx: TopicContext): void {
-  const pol = ctx.draft.policies ?? {};
-  const has = (v: any) => v !== undefined && v !== null && Object.keys(v ?? {}).length > 0;
-  const rows = [
-    { label: 'Scheduling Policy', set: has(pol.schedulingPolicy) },
-    { label: 'Scoring Policy', set: has(pol.scoringPolicy) },
-    { label: 'Seeding Policy', set: has(pol.seedingPolicy) },
-  ];
   const root = topicShell(
     'Policies',
-    'Static configuration the factory engines consume. Structured editors land in Phase 3d.',
+    'Static configuration the factory engines consume. Each policy has an editable name and a JSON body — structured forms per policy type land when the schemas are pinned.',
   );
-  const body = root.querySelector<HTMLElement>('.sp-topic-body')!;
-  body.innerHTML = `<ul class="sp-summary-list">${rows
-    .map((r) => `<li><strong>${r.label}:</strong> ${r.set ? 'configured' : '<em>using defaults</em>'}</li>`)
-    .join('')}</ul>`;
   host.appendChild(root);
+  const body = root.querySelector<HTMLElement>('.sp-topic-body')!;
+
+  for (const desc of POLICY_DESCRIPTORS) {
+    body.appendChild(buildPolicyCard(ctx, desc));
+  }
+}
+
+function buildPolicyCard(ctx: TopicContext, desc: PolicyDescriptor): HTMLElement {
+  const card = document.createElement('section');
+  card.className = 'sp-policy-card';
+
+  const head = document.createElement('header');
+  head.className = 'sp-policy-card-header';
+
+  const heading = document.createElement('div');
+  heading.className = 'sp-policy-card-heading';
+
+  const titleRow = document.createElement('div');
+  titleRow.className = 'sp-policy-card-title-row';
+  const title = document.createElement('h5');
+  title.className = 'sp-policy-card-title';
+  title.textContent = desc.label;
+  const status = document.createElement('span');
+  status.className = 'sp-policy-status';
+  titleRow.appendChild(title);
+  titleRow.appendChild(status);
+  heading.appendChild(titleRow);
+
+  const description = document.createElement('p');
+  description.className = 'sp-policy-card-description';
+  description.textContent = desc.description;
+  heading.appendChild(description);
+
+  head.appendChild(heading);
+
+  const resetBtn = document.createElement('button');
+  resetBtn.type = 'button';
+  resetBtn.className = 'sp-policy-reset-btn';
+  resetBtn.innerHTML = '<i class="fa-solid fa-rotate-left"></i> Reset';
+  resetBtn.title = 'Remove this policy from the draft';
+  head.appendChild(resetBtn);
+
+  card.appendChild(head);
+
+  const nameField = document.createElement('label');
+  nameField.className = 'sp-field';
+  const nameLabel = document.createElement('span');
+  nameLabel.className = 'sp-field-label';
+  nameLabel.textContent = 'Policy name';
+  const nameInput = document.createElement('input');
+  nameInput.type = 'text';
+  nameInput.className = 'sp-field-input';
+  nameInput.placeholder = 'Optional human-readable label';
+  nameField.appendChild(nameLabel);
+  nameField.appendChild(nameInput);
+  card.appendChild(nameField);
+
+  // Collapsible JSON editor for the rest of the policy.
+  const jsonWrap = document.createElement('details');
+  jsonWrap.className = 'sp-policy-json';
+
+  const summary = document.createElement('summary');
+  summary.className = 'sp-policy-json-summary';
+  summary.innerHTML = '<i class="fa-solid fa-code"></i> Advanced (JSON)';
+  jsonWrap.appendChild(summary);
+
+  const ta = document.createElement('textarea');
+  ta.className = 'sp-policy-json-input';
+  ta.rows = 6;
+  ta.spellcheck = false;
+  ta.placeholder = '{\n  "...": "..."\n}';
+  jsonWrap.appendChild(ta);
+
+  const jsonError = document.createElement('div');
+  jsonError.className = 'sp-policy-json-error';
+  jsonError.style.display = 'none';
+  jsonWrap.appendChild(jsonError);
+
+  card.appendChild(jsonWrap);
+
+  // ── Wire state ────────────────────────────────────────────────────────
+
+  const refresh = () => {
+    const policy = (ctx.draft.policies?.[desc.key] ?? undefined) as Record<string, any> | undefined;
+    const isSet = policy && Object.keys(policy).length > 0;
+    status.textContent = isSet ? 'configured' : 'using defaults';
+    status.classList.toggle('is-configured', !!isSet);
+
+    nameInput.value = (policy?.policyName as string) ?? '';
+
+    // Body view excludes policyName so the JSON editor only shows the rest.
+    const { policyName: _omit, ...rest } = (policy ?? {}) as Record<string, any>;
+    void _omit;
+    ta.value = Object.keys(rest).length ? JSON.stringify(rest, null, 2) : '';
+    jsonError.style.display = 'none';
+  };
+
+  const writePolicy = (next: Record<string, any> | undefined) => {
+    ctx.draft.policies = { ...(ctx.draft.policies ?? {}) };
+    if (next && Object.keys(next).length > 0) {
+      (ctx.draft.policies as any)[desc.key] = next;
+    } else {
+      delete (ctx.draft.policies as any)[desc.key];
+    }
+    ctx.onChange();
+    refresh();
+  };
+
+  nameInput.addEventListener('input', () => {
+    const current = ((ctx.draft.policies?.[desc.key] ?? {}) as Record<string, any>) || {};
+    const next = { ...current };
+    if (nameInput.value.trim()) {
+      next.policyName = nameInput.value;
+    } else {
+      delete next.policyName;
+    }
+    writePolicy(next);
+  });
+
+  ta.addEventListener('input', () => {
+    const raw = ta.value.trim();
+    if (raw === '') {
+      // Clear the body but preserve policyName if set.
+      const current = ((ctx.draft.policies?.[desc.key] ?? {}) as Record<string, any>) || {};
+      const policyName = current.policyName;
+      writePolicy(policyName ? { policyName } : undefined);
+      return;
+    }
+    try {
+      const parsed = JSON.parse(raw);
+      if (typeof parsed !== 'object' || parsed === null || Array.isArray(parsed)) {
+        showJsonError('Policy body must be a JSON object.');
+        return;
+      }
+      jsonError.style.display = 'none';
+      const current = ((ctx.draft.policies?.[desc.key] ?? {}) as Record<string, any>) || {};
+      const policyName = current.policyName;
+      const next = policyName ? { policyName, ...parsed } : { ...parsed };
+      writePolicy(next);
+    } catch (err) {
+      showJsonError(err instanceof Error ? err.message : 'Invalid JSON.');
+    }
+  });
+
+  resetBtn.addEventListener('click', () => writePolicy(undefined));
+
+  function showJsonError(message: string): void {
+    jsonError.textContent = message;
+    jsonError.style.display = '';
+  }
+
+  refresh();
+  return card;
 }
 
 const PRINT_TYPES: PrintType[] = ['draw', 'schedule', 'playerList', 'courtCard', 'signInSheet', 'matchCard'];

--- a/admin-client/src/pages/tournament/tabs/settingsTab/settingsPanel/topics.ts
+++ b/admin-client/src/pages/tournament/tabs/settingsTab/settingsPanel/topics.ts
@@ -10,13 +10,18 @@
  * See `Mentat/planning/ADMIN_SETTINGS_PAGE_REDESIGN.md`.
  */
 import { PERMISSION_GROUPS } from 'types/providerConfig';
-import type { ProviderConfigCaps, ProviderConfigSettings, ProviderPermissions } from 'types/providerConfig';
+import type {
+  AllowedCategory,
+  ProviderConfigCaps,
+  ProviderConfigSettings,
+} from 'types/providerConfig';
 import {
   CREATION_METHOD_OPTIONS,
   DRAW_TYPE_OPTIONS,
   EVENT_TYPE_OPTIONS,
   GENDER_OPTIONS,
 } from './constants';
+import { chipMultiSelect, rowEditor } from './widgets';
 
 export type TopicId = 'permissions' | 'allowed' | 'policies' | 'defaults' | 'print' | 'categories';
 
@@ -175,26 +180,73 @@ function setDefault(
 // ── Other topics (Phase 2 read-only summaries; editors land in 3b–d) ──────
 
 function renderAllowed(host: HTMLElement, ctx: TopicContext): void {
-  const perm: ProviderPermissions = ctx.draft.permissions ?? {};
-  const pol = ctx.draft.policies ?? {};
-  const rows: string[] = [];
-  const add = (label: string, list: string[] | undefined) => {
-    if (!list || !list.length) return;
-    rows.push(`<li><strong>${label}:</strong> ${list.map((v) => `<code>${escapeHtml(v)}</code>`).join(' ')}</li>`);
-  };
-  add('Draw Types', perm.allowedDrawTypes);
-  add('Creation Methods', perm.allowedCreationMethods);
-  add('Scoring Approaches', perm.allowedScoringApproaches);
-  add('MatchUp Formats', pol.allowedMatchUpFormats);
   const root = topicShell(
     'Allowed Selections',
-    'Narrowing within the provisioner-allowed universe. Multi-select chip editor lands in Phase 3b.',
+    'Narrow the provisioner-allowed universe. Click a chip to toggle. Empty list = inherit caps unchanged.',
   );
-  const body = root.querySelector<HTMLElement>('.sp-topic-body')!;
-  body.innerHTML = rows.length
-    ? `<ul class="sp-summary-list">${rows.join('')}</ul>`
-    : '<p class="sp-summary-empty"><em>No narrowing applied — inheriting all caps.</em></p>';
   host.appendChild(root);
+  const body = root.querySelector<HTMLElement>('.sp-topic-body')!;
+
+  body.appendChild(
+    chipMultiSelect({
+      label: 'Draw Types',
+      values: ctx.draft.permissions?.allowedDrawTypes ?? [],
+      pinnedUniverse: ctx.caps.permissions?.allowedDrawTypes,
+      placeholder: 'Add draw type…',
+      onChange: (next) => setPermArray(ctx, 'allowedDrawTypes', next),
+    }),
+  );
+  body.appendChild(
+    chipMultiSelect({
+      label: 'Creation Methods',
+      values: ctx.draft.permissions?.allowedCreationMethods ?? [],
+      pinnedUniverse: ctx.caps.permissions?.allowedCreationMethods,
+      placeholder: 'Add creation method…',
+      onChange: (next) => setPermArray(ctx, 'allowedCreationMethods', next),
+    }),
+  );
+  body.appendChild(
+    chipMultiSelect({
+      label: 'Scoring Approaches',
+      values: ctx.draft.permissions?.allowedScoringApproaches ?? [],
+      pinnedUniverse: ctx.caps.permissions?.allowedScoringApproaches,
+      placeholder: 'Add scoring approach…',
+      onChange: (next) => setPermArray(ctx, 'allowedScoringApproaches', next),
+    }),
+  );
+  body.appendChild(
+    chipMultiSelect({
+      label: 'MatchUp Formats',
+      values: ctx.draft.policies?.allowedMatchUpFormats ?? [],
+      pinnedUniverse: ctx.caps.policies?.allowedMatchUpFormats,
+      placeholder: 'Add matchUp format code…',
+      onChange: (next) => setPolicyArray(ctx, 'allowedMatchUpFormats', next),
+    }),
+  );
+}
+
+function setPermArray(
+  ctx: TopicContext,
+  key: 'allowedDrawTypes' | 'allowedCreationMethods' | 'allowedScoringApproaches',
+  next: string[],
+): void {
+  ctx.draft.permissions = { ...(ctx.draft.permissions ?? {}) };
+  if (next.length) {
+    ctx.draft.permissions[key] = next;
+  } else {
+    delete ctx.draft.permissions[key];
+  }
+  ctx.onChange();
+}
+
+function setPolicyArray(ctx: TopicContext, key: 'allowedMatchUpFormats', next: string[]): void {
+  ctx.draft.policies = { ...(ctx.draft.policies ?? {}) };
+  if (next.length) {
+    ctx.draft.policies[key] = next;
+  } else {
+    delete ctx.draft.policies[key];
+  }
+  ctx.onChange();
 }
 
 function renderPolicies(host: HTMLElement, ctx: TopicContext): void {
@@ -236,22 +288,39 @@ function renderPrint(host: HTMLElement, ctx: TopicContext): void {
 }
 
 function renderCategories(host: HTMLElement, ctx: TopicContext): void {
-  const cats = ctx.draft.policies?.allowedCategories ?? [];
-  const rows = cats.length
-    ? cats
-        .map(
-          (c) =>
-            `<li><code>${escapeHtml(c.ageCategoryCode)}</code>${c.categoryName ? ` — ${escapeHtml(c.categoryName)}` : ''}</li>`,
-        )
-        .join('')
-    : '<li><em>No categories restricted — all caps-allowed categories available.</em></li>';
   const root = topicShell(
     'Categories',
-    'Restrict event categories to this list. Row editor lands in Phase 3b.',
+    'Restrict event categories. Empty list = all caps-allowed categories available. Each row needs an age category code; the name is optional.',
   );
-  const body = root.querySelector<HTMLElement>('.sp-topic-body')!;
-  body.innerHTML = `<ul class="sp-summary-list">${rows}</ul>`;
   host.appendChild(root);
+  const body = root.querySelector<HTMLElement>('.sp-topic-body')!;
+
+  const universe = ctx.caps.policies?.allowedCategories ?? [];
+  const hint = universe.length
+    ? `Provisioner-allowed: ${universe.map((c) => c.ageCategoryCode).join(', ')}`
+    : undefined;
+
+  body.appendChild(
+    rowEditor<AllowedCategory>({
+      rows: ctx.draft.policies?.allowedCategories ?? [],
+      columns: [
+        { key: 'ageCategoryCode', label: 'Age Category Code', placeholder: 'e.g., U18', required: true },
+        { key: 'categoryName', label: 'Display Name', placeholder: 'e.g., Under 18' },
+      ],
+      isEmpty: (row) => !row.ageCategoryCode?.trim(),
+      emptyRow: () => ({ ageCategoryCode: '', categoryName: '' }),
+      hint,
+      onChange: (next) => {
+        ctx.draft.policies = { ...(ctx.draft.policies ?? {}) };
+        if (next.length) {
+          ctx.draft.policies.allowedCategories = next;
+        } else {
+          delete ctx.draft.policies.allowedCategories;
+        }
+        ctx.onChange();
+      },
+    }),
+  );
 }
 
 // ── Helpers ────────────────────────────────────────────────────────────────

--- a/admin-client/src/pages/tournament/tabs/settingsTab/settingsPanel/topics.ts
+++ b/admin-client/src/pages/tournament/tabs/settingsTab/settingsPanel/topics.ts
@@ -16,6 +16,12 @@ import type {
   ProviderConfigSettings,
 } from 'types/providerConfig';
 import {
+  createPrintCompositionEditor,
+  type PrintCompositionConfig,
+  type PrintCompositionEditorHandle,
+  type PrintType,
+} from 'courthive-components';
+import {
   CREATION_METHOD_OPTIONS,
   DRAW_TYPE_OPTIONS,
   EVENT_TYPE_OPTIONS,
@@ -268,23 +274,104 @@ function renderPolicies(host: HTMLElement, ctx: TopicContext): void {
   host.appendChild(root);
 }
 
+const PRINT_TYPES: PrintType[] = ['draw', 'schedule', 'playerList', 'courtCard', 'signInSheet', 'matchCard'];
+
 function renderPrint(host: HTMLElement, ctx: TopicContext): void {
-  const printPolicies = (ctx.draft.policies as any)?.printPolicies ?? {};
-  const types = ['draw', 'schedule', 'playerList', 'courtCard', 'signInSheet', 'matchCard'];
-  const rows = types
-    .map((type) => {
-      const cfg = printPolicies[type];
-      const configured = cfg && typeof cfg === 'object' && Object.keys(cfg).length > 0;
-      return `<li>${configured ? '●' : '○'} <code>${type}</code> ${configured ? '' : '<em>(uses pdf-factory defaults)</em>'}</li>`;
-    })
-    .join('');
   const root = topicShell(
     'Print Configuration',
-    'Per-print-type composition policies. The composition editor embeds here in Phase 3c.',
+    "Per-print-type composition policies. ●/○ markers in the picker show which types have a saved policy. Reset clears the active type's policy and falls back to pdf-factory defaults.",
   );
-  const body = root.querySelector<HTMLElement>('.sp-topic-body')!;
-  body.innerHTML = `<ul class="sp-summary-list">${rows}</ul>`;
   host.appendChild(root);
+  const body = root.querySelector<HTMLElement>('.sp-topic-body')!;
+
+  const printPolicies = ((ctx.draft.policies as any)?.printPolicies ?? {}) as Record<string, unknown>;
+
+  // Type picker + reset
+  const controls = document.createElement('div');
+  controls.className = 'sp-print-controls';
+
+  const picker = document.createElement('select');
+  picker.className = 'sp-field-input';
+  picker.setAttribute('aria-label', 'Print type');
+  for (const type of PRINT_TYPES) {
+    const o = document.createElement('option');
+    o.value = type;
+    o.textContent = configuredFlag(printPolicies, type) + type;
+    picker.appendChild(o);
+  }
+  controls.appendChild(picker);
+
+  const resetBtn = document.createElement('button');
+  resetBtn.type = 'button';
+  resetBtn.className = 'sp-row-add-btn';
+  resetBtn.innerHTML = '<i class="fa-solid fa-rotate-left"></i> Reset to defaults';
+  resetBtn.title = "Remove this provider's policy for the selected print type";
+  controls.appendChild(resetBtn);
+
+  body.appendChild(controls);
+
+  const editorHost = document.createElement('div');
+  editorHost.className = 'sp-print-editor-host';
+  body.appendChild(editorHost);
+
+  let active: PrintType = PRINT_TYPES[0];
+  let handle: PrintCompositionEditorHandle | null = null;
+
+  function refreshPicker(): void {
+    for (let i = 0; i < picker.options.length; i++) {
+      const opt = picker.options[i];
+      const t = opt.value as PrintType;
+      opt.textContent = configuredFlag(printPolicies, t) + t;
+    }
+  }
+
+  function writePolicy(type: PrintType, cfg: PrintCompositionConfig): void {
+    ctx.draft.policies = { ...(ctx.draft.policies ?? {}) };
+    const existing = ((ctx.draft.policies as any).printPolicies ?? {}) as Record<string, unknown>;
+    const next = { ...existing };
+    if (cfg && Object.keys(cfg).length > 0) {
+      next[type] = cfg;
+    } else {
+      delete next[type];
+    }
+    if (Object.keys(next).length > 0) {
+      (ctx.draft.policies as any).printPolicies = next;
+    } else {
+      delete (ctx.draft.policies as any).printPolicies;
+    }
+    // Keep the local snapshot in lockstep so picker markers reflect edits.
+    Object.keys(printPolicies).forEach((k) => delete printPolicies[k]);
+    Object.assign(printPolicies, next);
+    ctx.onChange();
+    refreshPicker();
+  }
+
+  function mount(type: PrintType): void {
+    handle?.destroy();
+    const existing = (printPolicies[type] ?? {}) as PrintCompositionConfig;
+    handle = createPrintCompositionEditor(editorHost, {
+      printType: type,
+      config: existing,
+      onChange: (cfg) => writePolicy(type, cfg),
+    });
+  }
+
+  picker.addEventListener('change', () => {
+    active = picker.value as PrintType;
+    mount(active);
+  });
+
+  resetBtn.addEventListener('click', () => {
+    writePolicy(active, {} as PrintCompositionConfig);
+    mount(active);
+  });
+
+  mount(active);
+}
+
+function configuredFlag(map: Record<string, unknown>, type: string): string {
+  const cfg = map[type];
+  return cfg && typeof cfg === 'object' && Object.keys(cfg as object).length > 0 ? '● ' : '○ ';
 }
 
 function renderCategories(host: HTMLElement, ctx: TopicContext): void {

--- a/admin-client/src/pages/tournament/tabs/settingsTab/settingsPanel/topics.ts
+++ b/admin-client/src/pages/tournament/tabs/settingsTab/settingsPanel/topics.ts
@@ -3,24 +3,39 @@
  * `providerConfigSettings` and renders into the right-hand content
  * column when the user picks it from the nav.
  *
- * Phase 2 ships read-only summaries per topic so the wiring (fetch →
- * state → render per-topic) is exercised end-to-end. Phase 3 swaps
- * each topic's `render` for an actual editor.
+ * Phase 3a: Defaults + Permissions are real editors that mutate the
+ *   shared `draft` and call `onChange`. Other topics still render
+ *   read-only summaries until Phase 3b–d.
+ *
+ * See `Mentat/planning/ADMIN_SETTINGS_PAGE_REDESIGN.md`.
  */
-import type { ProviderConfigCaps, ProviderConfigSettings } from 'types/providerConfig';
+import { PERMISSION_GROUPS } from 'types/providerConfig';
+import type { ProviderConfigCaps, ProviderConfigSettings, ProviderPermissions } from 'types/providerConfig';
+import {
+  CREATION_METHOD_OPTIONS,
+  DRAW_TYPE_OPTIONS,
+  EVENT_TYPE_OPTIONS,
+  GENDER_OPTIONS,
+} from './constants';
 
 export type TopicId = 'permissions' | 'allowed' | 'policies' | 'defaults' | 'print' | 'categories';
 
 export interface TopicContext {
   caps: ProviderConfigCaps;
-  settings: ProviderConfigSettings;
+  /**
+   * The mutable working draft. Topics mutate this directly and call
+   * `onChange()` so the panel can recompute dirty state and refresh
+   * the Save button. The panel deep-clones loaded settings into this
+   * draft, so mutations don't touch the original.
+   */
+  draft: ProviderConfigSettings;
+  onChange: () => void;
 }
 
 export interface TopicDescriptor {
   id: TopicId;
   label: string;
   icon: string;
-  /** Render the topic content into the supplied host element. */
   render: (host: HTMLElement, ctx: TopicContext) => void;
 }
 
@@ -33,133 +48,282 @@ export const TOPICS: TopicDescriptor[] = [
   { id: 'categories', label: 'Categories', icon: 'fa-layer-group', render: renderCategories },
 ];
 
-// ── Topic renderers (Phase 2: read-only summaries) ─────────────────────────
+// ── Permissions (real editor) ──────────────────────────────────────────────
 
 function renderPermissions(host: HTMLElement, ctx: TopicContext): void {
-  const set = ctx.settings.permissions ?? {};
-  const setKeys = Object.keys(set).filter((k) => typeof (set as any)[k] === 'boolean');
-  const summary = setKeys.length
-    ? setKeys.map((k) => `<li><code>${k}</code>: <strong>${(set as any)[k] ? 'allowed' : 'denied'}</strong></li>`).join('')
-    : '<li><em>No explicit permission overrides — defaults apply.</em></li>';
-  host.appendChild(
-    topicShell(
-      'Permissions',
-      'Booleans the provider has set for tournament directors. Empty = the provisioner cap is the only restriction.',
-      `<ul class="sp-summary-list">${summary}</ul>`,
-    ),
+  const root = topicShell(
+    'Permissions',
+    'Allow or deny capabilities for tournament directors. Caps locked by the provisioner are shown but cannot be enabled.',
+  );
+  host.appendChild(root);
+  const body = root.querySelector<HTMLElement>('.sp-topic-body')!;
+
+  for (const group of PERMISSION_GROUPS) {
+    const block = document.createElement('div');
+    block.className = 'sp-perm-group';
+
+    const heading = document.createElement('h5');
+    heading.className = 'sp-perm-group-title';
+    heading.textContent = group.label;
+    block.appendChild(heading);
+
+    const grid = document.createElement('div');
+    grid.className = 'sp-perm-grid';
+
+    for (const key of group.keys) {
+      const capForbids = (ctx.caps.permissions as any)?.[key] === false;
+      const settingsBlock = ctx.draft.permissions ?? {};
+      const current = (settingsBlock as any)[key];
+      // Render-time effective value: cap-forbidden is always false; otherwise
+      // honor the explicit setting; otherwise default to true (permissive).
+      const checked = capForbids ? false : current === undefined ? true : !!current;
+
+      const label = document.createElement('label');
+      label.className = 'sp-perm-item' + (capForbids ? ' is-locked' : '');
+      label.title = capForbids ? 'Locked by provisioner' : '';
+
+      const input = document.createElement('input');
+      input.type = 'checkbox';
+      input.checked = checked;
+      input.disabled = capForbids;
+      input.addEventListener('change', () => {
+        if (capForbids) return;
+        ctx.draft.permissions = { ...(ctx.draft.permissions ?? {}) };
+        (ctx.draft.permissions as any)[key] = input.checked;
+        ctx.onChange();
+      });
+
+      const text = document.createElement('span');
+      text.className = 'sp-perm-label';
+      text.textContent = humanize(String(key));
+
+      const lockIcon = document.createElement('i');
+      if (capForbids) {
+        lockIcon.className = 'fa-solid fa-lock';
+        lockIcon.setAttribute('aria-hidden', 'true');
+      }
+
+      label.appendChild(input);
+      label.appendChild(text);
+      if (capForbids) label.appendChild(lockIcon);
+      grid.appendChild(label);
+    }
+
+    block.appendChild(grid);
+    body.appendChild(block);
+  }
+}
+
+// ── Defaults (real editor) ─────────────────────────────────────────────────
+
+function renderDefaults(host: HTMLElement, ctx: TopicContext): void {
+  const root = topicShell(
+    'Defaults',
+    'Pre-fill values for new tournament/event/draw creation flows. Empty = no default.',
+  );
+  host.appendChild(root);
+  const body = root.querySelector<HTMLElement>('.sp-topic-body')!;
+
+  body.appendChild(
+    selectField({
+      label: 'Default Event Type',
+      value: ctx.draft.defaults?.defaultEventType,
+      options: [...EVENT_TYPE_OPTIONS],
+      onChange: (v) => setDefault(ctx, 'defaultEventType', v),
+    }),
+  );
+  body.appendChild(
+    selectField({
+      label: 'Default Draw Type',
+      value: ctx.draft.defaults?.defaultDrawType,
+      options: [...DRAW_TYPE_OPTIONS],
+      onChange: (v) => setDefault(ctx, 'defaultDrawType', v),
+    }),
+  );
+  body.appendChild(
+    selectField({
+      label: 'Default Creation Method',
+      value: ctx.draft.defaults?.defaultCreationMethod,
+      options: [...CREATION_METHOD_OPTIONS],
+      onChange: (v) => setDefault(ctx, 'defaultCreationMethod', v),
+    }),
+  );
+  body.appendChild(
+    selectField({
+      label: 'Default Gender',
+      value: ctx.draft.defaults?.defaultGender,
+      options: [...GENDER_OPTIONS],
+      onChange: (v) => setDefault(ctx, 'defaultGender', v),
+    }),
   );
 }
 
+function setDefault(
+  ctx: TopicContext,
+  key: 'defaultEventType' | 'defaultDrawType' | 'defaultCreationMethod' | 'defaultGender',
+  value: string,
+): void {
+  ctx.draft.defaults = { ...(ctx.draft.defaults ?? {}) };
+  if (value) {
+    ctx.draft.defaults[key] = value;
+  } else {
+    delete ctx.draft.defaults[key];
+  }
+  ctx.onChange();
+}
+
+// ── Other topics (Phase 2 read-only summaries; editors land in 3b–d) ──────
+
 function renderAllowed(host: HTMLElement, ctx: TopicContext): void {
-  const perm = ctx.settings.permissions ?? {};
-  const pol = ctx.settings.policies ?? {};
+  const perm: ProviderPermissions = ctx.draft.permissions ?? {};
+  const pol = ctx.draft.policies ?? {};
   const rows: string[] = [];
   const add = (label: string, list: string[] | undefined) => {
     if (!list || !list.length) return;
-    rows.push(`<li><strong>${label}:</strong> ${list.map((v) => `<code>${v}</code>`).join(' ')}</li>`);
+    rows.push(`<li><strong>${label}:</strong> ${list.map((v) => `<code>${escapeHtml(v)}</code>`).join(' ')}</li>`);
   };
   add('Draw Types', perm.allowedDrawTypes);
   add('Creation Methods', perm.allowedCreationMethods);
   add('Scoring Approaches', perm.allowedScoringApproaches);
   add('MatchUp Formats', pol.allowedMatchUpFormats);
-  host.appendChild(
-    topicShell(
-      'Allowed Selections',
-      'Narrowing within the provisioner-allowed universe. Empty list = inherit caps unchanged.',
-      rows.length
-        ? `<ul class="sp-summary-list">${rows.join('')}</ul>`
-        : '<p class="sp-summary-empty"><em>No narrowing applied — inheriting all caps.</em></p>',
-    ),
+  const root = topicShell(
+    'Allowed Selections',
+    'Narrowing within the provisioner-allowed universe. Multi-select chip editor lands in Phase 3b.',
   );
+  const body = root.querySelector<HTMLElement>('.sp-topic-body')!;
+  body.innerHTML = rows.length
+    ? `<ul class="sp-summary-list">${rows.join('')}</ul>`
+    : '<p class="sp-summary-empty"><em>No narrowing applied — inheriting all caps.</em></p>';
+  host.appendChild(root);
 }
 
 function renderPolicies(host: HTMLElement, ctx: TopicContext): void {
-  const pol = ctx.settings.policies ?? {};
+  const pol = ctx.draft.policies ?? {};
   const has = (v: any) => v !== undefined && v !== null && Object.keys(v ?? {}).length > 0;
   const rows = [
     { label: 'Scheduling Policy', set: has(pol.schedulingPolicy) },
     { label: 'Scoring Policy', set: has(pol.scoringPolicy) },
     { label: 'Seeding Policy', set: has(pol.seedingPolicy) },
   ];
-  host.appendChild(
-    topicShell(
-      'Policies',
-      'Static configuration the factory engines consume. Phase 3 introduces structured editors per policy type.',
-      `<ul class="sp-summary-list">${rows
-        .map((r) => `<li><strong>${r.label}:</strong> ${r.set ? 'configured' : '<em>using defaults</em>'}</li>`)
-        .join('')}</ul>`,
-    ),
+  const root = topicShell(
+    'Policies',
+    'Static configuration the factory engines consume. Structured editors land in Phase 3d.',
   );
-}
-
-function renderDefaults(host: HTMLElement, ctx: TopicContext): void {
-  const d = ctx.settings.defaults ?? {};
-  const fields: { label: string; value?: string }[] = [
-    { label: 'Default Event Type', value: d.defaultEventType },
-    { label: 'Default Draw Type', value: d.defaultDrawType },
-    { label: 'Default Creation Method', value: d.defaultCreationMethod },
-    { label: 'Default Gender', value: d.defaultGender },
-  ];
-  host.appendChild(
-    topicShell(
-      'Defaults',
-      'Pre-fill values for new tournament/event/draw creation flows.',
-      `<ul class="sp-summary-list">${fields
-        .map((f) => `<li><strong>${f.label}:</strong> ${f.value ? `<code>${f.value}</code>` : '<em>not set</em>'}</li>`)
-        .join('')}</ul>`,
-    ),
-  );
+  const body = root.querySelector<HTMLElement>('.sp-topic-body')!;
+  body.innerHTML = `<ul class="sp-summary-list">${rows
+    .map((r) => `<li><strong>${r.label}:</strong> ${r.set ? 'configured' : '<em>using defaults</em>'}</li>`)
+    .join('')}</ul>`;
+  host.appendChild(root);
 }
 
 function renderPrint(host: HTMLElement, ctx: TopicContext): void {
-  const printPolicies = (ctx.settings.policies as any)?.printPolicies ?? {};
+  const printPolicies = (ctx.draft.policies as any)?.printPolicies ?? {};
   const types = ['draw', 'schedule', 'playerList', 'courtCard', 'signInSheet', 'matchCard'];
   const rows = types
-    .map((t) => {
-      const cfg = printPolicies[t];
+    .map((type) => {
+      const cfg = printPolicies[type];
       const configured = cfg && typeof cfg === 'object' && Object.keys(cfg).length > 0;
-      return `<li>${configured ? '●' : '○'} <code>${t}</code> ${configured ? '' : '<em>(uses pdf-factory defaults)</em>'}</li>`;
+      return `<li>${configured ? '●' : '○'} <code>${type}</code> ${configured ? '' : '<em>(uses pdf-factory defaults)</em>'}</li>`;
     })
     .join('');
-  host.appendChild(
-    topicShell(
-      'Print Configuration',
-      'Per-print-type composition policies. Phase 3 embeds the courthive-components composition editor here.',
-      `<ul class="sp-summary-list">${rows}</ul>`,
-    ),
+  const root = topicShell(
+    'Print Configuration',
+    'Per-print-type composition policies. The composition editor embeds here in Phase 3c.',
   );
+  const body = root.querySelector<HTMLElement>('.sp-topic-body')!;
+  body.innerHTML = `<ul class="sp-summary-list">${rows}</ul>`;
+  host.appendChild(root);
 }
 
 function renderCategories(host: HTMLElement, ctx: TopicContext): void {
-  const cats = ctx.settings.policies?.allowedCategories ?? [];
+  const cats = ctx.draft.policies?.allowedCategories ?? [];
   const rows = cats.length
     ? cats
         .map(
           (c) =>
-            `<li><code>${c.ageCategoryCode}</code>${c.categoryName ? ` — ${c.categoryName}` : ''}</li>`,
+            `<li><code>${escapeHtml(c.ageCategoryCode)}</code>${c.categoryName ? ` — ${escapeHtml(c.categoryName)}` : ''}</li>`,
         )
         .join('')
     : '<li><em>No categories restricted — all caps-allowed categories available.</em></li>';
-  host.appendChild(
-    topicShell(
-      'Categories',
-      'Restrict event categories to this list. Phase 3 introduces a row editor for adding/removing.',
-      `<ul class="sp-summary-list">${rows}</ul>`,
-    ),
+  const root = topicShell(
+    'Categories',
+    'Restrict event categories to this list. Row editor lands in Phase 3b.',
   );
+  const body = root.querySelector<HTMLElement>('.sp-topic-body')!;
+  body.innerHTML = `<ul class="sp-summary-list">${rows}</ul>`;
+  host.appendChild(root);
 }
 
-// ── Shared shell for a topic's content ─────────────────────────────────────
+// ── Helpers ────────────────────────────────────────────────────────────────
 
-function topicShell(title: string, description: string, body: string): HTMLElement {
+function topicShell(title: string, description: string): HTMLElement {
   const root = document.createElement('section');
   root.className = 'sp-topic';
   root.innerHTML = `
     <header class="sp-topic-header">
-      <h4>${title}</h4>
-      <p class="sp-topic-description">${description}</p>
+      <h4>${escapeHtml(title)}</h4>
+      <p class="sp-topic-description">${escapeHtml(description)}</p>
     </header>
-    <div class="sp-topic-body">${body}</div>
+    <div class="sp-topic-body"></div>
   `;
   return root;
+}
+
+interface SelectFieldOpts {
+  label: string;
+  value?: string;
+  options: string[];
+  onChange: (value: string) => void;
+}
+
+function selectField(opts: SelectFieldOpts): HTMLElement {
+  const wrap = document.createElement('label');
+  wrap.className = 'sp-field';
+
+  const label = document.createElement('span');
+  label.className = 'sp-field-label';
+  label.textContent = opts.label;
+  wrap.appendChild(label);
+
+  const select = document.createElement('select');
+  select.className = 'sp-field-input';
+
+  // Empty option = "no default"
+  const blank = document.createElement('option');
+  blank.value = '';
+  blank.textContent = '— not set —';
+  select.appendChild(blank);
+
+  for (const opt of opts.options) {
+    const o = document.createElement('option');
+    o.value = opt;
+    o.textContent = opt;
+    if (opts.value === opt) o.selected = true;
+    select.appendChild(o);
+  }
+
+  // If the existing value isn't in the option list (legacy / custom),
+  // surface it so we don't silently swallow it.
+  if (opts.value && !opts.options.includes(opts.value)) {
+    const o = document.createElement('option');
+    o.value = opts.value;
+    o.textContent = opts.value + ' (custom)';
+    o.selected = true;
+    select.appendChild(o);
+  }
+
+  select.addEventListener('change', () => opts.onChange(select.value));
+  wrap.appendChild(select);
+  return wrap;
+}
+
+function humanize(key: string): string {
+  return key
+    .replace(/^can/, '')
+    .replace(/([A-Z])/g, ' $1')
+    .trim();
+}
+
+function escapeHtml(s: string): string {
+  return s.replace(/[&<>"']/g, (c) => ({ '&': '&amp;', '<': '&lt;', '>': '&gt;', '"': '&quot;', "'": '&#39;' })[c]!);
 }

--- a/admin-client/src/pages/tournament/tabs/settingsTab/settingsPanel/topics.ts
+++ b/admin-client/src/pages/tournament/tabs/settingsTab/settingsPanel/topics.ts
@@ -1,0 +1,165 @@
+/**
+ * Topic registry for the Settings panel. Each topic owns a chunk of
+ * `providerConfigSettings` and renders into the right-hand content
+ * column when the user picks it from the nav.
+ *
+ * Phase 2 ships read-only summaries per topic so the wiring (fetch →
+ * state → render per-topic) is exercised end-to-end. Phase 3 swaps
+ * each topic's `render` for an actual editor.
+ */
+import type { ProviderConfigCaps, ProviderConfigSettings } from 'types/providerConfig';
+
+export type TopicId = 'permissions' | 'allowed' | 'policies' | 'defaults' | 'print' | 'categories';
+
+export interface TopicContext {
+  caps: ProviderConfigCaps;
+  settings: ProviderConfigSettings;
+}
+
+export interface TopicDescriptor {
+  id: TopicId;
+  label: string;
+  icon: string;
+  /** Render the topic content into the supplied host element. */
+  render: (host: HTMLElement, ctx: TopicContext) => void;
+}
+
+export const TOPICS: TopicDescriptor[] = [
+  { id: 'permissions', label: 'Permissions', icon: 'fa-shield-halved', render: renderPermissions },
+  { id: 'allowed', label: 'Allowed Selections', icon: 'fa-list-check', render: renderAllowed },
+  { id: 'policies', label: 'Policies', icon: 'fa-scale-balanced', render: renderPolicies },
+  { id: 'defaults', label: 'Defaults', icon: 'fa-sliders', render: renderDefaults },
+  { id: 'print', label: 'Print Configuration', icon: 'fa-print', render: renderPrint },
+  { id: 'categories', label: 'Categories', icon: 'fa-layer-group', render: renderCategories },
+];
+
+// ── Topic renderers (Phase 2: read-only summaries) ─────────────────────────
+
+function renderPermissions(host: HTMLElement, ctx: TopicContext): void {
+  const set = ctx.settings.permissions ?? {};
+  const setKeys = Object.keys(set).filter((k) => typeof (set as any)[k] === 'boolean');
+  const summary = setKeys.length
+    ? setKeys.map((k) => `<li><code>${k}</code>: <strong>${(set as any)[k] ? 'allowed' : 'denied'}</strong></li>`).join('')
+    : '<li><em>No explicit permission overrides — defaults apply.</em></li>';
+  host.appendChild(
+    topicShell(
+      'Permissions',
+      'Booleans the provider has set for tournament directors. Empty = the provisioner cap is the only restriction.',
+      `<ul class="sp-summary-list">${summary}</ul>`,
+    ),
+  );
+}
+
+function renderAllowed(host: HTMLElement, ctx: TopicContext): void {
+  const perm = ctx.settings.permissions ?? {};
+  const pol = ctx.settings.policies ?? {};
+  const rows: string[] = [];
+  const add = (label: string, list: string[] | undefined) => {
+    if (!list || !list.length) return;
+    rows.push(`<li><strong>${label}:</strong> ${list.map((v) => `<code>${v}</code>`).join(' ')}</li>`);
+  };
+  add('Draw Types', perm.allowedDrawTypes);
+  add('Creation Methods', perm.allowedCreationMethods);
+  add('Scoring Approaches', perm.allowedScoringApproaches);
+  add('MatchUp Formats', pol.allowedMatchUpFormats);
+  host.appendChild(
+    topicShell(
+      'Allowed Selections',
+      'Narrowing within the provisioner-allowed universe. Empty list = inherit caps unchanged.',
+      rows.length
+        ? `<ul class="sp-summary-list">${rows.join('')}</ul>`
+        : '<p class="sp-summary-empty"><em>No narrowing applied — inheriting all caps.</em></p>',
+    ),
+  );
+}
+
+function renderPolicies(host: HTMLElement, ctx: TopicContext): void {
+  const pol = ctx.settings.policies ?? {};
+  const has = (v: any) => v !== undefined && v !== null && Object.keys(v ?? {}).length > 0;
+  const rows = [
+    { label: 'Scheduling Policy', set: has(pol.schedulingPolicy) },
+    { label: 'Scoring Policy', set: has(pol.scoringPolicy) },
+    { label: 'Seeding Policy', set: has(pol.seedingPolicy) },
+  ];
+  host.appendChild(
+    topicShell(
+      'Policies',
+      'Static configuration the factory engines consume. Phase 3 introduces structured editors per policy type.',
+      `<ul class="sp-summary-list">${rows
+        .map((r) => `<li><strong>${r.label}:</strong> ${r.set ? 'configured' : '<em>using defaults</em>'}</li>`)
+        .join('')}</ul>`,
+    ),
+  );
+}
+
+function renderDefaults(host: HTMLElement, ctx: TopicContext): void {
+  const d = ctx.settings.defaults ?? {};
+  const fields: { label: string; value?: string }[] = [
+    { label: 'Default Event Type', value: d.defaultEventType },
+    { label: 'Default Draw Type', value: d.defaultDrawType },
+    { label: 'Default Creation Method', value: d.defaultCreationMethod },
+    { label: 'Default Gender', value: d.defaultGender },
+  ];
+  host.appendChild(
+    topicShell(
+      'Defaults',
+      'Pre-fill values for new tournament/event/draw creation flows.',
+      `<ul class="sp-summary-list">${fields
+        .map((f) => `<li><strong>${f.label}:</strong> ${f.value ? `<code>${f.value}</code>` : '<em>not set</em>'}</li>`)
+        .join('')}</ul>`,
+    ),
+  );
+}
+
+function renderPrint(host: HTMLElement, ctx: TopicContext): void {
+  const printPolicies = (ctx.settings.policies as any)?.printPolicies ?? {};
+  const types = ['draw', 'schedule', 'playerList', 'courtCard', 'signInSheet', 'matchCard'];
+  const rows = types
+    .map((t) => {
+      const cfg = printPolicies[t];
+      const configured = cfg && typeof cfg === 'object' && Object.keys(cfg).length > 0;
+      return `<li>${configured ? '●' : '○'} <code>${t}</code> ${configured ? '' : '<em>(uses pdf-factory defaults)</em>'}</li>`;
+    })
+    .join('');
+  host.appendChild(
+    topicShell(
+      'Print Configuration',
+      'Per-print-type composition policies. Phase 3 embeds the courthive-components composition editor here.',
+      `<ul class="sp-summary-list">${rows}</ul>`,
+    ),
+  );
+}
+
+function renderCategories(host: HTMLElement, ctx: TopicContext): void {
+  const cats = ctx.settings.policies?.allowedCategories ?? [];
+  const rows = cats.length
+    ? cats
+        .map(
+          (c) =>
+            `<li><code>${c.ageCategoryCode}</code>${c.categoryName ? ` — ${c.categoryName}` : ''}</li>`,
+        )
+        .join('')
+    : '<li><em>No categories restricted — all caps-allowed categories available.</em></li>';
+  host.appendChild(
+    topicShell(
+      'Categories',
+      'Restrict event categories to this list. Phase 3 introduces a row editor for adding/removing.',
+      `<ul class="sp-summary-list">${rows}</ul>`,
+    ),
+  );
+}
+
+// ── Shared shell for a topic's content ─────────────────────────────────────
+
+function topicShell(title: string, description: string, body: string): HTMLElement {
+  const root = document.createElement('section');
+  root.className = 'sp-topic';
+  root.innerHTML = `
+    <header class="sp-topic-header">
+      <h4>${title}</h4>
+      <p class="sp-topic-description">${description}</p>
+    </header>
+    <div class="sp-topic-body">${body}</div>
+  `;
+  return root;
+}

--- a/admin-client/src/pages/tournament/tabs/settingsTab/settingsPanel/widgets.ts
+++ b/admin-client/src/pages/tournament/tabs/settingsTab/settingsPanel/widgets.ts
@@ -109,32 +109,48 @@ function buildAddInput(placeholder: string | undefined, onAdd: (value: string) =
   wrap.className = 'sp-chip-add';
   const input = document.createElement('input');
   input.type = 'text';
-  input.placeholder = placeholder ?? 'Add…';
+  input.placeholder = placeholder ?? 'Type to add, then Enter or +';
   input.className = 'sp-chip-add-input';
-  input.addEventListener('keydown', (e) => {
-    if (e.key === 'Enter') {
-      e.preventDefault();
-      const v = input.value;
-      if (v.trim()) {
-        onAdd(v);
-        input.value = '';
-      }
-    }
-  });
+
   const btn = document.createElement('button');
   btn.type = 'button';
   btn.className = 'sp-chip-add-btn';
   btn.innerHTML = '<i class="fa-solid fa-plus"></i>';
   btn.title = 'Add';
-  btn.addEventListener('click', () => {
-    const v = input.value;
-    if (v.trim()) {
-      onAdd(v);
-      input.value = '';
+
+  function syncBtnState(): void {
+    const hasValue = input.value.trim().length > 0;
+    btn.classList.toggle('is-ready', hasValue);
+    // Keep the button enabled even when empty so the click handler can
+    // run (focus the input). Disabled buttons swallow clicks entirely.
+  }
+
+  function commit(): boolean {
+    const v = input.value.trim();
+    if (!v) {
+      input.focus();
+      return false;
+    }
+    onAdd(v);
+    return true;
+  }
+
+  input.addEventListener('input', syncBtnState);
+  input.addEventListener('keydown', (e) => {
+    if (e.key === 'Enter') {
+      e.preventDefault();
+      commit();
     }
   });
+  btn.addEventListener('click', () => {
+    if (!commit()) return;
+    // commit() already wrote the value; rebuild() destroys this input
+    // when chips re-render, so nothing else to do here.
+  });
+
   wrap.appendChild(input);
   wrap.appendChild(btn);
+  syncBtnState();
   return wrap;
 }
 

--- a/admin-client/src/pages/tournament/tabs/settingsTab/settingsPanel/widgets.ts
+++ b/admin-client/src/pages/tournament/tabs/settingsTab/settingsPanel/widgets.ts
@@ -1,11 +1,20 @@
 /**
  * Reusable input widgets for the Settings panel topics.
  *
- * - chipMultiSelect: cap-aware multi-select. When `pinnedUniverse` is
- *   provided (provisioner-restricted), every value renders as a chip
- *   that toggles on click. When `pinnedUniverse` is empty/undefined
- *   (no cap restriction), only the user's selections render as chips
- *   and a text input lets them add arbitrary values.
+ * - chipMultiSelect: closed-list multi-select with three rendering modes,
+ *   chosen by which universe is supplied:
+ *
+ *     1. `pinnedUniverse` (provisioner-restricted) — chips render the
+ *        provisioner's allowed list. Selected chips that fall outside
+ *        the cap render as orphan chips so the user can see and clear
+ *        them.
+ *
+ *     2. `fullUniverse` (factory enum, no provisioner restriction) —
+ *        chips render the full factory enum. Same toggle behavior, no
+ *        orphan handling needed: any value not in the enum is invalid.
+ *
+ *     3. neither — free-form text input for grammars whose universe
+ *        isn't a fixed enum (matchUpFormatCode strings).
  *
  * - rowEditor: simple add/edit/delete table for a list of records.
  */
@@ -13,7 +22,17 @@
 export interface ChipMultiSelectOpts {
   label: string;
   values: string[];
+  /** Provisioner-restricted universe; takes precedence over `fullUniverse`. */
   pinnedUniverse?: string[];
+  /** Closed factory enum used when caps don't restrict the universe. */
+  fullUniverse?: readonly string[];
+  /**
+   * Optional display-label override for individual values. Used when the
+   * stored value is an opaque id (e.g. a topology UUID) and the chip
+   * should render a human-readable name. Falls back to the raw value
+   * when no override is present.
+   */
+  labels?: Record<string, string>;
   placeholder?: string;
   onChange: (next: string[]) => void;
 }
@@ -35,34 +54,48 @@ export function chipMultiSelect(opts: ChipMultiSelectOpts): HTMLElement {
   wrap.appendChild(chipsHost);
 
   const selected = new Set(opts.values);
-  const restricted = !!(opts.pinnedUniverse && opts.pinnedUniverse.length);
+  const pinned = opts.pinnedUniverse && opts.pinnedUniverse.length ? opts.pinnedUniverse : null;
+  const full = opts.fullUniverse && opts.fullUniverse.length ? opts.fullUniverse : null;
 
   function emit(): void {
     opts.onChange([...selected]);
   }
 
+  const labelFor = (value: string): string => opts.labels?.[value] ?? value;
+
   function rebuild(): void {
     chipsHost.innerHTML = '';
 
-    if (restricted) {
-      const universe = opts.pinnedUniverse!;
-      for (const value of universe) {
-        chipsHost.appendChild(makeChip(value, selected.has(value), () => toggle(value)));
+    if (pinned) {
+      for (const value of pinned) {
+        chipsHost.appendChild(makeChip(labelFor(value), selected.has(value), () => toggle(value)));
       }
       // Surface any selected values that aren't in the universe (legacy /
       // out-of-cap data). Render them as chips with an out-of-cap visual
       // marker so the user can see and remove them.
-      const orphans = [...selected].filter((v) => !universe.includes(v));
+      const orphans = [...selected].filter((v) => !pinned.includes(v));
       for (const value of orphans) {
-        chipsHost.appendChild(makeChip(value, true, () => toggle(value), { orphan: true }));
+        chipsHost.appendChild(makeChip(labelFor(value), true, () => toggle(value), { orphan: true }));
       }
       const hint = document.createElement('div');
       hint.className = 'sp-chips-hint';
       hint.textContent = 'Click to toggle. Provisioner-allowed list above.';
       chipsHost.appendChild(hint);
+    } else if (full) {
+      for (const value of full) {
+        chipsHost.appendChild(makeChip(labelFor(value), selected.has(value), () => toggle(value)));
+      }
+      const orphans = [...selected].filter((v) => !full.includes(v));
+      for (const value of orphans) {
+        chipsHost.appendChild(makeChip(labelFor(value), true, () => toggle(value), { orphan: true }));
+      }
+      const hint = document.createElement('div');
+      hint.className = 'sp-chips-hint';
+      hint.textContent = 'Click to toggle. Empty selection = all values allowed.';
+      chipsHost.appendChild(hint);
     } else {
       for (const value of selected) {
-        chipsHost.appendChild(makeChip(value, true, () => toggle(value)));
+        chipsHost.appendChild(makeChip(labelFor(value), true, () => toggle(value)));
       }
       chipsHost.appendChild(buildAddInput(opts.placeholder, (v) => add(v)));
     }

--- a/admin-client/src/pages/tournament/tabs/settingsTab/settingsPanel/widgets.ts
+++ b/admin-client/src/pages/tournament/tabs/settingsTab/settingsPanel/widgets.ts
@@ -1,0 +1,253 @@
+/**
+ * Reusable input widgets for the Settings panel topics.
+ *
+ * - chipMultiSelect: cap-aware multi-select. When `pinnedUniverse` is
+ *   provided (provisioner-restricted), every value renders as a chip
+ *   that toggles on click. When `pinnedUniverse` is empty/undefined
+ *   (no cap restriction), only the user's selections render as chips
+ *   and a text input lets them add arbitrary values.
+ *
+ * - rowEditor: simple add/edit/delete table for a list of records.
+ */
+
+export interface ChipMultiSelectOpts {
+  label: string;
+  values: string[];
+  pinnedUniverse?: string[];
+  placeholder?: string;
+  onChange: (next: string[]) => void;
+}
+
+export function chipMultiSelect(opts: ChipMultiSelectOpts): HTMLElement {
+  const wrap = document.createElement('div');
+  wrap.className = 'sp-field sp-field-wide';
+
+  const labelRow = document.createElement('div');
+  labelRow.className = 'sp-field-label-row';
+  const label = document.createElement('span');
+  label.className = 'sp-field-label';
+  label.textContent = opts.label;
+  labelRow.appendChild(label);
+  wrap.appendChild(labelRow);
+
+  const chipsHost = document.createElement('div');
+  chipsHost.className = 'sp-chips';
+  wrap.appendChild(chipsHost);
+
+  const selected = new Set(opts.values);
+  const restricted = !!(opts.pinnedUniverse && opts.pinnedUniverse.length);
+
+  function emit(): void {
+    opts.onChange([...selected]);
+  }
+
+  function rebuild(): void {
+    chipsHost.innerHTML = '';
+
+    if (restricted) {
+      const universe = opts.pinnedUniverse!;
+      for (const value of universe) {
+        chipsHost.appendChild(makeChip(value, selected.has(value), () => toggle(value)));
+      }
+      // Surface any selected values that aren't in the universe (legacy /
+      // out-of-cap data). Render them as chips with an out-of-cap visual
+      // marker so the user can see and remove them.
+      const orphans = [...selected].filter((v) => !universe.includes(v));
+      for (const value of orphans) {
+        chipsHost.appendChild(makeChip(value, true, () => toggle(value), { orphan: true }));
+      }
+      const hint = document.createElement('div');
+      hint.className = 'sp-chips-hint';
+      hint.textContent = 'Click to toggle. Provisioner-allowed list above.';
+      chipsHost.appendChild(hint);
+    } else {
+      for (const value of selected) {
+        chipsHost.appendChild(makeChip(value, true, () => toggle(value)));
+      }
+      chipsHost.appendChild(buildAddInput(opts.placeholder, (v) => add(v)));
+    }
+  }
+
+  function toggle(value: string): void {
+    if (selected.has(value)) selected.delete(value);
+    else selected.add(value);
+    emit();
+    rebuild();
+  }
+
+  function add(value: string): void {
+    const trimmed = value.trim();
+    if (!trimmed) return;
+    if (selected.has(trimmed)) return;
+    selected.add(trimmed);
+    emit();
+    rebuild();
+  }
+
+  rebuild();
+  return wrap;
+}
+
+function makeChip(
+  label: string,
+  selected: boolean,
+  onClick: () => void,
+  opts?: { orphan?: boolean },
+): HTMLElement {
+  const chip = document.createElement('button');
+  chip.type = 'button';
+  chip.className = 'sp-chip' + (selected ? ' is-selected' : '') + (opts?.orphan ? ' is-orphan' : '');
+  chip.title = opts?.orphan ? 'Outside provisioner-allowed list — click to remove' : '';
+  chip.innerHTML = `<span class="sp-chip-label"></span>${selected ? '<i class="fa-solid fa-xmark"></i>' : '<i class="fa-solid fa-plus"></i>'}`;
+  chip.querySelector<HTMLElement>('.sp-chip-label')!.textContent = label;
+  chip.addEventListener('click', onClick);
+  return chip;
+}
+
+function buildAddInput(placeholder: string | undefined, onAdd: (value: string) => void): HTMLElement {
+  const wrap = document.createElement('div');
+  wrap.className = 'sp-chip-add';
+  const input = document.createElement('input');
+  input.type = 'text';
+  input.placeholder = placeholder ?? 'Add…';
+  input.className = 'sp-chip-add-input';
+  input.addEventListener('keydown', (e) => {
+    if (e.key === 'Enter') {
+      e.preventDefault();
+      const v = input.value;
+      if (v.trim()) {
+        onAdd(v);
+        input.value = '';
+      }
+    }
+  });
+  const btn = document.createElement('button');
+  btn.type = 'button';
+  btn.className = 'sp-chip-add-btn';
+  btn.innerHTML = '<i class="fa-solid fa-plus"></i>';
+  btn.title = 'Add';
+  btn.addEventListener('click', () => {
+    const v = input.value;
+    if (v.trim()) {
+      onAdd(v);
+      input.value = '';
+    }
+  });
+  wrap.appendChild(input);
+  wrap.appendChild(btn);
+  return wrap;
+}
+
+// ── Row editor (used by Categories) ────────────────────────────────────────
+
+export interface RowEditorColumn<T> {
+  key: keyof T & string;
+  label: string;
+  placeholder?: string;
+  required?: boolean;
+}
+
+export interface RowEditorOpts<T extends Record<string, any>> {
+  rows: T[];
+  columns: RowEditorColumn<T>[];
+  onChange: (next: T[]) => void;
+  emptyRow: () => T;
+  isEmpty?: (row: T) => boolean;
+  /** Hint values shown below the editor (e.g., caps universe). */
+  hint?: string;
+}
+
+export function rowEditor<T extends Record<string, any>>(opts: RowEditorOpts<T>): HTMLElement {
+  const wrap = document.createElement('div');
+  wrap.className = 'sp-row-editor';
+
+  const rows = [...opts.rows];
+
+  const tableHost = document.createElement('div');
+  tableHost.className = 'sp-row-table';
+  wrap.appendChild(tableHost);
+
+  const addBtn = document.createElement('button');
+  addBtn.type = 'button';
+  addBtn.className = 'sp-row-add-btn';
+  addBtn.innerHTML = '<i class="fa-solid fa-plus"></i> Add row';
+  addBtn.addEventListener('click', () => {
+    rows.push(opts.emptyRow());
+    emit();
+    rebuild();
+  });
+  wrap.appendChild(addBtn);
+
+  if (opts.hint) {
+    const hint = document.createElement('div');
+    hint.className = 'sp-row-hint';
+    hint.textContent = opts.hint;
+    wrap.appendChild(hint);
+  }
+
+  function emit(): void {
+    const cleaned = opts.isEmpty ? rows.filter((r) => !opts.isEmpty!(r)) : rows;
+    opts.onChange(cleaned);
+  }
+
+  function rebuild(): void {
+    tableHost.innerHTML = '';
+
+    const headerRow = document.createElement('div');
+    headerRow.className = 'sp-row-header';
+    for (const col of opts.columns) {
+      const cell = document.createElement('div');
+      cell.className = 'sp-row-cell-header';
+      cell.textContent = col.label + (col.required ? ' *' : '');
+      headerRow.appendChild(cell);
+    }
+    headerRow.appendChild(document.createElement('div')); // delete column header
+    tableHost.appendChild(headerRow);
+
+    if (rows.length === 0) {
+      const empty = document.createElement('div');
+      empty.className = 'sp-row-empty';
+      empty.textContent = 'No rows. Click Add row to start.';
+      tableHost.appendChild(empty);
+      return;
+    }
+
+    rows.forEach((row, idx) => {
+      const tr = document.createElement('div');
+      tr.className = 'sp-row';
+      for (const col of opts.columns) {
+        const cell = document.createElement('div');
+        cell.className = 'sp-row-cell';
+        const input = document.createElement('input');
+        input.type = 'text';
+        input.className = 'sp-field-input';
+        input.placeholder = col.placeholder ?? '';
+        input.value = String(row[col.key] ?? '');
+        input.addEventListener('input', () => {
+          (rows[idx] as any)[col.key] = input.value;
+          emit();
+        });
+        cell.appendChild(input);
+        tr.appendChild(cell);
+      }
+      const delCell = document.createElement('div');
+      delCell.className = 'sp-row-cell-delete';
+      const delBtn = document.createElement('button');
+      delBtn.type = 'button';
+      delBtn.className = 'sp-row-del-btn';
+      delBtn.innerHTML = '<i class="fa-solid fa-trash"></i>';
+      delBtn.title = 'Remove row';
+      delBtn.addEventListener('click', () => {
+        rows.splice(idx, 1);
+        emit();
+        rebuild();
+      });
+      delCell.appendChild(delBtn);
+      tr.appendChild(delCell);
+      tableHost.appendChild(tr);
+    });
+  }
+
+  rebuild();
+  return wrap;
+}

--- a/admin-client/src/router/router.ts
+++ b/admin-client/src/router/router.ts
@@ -6,18 +6,11 @@ import { renderSystemPage } from 'pages/system/renderSystemPage';
 import { renderAdminPage } from 'pages/admin/renderAdminPage';
 import { renderSyncPage } from 'pages/sync/renderSyncPage';
 import { getLoginState } from 'services/authentication/loginState';
+import { updateNavVisibility } from 'services/navigation/navVisibility';
 import { context } from 'services/context';
 import Navigo from 'navigo';
 
-import {
-  SUPER_ADMIN,
-  PROVISIONER,
-  SYSTEM,
-  PROVISIONER_ROUTE,
-  SANCTIONING,
-  SYNC,
-  NONE,
-} from 'constants/tmxConstants';
+import { SUPER_ADMIN, PROVISIONER, SYSTEM, PROVISIONER_ROUTE, SANCTIONING, SYNC } from 'constants/tmxConstants';
 
 export function routeAdmin(): void {
   const router = new Navigo('/', { hash: true });
@@ -126,23 +119,4 @@ export function routeAdmin(): void {
 
 function isProvisionerOrSuperAdmin(state: any): boolean {
   return !!(state?.roles?.includes(SUPER_ADMIN) || state?.roles?.includes(PROVISIONER));
-}
-
-function updateNavVisibility(): void {
-  const state = getLoginState();
-  const isSuperAdmin = state?.roles?.includes(SUPER_ADMIN);
-  const isProvisioner = state?.roles?.includes(PROVISIONER);
-
-  const systemIcon = document.getElementById('h-system');
-  if (systemIcon) {
-    systemIcon.style.display = isSuperAdmin ? '' : NONE;
-  }
-  const hSync = document.getElementById('h-sync');
-  if (hSync) {
-    hSync.style.display = isSuperAdmin ? '' : NONE;
-  }
-  const provisionerIcon = document.getElementById('h-provisioner');
-  if (provisionerIcon) {
-    provisionerIcon.style.display = isSuperAdmin || isProvisioner ? '' : NONE;
-  }
 }

--- a/admin-client/src/router/router.ts
+++ b/admin-client/src/router/router.ts
@@ -5,12 +5,14 @@ import { renderProvisionerPage } from 'pages/provisioner/renderProvisionerPage';
 import { renderSystemPage } from 'pages/system/renderSystemPage';
 import { renderAdminPage } from 'pages/admin/renderAdminPage';
 import { renderSyncPage } from 'pages/sync/renderSyncPage';
+import { renderTemplatesPage } from 'pages/templates/renderTemplatesPage';
+import { renderPoliciesPage } from 'pages/policies/renderPoliciesPage';
 import { getLoginState } from 'services/authentication/loginState';
 import { updateNavVisibility } from 'services/navigation/navVisibility';
 import { context } from 'services/context';
 import Navigo from 'navigo';
 
-import { SUPER_ADMIN, PROVISIONER, SYSTEM, PROVISIONER_ROUTE, SANCTIONING, SYNC } from 'constants/tmxConstants';
+import { SUPER_ADMIN, PROVISIONER, SYSTEM, PROVISIONER_ROUTE, SANCTIONING, SYNC, TEMPLATES, POLICIES } from 'constants/tmxConstants';
 
 export function routeAdmin(): void {
   const router = new Navigo('/', { hash: true });
@@ -21,11 +23,15 @@ export function routeAdmin(): void {
   const adminIcon = document.getElementById('h-admin');
   const provisionerIcon = document.getElementById('h-provisioner');
   const sanctioningIcon = document.getElementById('h-sanctioning');
+  const templatesIcon = document.getElementById('h-templates');
+  const policiesIcon = document.getElementById('h-policies');
   const syncIcon = document.getElementById('h-sync');
   if (systemIcon) systemIcon.addEventListener('click', () => router.navigate(`/${SYSTEM}`));
   if (adminIcon) adminIcon.addEventListener('click', () => router.navigate('/admin'));
   if (provisionerIcon) provisionerIcon.addEventListener('click', () => router.navigate(`/${PROVISIONER_ROUTE}`));
   if (sanctioningIcon) sanctioningIcon.addEventListener('click', () => router.navigate(`/${SANCTIONING}`));
+  if (templatesIcon) templatesIcon.addEventListener('click', () => router.navigate(`/${TEMPLATES}`));
+  if (policiesIcon) policiesIcon.addEventListener('click', () => router.navigate(`/${POLICIES}`));
   if (syncIcon) syncIcon.addEventListener('click', () => router.navigate(`/${SYNC}`));
 
   router.hooks({
@@ -87,6 +93,22 @@ export function routeAdmin(): void {
 
   router.on(`/${SANCTIONING}`, () => {
     renderSanctioningDashboard();
+  });
+
+  // Templates route (PROVIDER_ADMIN of an active provider, or super-admin
+  // impersonating one). Topologies / tieFormats / compositions are
+  // per-provider, so an active provider is required.
+  router.on(`/${TEMPLATES}/:templateView`, (match) => {
+    void renderTemplatesPage({ templateView: match?.data?.templateView });
+  });
+
+  router.on(`/${TEMPLATES}`, () => {
+    void renderTemplatesPage();
+  });
+
+  // Policies route — per-provider catalog.
+  router.on(`/${POLICIES}`, () => {
+    void renderPoliciesPage();
   });
 
   // Tournament Sync route (superadmin only)

--- a/admin-client/src/services/apis/catalogApi.ts
+++ b/admin-client/src/services/apis/catalogApi.ts
@@ -1,0 +1,50 @@
+/**
+ * Generic per-provider catalog API. Backs Templates page (compositions,
+ * tieFormats) and the Policies page (policies). Same shape per type;
+ * the `:type` URL segment is one of `composition` | `tieFormat` | `policy`.
+ *
+ * PROVIDER_ADMIN of the target provider or SUPER_ADMIN required.
+ */
+import { baseApi } from './baseApi';
+
+export type CatalogType = 'composition' | 'tieFormat' | 'policy';
+
+export interface CatalogItemDto {
+  catalogId: string;
+  catalogType: CatalogType;
+  name: string;
+  description?: string | null;
+  data: any;
+  metadata?: any;
+  createdAt: string;
+  updatedAt: string;
+}
+
+export async function listCatalog(providerId: string, type: CatalogType) {
+  return baseApi.get(`/provider/${providerId}/catalog/${type}`);
+}
+
+export async function getCatalogItem(providerId: string, type: CatalogType, catalogId: string) {
+  return baseApi.get(`/provider/${providerId}/catalog/${type}/${catalogId}`);
+}
+
+export async function createCatalogItem(
+  providerId: string,
+  type: CatalogType,
+  body: { name: string; description?: string; data: any; metadata?: any },
+) {
+  return baseApi.post(`/provider/${providerId}/catalog/${type}`, body);
+}
+
+export async function updateCatalogItem(
+  providerId: string,
+  type: CatalogType,
+  catalogId: string,
+  patch: { name?: string; description?: string; data?: any; metadata?: any },
+) {
+  return baseApi.put(`/provider/${providerId}/catalog/${type}/${catalogId}`, patch);
+}
+
+export async function deleteCatalogItem(providerId: string, type: CatalogType, catalogId: string) {
+  return baseApi.delete(`/provider/${providerId}/catalog/${type}/${catalogId}`);
+}

--- a/admin-client/src/services/apis/provisionerWorkspaceApi.ts
+++ b/admin-client/src/services/apis/provisionerWorkspaceApi.ts
@@ -27,6 +27,7 @@ export function setActiveProvisionerId(provisionerId: string): void {
   } catch {
     /* non-fatal */
   }
+  notifyProvisionerChange();
 }
 
 export function clearActiveProvisionerId(): void {
@@ -34,6 +35,18 @@ export function clearActiveProvisionerId(): void {
     globalThis.localStorage?.removeItem(ACTIVE_PROVISIONER_KEY);
   } catch {
     /* non-fatal */
+  }
+  notifyProvisionerChange();
+}
+
+/**
+ * Fire a DOM event so the nav-visibility module can refresh the
+ * provisioner icon's display state without forming a circular import
+ * (this module is imported by navVisibility.ts).
+ */
+function notifyProvisionerChange(): void {
+  if (typeof document !== 'undefined') {
+    document.dispatchEvent(new CustomEvent('admin:provisioner-changed'));
   }
 }
 

--- a/admin-client/src/services/apis/topologyApi.ts
+++ b/admin-client/src/services/apis/topologyApi.ts
@@ -1,0 +1,49 @@
+/**
+ * Per-provider topology catalog API.
+ *
+ * Topologies are bracket structures authored by provider admins via the
+ * Templates page. The IDs are referenced by `allowedDrawTypes` in
+ * `providerConfigSettings` so the Settings panel's Allowed Selections
+ * chip widget can surface provider-defined draw structures alongside
+ * the factory enum.
+ *
+ * All endpoints require PROVIDER_ADMIN of the target provider or
+ * SUPER_ADMIN.
+ */
+import { baseApi } from './baseApi';
+
+export interface TopologyDto {
+  topologyId: string;
+  name: string;
+  description?: string | null;
+  state: any;
+  createdAt: string;
+  updatedAt: string;
+}
+
+export async function listTopologies(providerId: string) {
+  return baseApi.get(`/provider/${providerId}/topologies`);
+}
+
+export async function getTopology(providerId: string, topologyId: string) {
+  return baseApi.get(`/provider/${providerId}/topologies/${topologyId}`);
+}
+
+export async function createTopology(
+  providerId: string,
+  body: { name: string; description?: string; state: any },
+) {
+  return baseApi.post(`/provider/${providerId}/topologies`, body);
+}
+
+export async function updateTopology(
+  providerId: string,
+  topologyId: string,
+  patch: { name?: string; description?: string; state?: any },
+) {
+  return baseApi.put(`/provider/${providerId}/topologies/${topologyId}`, patch);
+}
+
+export async function deleteTopology(providerId: string, topologyId: string) {
+  return baseApi.delete(`/provider/${providerId}/topologies/${topologyId}`);
+}

--- a/admin-client/src/services/navigation/navVisibility.ts
+++ b/admin-client/src/services/navigation/navVisibility.ts
@@ -10,6 +10,7 @@
  */
 import { getLoginState } from 'services/authentication/loginState';
 import { getActiveProvisionerId } from 'services/apis/provisionerWorkspaceApi';
+import { getActiveProvider } from 'services/provider/providerState';
 import { NONE, PROVISIONER, SUPER_ADMIN } from 'constants/tmxConstants';
 
 export function updateNavVisibility(): void {
@@ -17,6 +18,7 @@ export function updateNavVisibility(): void {
   const isSuperAdmin = !!state?.roles?.includes(SUPER_ADMIN);
   const isProvisioner = !!state?.roles?.includes(PROVISIONER);
   const hasActiveProvisioner = !!getActiveProvisionerId();
+  const hasActiveProvider = !!getActiveProvider();
 
   setIconDisplay('h-system', isSuperAdmin);
   setIconDisplay('h-sync', isSuperAdmin);
@@ -27,6 +29,13 @@ export function updateNavVisibility(): void {
   // X-Provisioner-Id header the /provisioner/* endpoints reject the
   // request, so showing the icon would just lead to an error toast.
   setIconDisplay('h-provisioner', isProvisioner || (isSuperAdmin && hasActiveProvisioner));
+
+  // Templates icon: per-provider catalog requires an active provider.
+  // PROVIDER_ADMIN users have one by default; super-admins must impersonate.
+  setIconDisplay('h-templates', hasActiveProvider);
+
+  // Policies icon: same per-provider scoping rule as Templates.
+  setIconDisplay('h-policies', hasActiveProvider);
 }
 
 function setIconDisplay(id: string, visible: boolean): void {

--- a/admin-client/src/services/navigation/navVisibility.ts
+++ b/admin-client/src/services/navigation/navVisibility.ts
@@ -1,0 +1,49 @@
+/**
+ * Top-bar nav icon visibility — driven by login role + (for the
+ * provisioner icon) whether the user has actively selected a
+ * provisioner via the provisioner workspace.
+ *
+ * The router calls `updateNavVisibility()` on every navigation; the
+ * provisioner-state setters in `provisionerWorkspaceApi.ts` also call
+ * it so the icon flips immediately when the user picks or clears
+ * their active provisioner.
+ */
+import { getLoginState } from 'services/authentication/loginState';
+import { getActiveProvisionerId } from 'services/apis/provisionerWorkspaceApi';
+import { NONE, PROVISIONER, SUPER_ADMIN } from 'constants/tmxConstants';
+
+export function updateNavVisibility(): void {
+  const state = getLoginState();
+  const isSuperAdmin = !!state?.roles?.includes(SUPER_ADMIN);
+  const isProvisioner = !!state?.roles?.includes(PROVISIONER);
+  const hasActiveProvisioner = !!getActiveProvisionerId();
+
+  setIconDisplay('h-system', isSuperAdmin);
+  setIconDisplay('h-sync', isSuperAdmin);
+
+  // Provisioner icon: PROVISIONER users always see it (their JWT carries
+  // the provisioner context so the API works without an explicit pick).
+  // SUPER_ADMIN sees it only after picking a provisioner — without the
+  // X-Provisioner-Id header the /provisioner/* endpoints reject the
+  // request, so showing the icon would just lead to an error toast.
+  setIconDisplay('h-provisioner', isProvisioner || (isSuperAdmin && hasActiveProvisioner));
+}
+
+function setIconDisplay(id: string, visible: boolean): void {
+  const el = document.getElementById(id);
+  if (el) el.style.display = visible ? '' : NONE;
+}
+
+let listenersWired = false;
+
+/**
+ * Listen for provisioner-state changes from
+ * `provisionerWorkspaceApi.setActiveProvisionerId / clearActiveProvisionerId`
+ * and refresh the icon when they fire. Call once during admin-client
+ * bootstrap.
+ */
+export function wireNavVisibilityListeners(): void {
+  if (listenersWired || typeof document === 'undefined') return;
+  listenersWired = true;
+  document.addEventListener('admin:provisioner-changed', () => updateNavVisibility());
+}

--- a/admin-client/src/services/transitions/screenSlaver.ts
+++ b/admin-client/src/services/transitions/screenSlaver.ts
@@ -2,11 +2,11 @@
  * Screen state management for admin app content areas.
  * Controls visibility of the admin and system page containers.
  */
-import { TMX_ADMIN, TMX_SYSTEM, TMX_PROVISIONER, TMX_SANCTIONING, TMX_SYNC } from 'constants/tmxConstants';
+import { TMX_ADMIN, TMX_SYSTEM, TMX_PROVISIONER, TMX_SANCTIONING, TMX_SYNC, TMX_TEMPLATES, TMX_POLICIES } from 'constants/tmxConstants';
 
 let content: string | undefined;
 
-const PAGE_IDS = [TMX_SYSTEM, TMX_ADMIN, TMX_PROVISIONER, TMX_SANCTIONING, TMX_SYNC];
+const PAGE_IDS = [TMX_SYSTEM, TMX_ADMIN, TMX_PROVISIONER, TMX_SANCTIONING, TMX_SYNC, TMX_TEMPLATES, TMX_POLICIES];
 
 function selectDisplay(which: string): void {
   for (const id of PAGE_IDS) {
@@ -34,6 +34,14 @@ function selectDisplay(which: string): void {
   const syncIcon = document.getElementById('h-sync');
   if (syncIcon) {
     syncIcon.classList.toggle('active', which === TMX_SYNC);
+  }
+  const templatesIcon = document.getElementById('h-templates');
+  if (templatesIcon) {
+    templatesIcon.classList.toggle('active', which === TMX_TEMPLATES);
+  }
+  const policiesIcon = document.getElementById('h-policies');
+  if (policiesIcon) {
+    policiesIcon.classList.toggle('active', which === TMX_POLICIES);
   }
 }
 
@@ -73,5 +81,19 @@ export const showTMXprovisioner = (): void => {
   const titleEl = document.getElementById('pageTitle');
   if (titleEl) titleEl.textContent = 'My Organization';
   content = TMX_PROVISIONER;
+  selectDisplay(content);
+};
+
+export const showTMXtemplates = (): void => {
+  const titleEl = document.getElementById('pageTitle');
+  if (titleEl) titleEl.textContent = 'Templates';
+  content = TMX_TEMPLATES;
+  selectDisplay(content);
+};
+
+export const showTMXpolicies = (): void => {
+  const titleEl = document.getElementById('pageTitle');
+  if (titleEl) titleEl.textContent = 'Policies';
+  content = TMX_POLICIES;
   selectDisplay(content);
 };

--- a/package.json
+++ b/package.json
@@ -149,7 +149,7 @@
       "@scarf/scarf",
       "@swc/core",
       "classic-level",
-      "core-js",
+      "esbuild",
       "unrs-resolver"
     ]
   },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -251,6 +251,58 @@ importers:
         specifier: 6.0.3
         version: 6.0.3
 
+  admin-client:
+    dependencies:
+      animate.css:
+        specifier: ^4.1.1
+        version: 4.1.1
+      axios:
+        specifier: ^1.13.0
+        version: 1.15.2
+      courthive-components:
+        specifier: ^1.1.1
+        version: 1.1.1
+      i18next:
+        specifier: ^26.0.0
+        version: 26.0.8(typescript@6.0.3)
+      jwt-decode:
+        specifier: ^4.0.0
+        version: 4.0.0
+      navigo:
+        specifier: ^8.11.1
+        version: 8.11.1
+      tabulator-tables:
+        specifier: ^6.3.1
+        version: 6.4.0
+    devDependencies:
+      '@playwright/test':
+        specifier: ^1.59.1
+        version: 1.59.1
+      '@storybook/addon-docs':
+        specifier: ^10.2.17
+        version: 10.3.6(@types/react@19.2.14)(esbuild@0.27.7)(rollup@4.60.0)(storybook@10.3.6(@testing-library/dom@10.4.1)(prettier@3.8.3)(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(vite@8.0.10(@types/node@25.6.0)(esbuild@0.27.7)(jiti@2.6.1)(terser@5.44.0)(tsx@4.21.0)(yaml@2.8.2))(webpack@5.106.0(esbuild@0.27.7))
+      '@storybook/html':
+        specifier: ^10.2.17
+        version: 10.3.6(storybook@10.3.6(@testing-library/dom@10.4.1)(prettier@3.8.3)(react-dom@19.2.5(react@19.2.5))(react@19.2.5))
+      '@storybook/html-vite':
+        specifier: ^10.2.17
+        version: 10.3.6(esbuild@0.27.7)(rollup@4.60.0)(storybook@10.3.6(@testing-library/dom@10.4.1)(prettier@3.8.3)(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(vite@8.0.10(@types/node@25.6.0)(esbuild@0.27.7)(jiti@2.6.1)(terser@5.44.0)(tsx@4.21.0)(yaml@2.8.2))(webpack@5.106.0(esbuild@0.27.7))
+      happy-dom:
+        specifier: ^20.8.3
+        version: 20.9.0
+      storybook:
+        specifier: ^10.2.17
+        version: 10.3.6(@testing-library/dom@10.4.1)(prettier@3.8.3)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
+      typescript:
+        specifier: ^6.0.0
+        version: 6.0.3
+      vite:
+        specifier: ^8.0.0
+        version: 8.0.10(@types/node@25.6.0)(esbuild@0.27.7)(jiti@2.6.1)(terser@5.44.0)(tsx@4.21.0)(yaml@2.8.2)
+      vitest:
+        specifier: ^4.0.16
+        version: 4.1.5(@types/node@25.6.0)(happy-dom@20.9.0)(vite@8.0.10(@types/node@25.6.0)(esbuild@0.27.7)(jiti@2.6.1)(terser@5.44.0)(tsx@4.21.0)(yaml@2.8.2))
+
   audit-worker:
     dependencies:
       dotenv:
@@ -573,14 +625,23 @@ packages:
     resolution: {integrity: sha512-IchNf6dN4tHoMFIn/7OE8LWZ19Y6q/67Bmf6vnGREv8RSbBVb9LPJxEcnwrcwX6ixSvaiGoomAUvu4YSxXrVgw==}
     engines: {node: '>=12'}
 
+  '@emnapi/core@1.10.0':
+    resolution: {integrity: sha512-yq6OkJ4p82CAfPl0u9mQebQHKPJkY7WrIuk205cTYnYe+k2Z8YBh11FrbRG/H6ihirqcacOgl2BIO8oyMQLeXw==}
+
   '@emnapi/core@1.7.0':
     resolution: {integrity: sha512-pJdKGq/1iquWYtv1RRSljZklxHCOCAJFJrImO5ZLKPJVJlVUcs8yFwNQlqS0Lo8xT1VAXXTCZocF9n26FWEKsw==}
+
+  '@emnapi/runtime@1.10.0':
+    resolution: {integrity: sha512-ewvYlk86xUoGI0zQRNq/mC+16R1QeDlKQy21Ki3oSYXNgLb45GV1P6A0M+/s6nyCuNDqe5VpaY84BzXGwVbwFA==}
 
   '@emnapi/runtime@1.7.0':
     resolution: {integrity: sha512-oAYoQnCYaQZKVS53Fq23ceWMRxq5EhQsE0x0RdQ55jT7wagMu5k+fS39v1fiSLrtrLQlXwVINenqhLMtTrV/1Q==}
 
   '@emnapi/wasi-threads@1.1.0':
     resolution: {integrity: sha512-WI0DdZ8xFSbgMjR1sFsKABJ/C5OnRrjT06JXbZKexJGrDuPTzZdDYfFlsgcCXCyf+suG5QU2e/y1Wo2V/OapLQ==}
+
+  '@emnapi/wasi-threads@1.2.1':
+    resolution: {integrity: sha512-uTII7OYF+/Mes/MrcIOYp5yOtSMLBWSIoLPpcgwipoiKbli6k322tcoFsxoIIxPDqW01SQGAgko4EzZi2BNv2w==}
 
   '@esbuild/aix-ppc64@0.27.7':
     resolution: {integrity: sha512-EKX3Qwmhz1eMdEJokhALr0YiD0lhQNwDqkPYyPhiSwKrh7/4KRjQc04sZ8db+5DVVnZ1LmbNDI1uAMPEUBnQPg==}
@@ -1401,6 +1462,9 @@ packages:
   '@oxc-project/types@0.122.0':
     resolution: {integrity: sha512-oLAl5kBpV4w69UtFZ9xqcmTi+GENWOcPF7FCrczTiBbmC0ibXxCwyvZGbO39rCVEuLGAZM84DH0pUIyyv/YJzA==}
 
+  '@oxc-project/types@0.127.0':
+    resolution: {integrity: sha512-aIYXQBo4lCbO4z0R3FHeucQHpF46l2LbMdxRvqvuRuW2OxdnSkcng5B8+K12spgLDj93rtN3+J2Vac/TIO+ciQ==}
+
   '@paralleldrive/cuid2@2.3.1':
     resolution: {integrity: sha512-XO7cAxhnTZl0Yggq6jOgjiOHhbgcO4NqFqwSmQpjK3b6TEE6Uj/jfSk6wzYyemh3+I0sHirKSetjQwn5cZktFw==}
 
@@ -1416,6 +1480,9 @@ packages:
     resolution: {integrity: sha512-PG6q63nQg5c9rIi4/Z5lR5IVF7yU5MqmKaPOe0HSc0O2cX1fPi96sUQu5j7eo4gKCkB2AnNGoWt7y4/Xx3Kcqg==}
     engines: {node: '>=18'}
     hasBin: true
+
+  '@popperjs/core@2.11.8':
+    resolution: {integrity: sha512-P1st0aksCrn9sGZhp8GMYwBnQsbvAWsZAX44oXNNvLHGqAOcoVxmjZiohstwQ7SqKnbR47akdNi+uleWD8+g6A==}
 
   '@redis/bloom@5.12.1':
     resolution: {integrity: sha512-PUUfv+ms7jgPSBVoo/DN4AkPHj4D5TZSd6SbJX7egzBplkYUcKmHRE8RKia7UtZ8bSQbLguLvxVO+asKtQfZWA==}
@@ -1463,8 +1530,20 @@ packages:
     cpu: [arm64]
     os: [android]
 
+  '@rolldown/binding-android-arm64@1.0.0-rc.17':
+    resolution: {integrity: sha512-s70pVGhw4zqGeFnXWvAzJDlvxhlRollagdCCKRgOsgUOH3N1l0LIxf83AtGzmb5SiVM4Hjl5HyarMRfdfj3DaQ==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [android]
+
   '@rolldown/binding-darwin-arm64@1.0.0-rc.12':
     resolution: {integrity: sha512-cFYr6zTG/3PXXF3pUO+umXxt1wkRK/0AYT8lDwuqvRC+LuKYWSAQAQZjCWDQpAH172ZV6ieYrNnFzVVcnSflAg==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@rolldown/binding-darwin-arm64@1.0.0-rc.17':
+    resolution: {integrity: sha512-4ksWc9n0mhlZpZ9PMZgTGjeOPRu8MB1Z3Tz0Mo02eWfWCHMW1zN82Qz/pL/rC+yQa+8ZnutMF0JjJe7PjwasYw==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [darwin]
@@ -1475,8 +1554,20 @@ packages:
     cpu: [x64]
     os: [darwin]
 
+  '@rolldown/binding-darwin-x64@1.0.0-rc.17':
+    resolution: {integrity: sha512-SUSDOI6WwUVNcWxd02QEBjLdY1VPHvlEkw6T/8nYG322iYWCTxRb1vzk4E+mWWYehTp7ERibq54LSJGjmouOsw==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [darwin]
+
   '@rolldown/binding-freebsd-x64@1.0.0-rc.12':
     resolution: {integrity: sha512-dMLeprcVsyJsKolRXyoTH3NL6qtsT0Y2xeuEA8WQJquWFXkEC4bcu1rLZZSnZRMtAqwtrF/Ib9Ddtpa/Gkge9Q==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [freebsd]
+
+  '@rolldown/binding-freebsd-x64@1.0.0-rc.17':
+    resolution: {integrity: sha512-hwnz3nw9dbJ05EDO/PvcjaaewqqDy7Y1rn1UO81l8iIK1GjenME75dl16ajbvSSMfv66WXSRCYKIqfgq2KCfxw==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [freebsd]
@@ -1487,8 +1578,21 @@ packages:
     cpu: [arm]
     os: [linux]
 
+  '@rolldown/binding-linux-arm-gnueabihf@1.0.0-rc.17':
+    resolution: {integrity: sha512-IS+W7epTcwANmFSQFrS1SivEXHtl1JtuQA9wlxrZTcNi6mx+FDOYrakGevvvTwgj2JvWiK8B29/qD9BELZPyXQ==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm]
+    os: [linux]
+
   '@rolldown/binding-linux-arm64-gnu@1.0.0-rc.12':
     resolution: {integrity: sha512-/I5AS4cIroLpslsmzXfwbe5OmWvSsrFuEw3mwvbQ1kDxJ822hFHIx+vsN/TAzNVyepI/j/GSzrtCIwQPeKCLIg==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [linux]
+    libc: [glibc]
+
+  '@rolldown/binding-linux-arm64-gnu@1.0.0-rc.17':
+    resolution: {integrity: sha512-e6usGaHKW5BMNZOymS1UcEYGowQMWcgZ71Z17Sl/h2+ZziNJ1a9n3Zvcz6LdRyIW5572wBCTH/Z+bKuZouGk9Q==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [linux]
@@ -1501,8 +1605,22 @@ packages:
     os: [linux]
     libc: [musl]
 
+  '@rolldown/binding-linux-arm64-musl@1.0.0-rc.17':
+    resolution: {integrity: sha512-b/CgbwAJpmrRLp02RPfhbudf5tZnN9nsPWK82znefso832etkem8H7FSZwxrOI9djcdTP7U6YfNhbRnh7djErg==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [linux]
+    libc: [musl]
+
   '@rolldown/binding-linux-ppc64-gnu@1.0.0-rc.12':
     resolution: {integrity: sha512-AP3E9BpcUYliZCxa3w5Kwj9OtEVDYK6sVoUzy4vTOJsjPOgdaJZKFmN4oOlX0Wp0RPV2ETfmIra9x1xuayFB7g==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [ppc64]
+    os: [linux]
+    libc: [glibc]
+
+  '@rolldown/binding-linux-ppc64-gnu@1.0.0-rc.17':
+    resolution: {integrity: sha512-4EII1iNGRUN5WwGbF/kOh/EIkoDN9HsupgLQoXfY+D1oyJm7/F4t5PYU5n8SWZgG0FEwakyM8pGgwcBYruGTlA==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [ppc64]
     os: [linux]
@@ -1515,8 +1633,22 @@ packages:
     os: [linux]
     libc: [glibc]
 
+  '@rolldown/binding-linux-s390x-gnu@1.0.0-rc.17':
+    resolution: {integrity: sha512-AH8oq3XqQo4IibpVXvPeLDI5pzkpYn0WiZAfT05kFzoJ6tQNzwRdDYQ45M8I/gslbodRZwW8uxLhbSBbkv96rA==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [s390x]
+    os: [linux]
+    libc: [glibc]
+
   '@rolldown/binding-linux-x64-gnu@1.0.0-rc.12':
     resolution: {integrity: sha512-RNrafz5bcwRy+O9e6P8Z/OCAJW/A+qtBczIqVYwTs14pf4iV1/+eKEjdOUta93q2TsT/FI0XYDP3TCky38LMAg==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [linux]
+    libc: [glibc]
+
+  '@rolldown/binding-linux-x64-gnu@1.0.0-rc.17':
+    resolution: {integrity: sha512-cLnjV3xfo7KslbU41Z7z8BH/E1y5mzUYzAqih1d1MDaIGZRCMqTijqLv76/P7fyHuvUcfGsIpqCdddbxLLK9rA==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [linux]
@@ -1529,8 +1661,21 @@ packages:
     os: [linux]
     libc: [musl]
 
+  '@rolldown/binding-linux-x64-musl@1.0.0-rc.17':
+    resolution: {integrity: sha512-0phclDw1spsL7dUB37sIARuis2tAgomCJXAHZlpt8PXZ4Ba0dRP1e+66lsRqrfhISeN9bEGNjQs+T/Fbd7oYGw==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [linux]
+    libc: [musl]
+
   '@rolldown/binding-openharmony-arm64@1.0.0-rc.12':
     resolution: {integrity: sha512-vRugONE4yMfVn0+7lUKdKvN4D5YusEiPilaoO2sgUWpCvrncvWgPMzK00ZFFJuiPgLwgFNP5eSiUlv2tfc+lpA==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [openharmony]
+
+  '@rolldown/binding-openharmony-arm64@1.0.0-rc.17':
+    resolution: {integrity: sha512-0ag/hEgXOwgw4t8QyQvUCxvEg+V0KBcA6YuOx9g0r02MprutRF5dyljgm3EmR02O292UX7UeS6HzWHAl6KgyhA==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [openharmony]
@@ -1540,8 +1685,19 @@ packages:
     engines: {node: '>=14.0.0'}
     cpu: [wasm32]
 
+  '@rolldown/binding-wasm32-wasi@1.0.0-rc.17':
+    resolution: {integrity: sha512-LEXei6vo0E5wTGwpkJ4KoT3OZJRnglwldt5ziLzOlc6qqb55z4tWNq2A+PFqCJuvWWdP53CVhG1Z9NtToDPJrA==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [wasm32]
+
   '@rolldown/binding-win32-arm64-msvc@1.0.0-rc.12':
     resolution: {integrity: sha512-5eOND4duWkwx1AzCxadcOrNeighiLwMInEADT0YM7xeEOOFcovWZCq8dadXgcRHSf3Ulh1kFo/qvzoFiCLOL1Q==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [win32]
+
+  '@rolldown/binding-win32-arm64-msvc@1.0.0-rc.17':
+    resolution: {integrity: sha512-gUmyzBl3SPMa6hrqFUth9sVfcLBlYsbMzBx5PlexMroZStgzGqlZ26pYG89rBb45Mnia+oil6YAIFeEWGWhoZA==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [win32]
@@ -1552,8 +1708,17 @@ packages:
     cpu: [x64]
     os: [win32]
 
+  '@rolldown/binding-win32-x64-msvc@1.0.0-rc.17':
+    resolution: {integrity: sha512-3hkiolcUAvPB9FLb3UZdfjVVNWherN1f/skkGWJP/fgSQhYUZpSIRr0/I8ZK9TkF3F7kxvJAk0+IcKvPHk9qQg==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [win32]
+
   '@rolldown/pluginutils@1.0.0-rc.12':
     resolution: {integrity: sha512-HHMwmarRKvoFsJorqYlFeFRzXZqCt2ETQlEDOb9aqssrnVBB1/+xgTGtuTrIk5vzLNX1MjMtTf7W9z3tsSbrxw==}
+
+  '@rolldown/pluginutils@1.0.0-rc.17':
+    resolution: {integrity: sha512-n8iosDOt6Ig1UhJ2AYqoIhHWh/isz0xpicHTzpKBeotdVsTEcxsSA/i3EVM7gQAj0rU27OLAxCjzlj15IWY7bg==}
 
   '@rollup/rollup-android-arm-eabi@4.60.0':
     resolution: {integrity: sha512-WOhNW9K8bR3kf4zLxbfg6Pxu2ybOUbB2AjMDHSQx86LIF4rH4Ft7vmMwNt0loO0eonglSNy4cpD3MKXXKQu0/A==}
@@ -1735,10 +1900,21 @@ packages:
     peerDependencies:
       storybook: ^10.3.5
 
+  '@storybook/addon-docs@10.3.6':
+    resolution: {integrity: sha512-TvIdADVPtauxW0LzXIpIv7X6GxwetorhyNh+6+7MHC27XSBCWVxxRUwL63YeLlHTuXsIk0quG3b1xgwVRzWOJA==}
+    peerDependencies:
+      storybook: ^10.3.6
+
   '@storybook/builder-vite@10.3.5':
     resolution: {integrity: sha512-i4KwCOKbhtlbQIbhm53+Kk7bMnxa0cwTn1pxmtA/x5wm1Qu7FrrBQV0V0DNjkUqzcSKo1CjspASJV/HlY0zYlw==}
     peerDependencies:
       storybook: ^10.3.5
+      vite: ^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0
+
+  '@storybook/builder-vite@10.3.6':
+    resolution: {integrity: sha512-gpvR/sE4BcrFtmQZ+Ker7zD23oQzoVeqD9nF6cK6yzY+Q0svJXyX2EPmFG4y+EwygD5/vNzDpP84gGMut8VRwg==}
+    peerDependencies:
+      storybook: ^10.3.6
       vite: ^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0
 
   '@storybook/csf-plugin@10.3.5':
@@ -1759,6 +1935,24 @@ packages:
       webpack:
         optional: true
 
+  '@storybook/csf-plugin@10.3.6':
+    resolution: {integrity: sha512-9kBf7VRdRqTSIYo+rPtVn5yjYYyK8kP2QhEYx3oiXvfwy4RexmbJnhk/tXa/lNiTqukA1TqaWQ2+5MqF4fu6YQ==}
+    peerDependencies:
+      esbuild: '*'
+      rollup: '*'
+      storybook: ^10.3.6
+      vite: '*'
+      webpack: '*'
+    peerDependenciesMeta:
+      esbuild:
+        optional: true
+      rollup:
+        optional: true
+      vite:
+        optional: true
+      webpack:
+        optional: true
+
   '@storybook/global@5.0.0':
     resolution: {integrity: sha512-FcOqPAXACP0I3oJ/ws6/rrPT9WGhu915Cg8D02a9YxLo0DE9zI+a9A5gRGvmQ09fiWPukqI8ZAEoQEdWUKMQdQ==}
 
@@ -1767,10 +1961,20 @@ packages:
     peerDependencies:
       storybook: ^10.3.5
 
+  '@storybook/html-vite@10.3.6':
+    resolution: {integrity: sha512-yurdzG3UYQdGEjzc005jPC8cFeQCLX6hQebGwTCOGBfn9ZDwmHprQctHbKPcOZ+da96wspBUSpi1H4c+PDKH3w==}
+    peerDependencies:
+      storybook: ^10.3.6
+
   '@storybook/html@10.3.5':
     resolution: {integrity: sha512-htbHaCjCMwVTFihnnjieGWFG10ixEVTKNGY7jkgp6ztH50fX5kp8N4F06eUMaFDPW+U7gcUiLIb2fv+oNIYImA==}
     peerDependencies:
       storybook: ^10.3.5
+
+  '@storybook/html@10.3.6':
+    resolution: {integrity: sha512-Ty3RsKCy3RVYu9naFluYswmqOw+B5VYHSjQpwLl7kmTxk+Ykz14js4Rj7aV1tdyH0R8SM1g1CfL6QOizNCl96g==}
+    peerDependencies:
+      storybook: ^10.3.6
 
   '@storybook/icons@2.0.1':
     resolution: {integrity: sha512-/smVjw88yK3CKsiuR71vNgWQ9+NuY2L+e8X7IMrFjexjm6ZR8ULrV2DRkTA61aV6ryefslzHEGDInGpnNeIocg==}
@@ -1784,6 +1988,13 @@ packages:
       react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
       react-dom: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
       storybook: ^10.3.5
+
+  '@storybook/react-dom-shim@10.3.6':
+    resolution: {integrity: sha512-/Tu1gPu+Fw+zOnAGmxRmOD30FX3a04LxcTAKflEtdpmtIMVR5bA3qpjy+f5YhoyDCecbXyKmL1OeIU2FIIZHqQ==}
+    peerDependencies:
+      react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
+      react-dom: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
+      storybook: ^10.3.6
 
   '@swc/cli@0.8.1':
     resolution: {integrity: sha512-L+ACCGHCiS0VqHVep/INLVnvRvJ2XooQFLZq4L8snhxw1jsqz+XRcY313UsyPVturPPE1shW3jic7rt3qEQTSQ==}
@@ -2041,6 +2252,12 @@ packages:
 
   '@types/validator@13.15.10':
     resolution: {integrity: sha512-T8L6i7wCuyoK8A/ZeLYt1+q0ty3Zb9+qbSSvrIVitzT3YjZqkTZ40IbRsPanlB4h1QB3JVL1SYCdR6ngtFYcuA==}
+
+  '@types/whatwg-mimetype@3.0.2':
+    resolution: {integrity: sha512-c2AKvDT8ToxLIOUlN51gTiHXflsfIFisS4pO7pDPoKouJCESkhZnEy623gwP9laCy5lnLDAw1vAzu2vM2YLOrA==}
+
+  '@types/ws@8.18.1':
+    resolution: {integrity: sha512-ThVF6DCVhA8kUGy+aazFQ4kXQ7E1Ty7A3ypFOe0IcJV8O/M511G99AW24irKrW56Wt44yG9+ij8FaqoBGkuBXg==}
 
   '@types/yargs-parser@21.0.3':
     resolution: {integrity: sha512-I4q9QU9MQv4oEOz4tAHJtNz1cwuLxn2F3xcc2iV5WdqLPpUnj30aUuxt1mAxYTG+oe8CZMV/+6rU4S4gRDzqtQ==}
@@ -2420,6 +2637,9 @@ packages:
   ajv@8.20.0:
     resolution: {integrity: sha512-Thbli+OlOj+iMPYFBVBfJ3OmCAnaSyNn4M1vz9T6Gka5Jt9ba/HIR56joy65tY6kx/FCF5VXNB819Y7/GUrBGA==}
 
+  animate.css@4.1.1:
+    resolution: {integrity: sha512-+mRmCTv6SbCmtYJCN4faJMNFVNN5EuCTTprDTAo7YzIGji2KADmakjVA3+8mVDkZ2Bf09vayB35lSQIex2+QaQ==}
+
   ansi-colors@4.1.3:
     resolution: {integrity: sha512-/6w/C21Pm1A7aZitlI5Ni/2J6FFQN8i1Cvz3kHABAAbw93v/NlvKdVOqz7CCWz/3iv/JplRSEEZ83XION15ovw==}
     engines: {node: '>=6'}
@@ -2512,6 +2732,9 @@ packages:
   asynckit@0.4.0:
     resolution: {integrity: sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==}
 
+  awesomplete@1.1.7:
+    resolution: {integrity: sha512-hwClzFReIIfheoMWpoJ7juLp1o6Q7YjTtEdZIGfXvhRHA9ewKM03VS4ZoK+OEFIKM066PfQt9pzRIGV1TguRBw==}
+
   axios@1.15.2:
     resolution: {integrity: sha512-wLrXxPtcrPTsNlJmKjkPnNPK2Ihe0hn0wGSaTEiHRPxwjvJwT3hKmXF4dpqxmPO9SoNb2FsYXj/xEo0gHN+D5A==}
 
@@ -2577,6 +2800,11 @@ packages:
     resolution: {integrity: sha512-lGe34o6EHj9y3Kts9R4ZYs/Gr+6N7MCaMlIFA3F1R2O5/m7K06AxfSeO5530PEERE6/WyEg3lsuyw4GHlPZHog==}
     engines: {node: ^4.5.0 || >= 5.9}
 
+  baseline-browser-mapping@2.10.24:
+    resolution: {integrity: sha512-I2NkZOOrj2XuguvWCK6OVh9GavsNjZjK908Rq3mIBK25+GD8vPX5w2WdxVqnQ7xx3SrZJiCiZFu+/Oz50oSYSA==}
+    engines: {node: '>=6.0.0'}
+    hasBin: true
+
   baseline-browser-mapping@2.9.19:
     resolution: {integrity: sha512-ipDqC8FrAl/76p2SSWKSI+H9tFwm7vYqXQrItCuiVPt26Km0jS+NzSsBWAaBusvSbQcfJG+JitdMm+wZAgTYqg==}
     hasBin: true
@@ -2630,6 +2858,11 @@ packages:
 
   browserslist@4.28.1:
     resolution: {integrity: sha512-ZC5Bd0LgJXgwGqUknZY/vkUQ04r8NXnJZ3yYi4vDmSiZmC/pdSN0NbNRPxZpbtO4uAfDUAFffO8IZoM3Gj8IkA==}
+    engines: {node: ^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7}
+    hasBin: true
+
+  browserslist@4.28.2:
+    resolution: {integrity: sha512-48xSriZYYg+8qXna9kwqjIVzuQxi+KYWp2+5nCYnYKPTr0LvD89Jqk2Or5ogxz0NUMfIjhh2lIUX/LyX9B4oIg==}
     engines: {node: ^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7}
     hasBin: true
 
@@ -2709,6 +2942,9 @@ packages:
   caniuse-lite@1.0.30001767:
     resolution: {integrity: sha512-34+zUAMhSH+r+9eKmYG+k2Rpt8XttfE4yXAjoZvkAPs15xcYQhyBYdalJ65BzivAvGRMViEjy6oKr/S91loekQ==}
 
+  caniuse-lite@1.0.30001791:
+    resolution: {integrity: sha512-yk0l/YSrOnFZk3UROpDLQD9+kC1l4meK/wed583AXrzoarMGJcbRi2Q4RaUYbKxYAsZ8sWmaSa/DsLmdBeI1vQ==}
+
   catering@2.1.1:
     resolution: {integrity: sha512-K7Qy8O9p76sL3/3m7/zLKbRkyOlSZAgzEaLhyj2mXS8PsCud2Eo4hAb8aLtZqHh0QGqLcb9dlJSu6lHRVENm1w==}
     engines: {node: '>=6'}
@@ -2757,9 +2993,15 @@ packages:
   class-validator@0.15.1:
     resolution: {integrity: sha512-LqoS80HBBSCVhz/3KloUly0ovokxpdOLR++Al3J3+dHXWt9sTKlKd4eYtoxhxyUjoe5+UcIM+5k9MIxyBWnRTw==}
 
+  class-variance-authority@0.7.1:
+    resolution: {integrity: sha512-Ka+9Trutv7G8M6WT6SeiRWz792K5qEqIGEGzXKhAE6xOWAY6pPH8U+9IY3oCMv6kqTmLsv7Xh/2w2RigkePMsg==}
+
   classic-level@1.4.1:
     resolution: {integrity: sha512-qGx/KJl3bvtOHrGau2WklEZuXhS3zme+jf+fsu6Ej7W7IP/C49v7KNlWIsT1jZu0YnfzSIYDGcEWpCa1wKGWXQ==}
     engines: {node: '>=12'}
+
+  classnames@2.5.1:
+    resolution: {integrity: sha512-saHYOzhIQs6wy2sVxTM6bUDsQO4F50V9RQ22qBpEdCW+I+/Wmke2HOl6lS6dTpdxVhb88/I6+Hs+438c3lfUow==}
 
   cli-cursor@3.1.0:
     resolution: {integrity: sha512-I/zHAwsKf9FqGoXM4WWRACob9+SNukZTd94DWF57E4toouRulbCxcUh6RKUEOQlYTHJnzkPMySvPNaaSLNfLZw==}
@@ -2796,6 +3038,10 @@ packages:
   clone@1.0.4:
     resolution: {integrity: sha512-JQHZ2QMW6l3aH/j6xCqQThY/9OH4D/9ls34cgkUBiEeocRTU04tHfKPBsUK1PqZCUQM7GiA0IIXJSuXHI64Kbg==}
     engines: {node: '>=0.8'}
+
+  clsx@2.1.1:
+    resolution: {integrity: sha512-eYm0QWBtUrBWZWG0d386OGAw16Z995PiOVo2B7bjWSbHedGl5e0ZWaq65kOGgUSNesEIDkB9ISbTg/JK9dhCZA==}
+    engines: {node: '>=6'}
 
   cluster-key-slot@1.1.2:
     resolution: {integrity: sha512-RMr0FhtfXemyinomL4hrWcYJxmX6deFdCxpJzhDttxgO1+bcCnkk+9drydLVDmAMG7NE6aN/fl4F7ucU/90gAA==}
@@ -2844,6 +3090,10 @@ packages:
   commander@6.2.1:
     resolution: {integrity: sha512-U7VdrJFnJgo4xjrHpTzu0yrHPGImdsmD95ZlgYSEajAn2JKzDhDTPG9kBTefmObL2w/ngeZnilk+OV9CG3d7UA==}
     engines: {node: '>= 6'}
+
+  commander@7.2.0:
+    resolution: {integrity: sha512-QrWXB+ZQSVPmIWIhtEO9H+gwHaMGYiF5ChvoJ+K9ZGHG/sVsa6yiesAD1GC/x46sET00Xlwo1u49RVVVzvcSkw==}
+    engines: {node: '>= 10'}
 
   commander@8.3.0:
     resolution: {integrity: sha512-OkTL9umf+He2DZkUq8f8J9of7yL6RJKI24dVITBmNfZBmri9zYZQrKkuXiKhyfPSu8tUhnVBB1iKXevvnlR4Ww==}
@@ -2968,6 +3218,10 @@ packages:
       typescript:
         optional: true
 
+  courthive-components@1.1.1:
+    resolution: {integrity: sha512-JsiR7i4ZHWudl+b8uL9vlpgzicENo36q0uqZhnFIq1ROeo9UNlEtToEBH8RVdCJA1vr2JEM9vjwTNSW+teuVCQ==}
+    engines: {node: '>=22'}
+
   create-require@1.1.1:
     resolution: {integrity: sha512-dcKFX3jn0MpIaXjisoRvexIJVEKzaq7z2rZKxf+MSr9TkdmHmsU4m2lcLojrj/FHl8mk5VxMmYA+ftRkP/3oKQ==}
 
@@ -2991,14 +3245,30 @@ packages:
   d3-array@1.2.4:
     resolution: {integrity: sha512-KHW6M86R+FUPYGb3R5XiYjXPq7VzwxZ22buHhAEVG5ztoEcZZMLov530mmccaqA1GghZArjQV46fuc8kUqhhHw==}
 
+  d3-array@3.2.4:
+    resolution: {integrity: sha512-tdQAmyA18i4J7wprpYq8ClcxZy3SC31QMeByyCFyRt7BVHdREQZ5lpzoe5mFEYZUWe+oq8HBvk9JjpibyEV4Jg==}
+    engines: {node: '>=12'}
+
   d3-axis@1.0.12:
     resolution: {integrity: sha512-ejINPfPSNdGFKEOAtnBtdkpr24c4d4jsei6Lg98mxf424ivoDP2956/5HDpIAtmHo85lqT4pruy+zEgvRUBqaQ==}
+
+  d3-axis@3.0.0:
+    resolution: {integrity: sha512-IH5tgjV4jE/GhHkRV0HiVYPDtvfjHQlQfJHs0usq7M30XcSBvOotpmH1IgkcXsO/5gEQZD43B//fc7SRT5S+xw==}
+    engines: {node: '>=12'}
 
   d3-brush@1.1.6:
     resolution: {integrity: sha512-7RW+w7HfMCPyZLifTz/UnJmI5kdkXtpCbombUSs8xniAyo0vIbrDzDwUJB6eJOgl9u5DQOt2TQlYumxzD1SvYA==}
 
+  d3-brush@3.0.0:
+    resolution: {integrity: sha512-ALnjWlVYkXsVIGlOsuWH1+3udkYFI48Ljihfnh8FZPF2QS9o+PzGLBslO0PjzVoHLZ2KCVgAM8NVkXPJB2aNnQ==}
+    engines: {node: '>=12'}
+
   d3-chord@1.0.6:
     resolution: {integrity: sha512-JXA2Dro1Fxw9rJe33Uv+Ckr5IrAa74TlfDEhE/jfLOaXegMQFQTAgAw9WnZL8+HxVBRXaRGCkrNU7pJeylRIuA==}
+
+  d3-chord@3.0.1:
+    resolution: {integrity: sha512-VE5S6TNa+j8msksl7HwjxMHDM2yNK3XCkusIlpX5kwauBfXuyLAtNg9jCp/iHH61tgI4sb6R/EIMWCqEIdjT/g==}
+    engines: {node: '>=12'}
 
   d3-collection@1.0.7:
     resolution: {integrity: sha512-ii0/r5f4sjKNTfh84Di+DpztYwqKhEyUlKoPrzUFfeSkWxjW49xU2QzO9qrPrNkpdI0XJkfzvmTu8V2Zylln6A==}
@@ -3006,75 +3276,178 @@ packages:
   d3-color@1.4.1:
     resolution: {integrity: sha512-p2sTHSLCJI2QKunbGb7ocOh7DgTAn8IrLx21QRc/BSnodXM4sv6aLQlnfpvehFMLZEfBc6g9pH9SWQccFYfJ9Q==}
 
+  d3-color@3.1.0:
+    resolution: {integrity: sha512-zg/chbXyeBtMQ1LbD/WSoW2DpC3I0mpmPdW+ynRTj/x2DAWYrIY7qeZIHidozwV24m4iavr15lNwIwLxRmOxhA==}
+    engines: {node: '>=12'}
+
   d3-contour@1.3.2:
     resolution: {integrity: sha512-hoPp4K/rJCu0ladiH6zmJUEz6+u3lgR+GSm/QdM2BBvDraU39Vr7YdDCicJcxP1z8i9B/2dJLgDC1NcvlF8WCg==}
+
+  d3-contour@4.0.2:
+    resolution: {integrity: sha512-4EzFTRIikzs47RGmdxbeUvLWtGedDUNkTcmzoeyg4sP/dvCexO47AaQL7VKy/gul85TOxw+IBgA8US2xwbToNA==}
+    engines: {node: '>=12'}
+
+  d3-delaunay@6.0.4:
+    resolution: {integrity: sha512-mdjtIZ1XLAM8bm/hx3WwjfHt6Sggek7qH043O8KEjDXN40xi3vx/6pYSVTwLjEgiXQTbvaouWKynLBiUZ6SK6A==}
+    engines: {node: '>=12'}
 
   d3-dispatch@1.0.6:
     resolution: {integrity: sha512-fVjoElzjhCEy+Hbn8KygnmMS7Or0a9sI2UzGwoB7cCtvI1XpVN9GpoYlnb3xt2YV66oXYb1fLJ8GMvP4hdU1RA==}
 
+  d3-dispatch@3.0.1:
+    resolution: {integrity: sha512-rzUyPU/S7rwUflMyLc1ETDeBj0NRuHKKAcvukozwhshr6g6c5d8zh4c2gQjY2bZ0dXeGLWc1PF174P2tVvKhfg==}
+    engines: {node: '>=12'}
+
   d3-drag@1.2.5:
     resolution: {integrity: sha512-rD1ohlkKQwMZYkQlYVCrSFxsWPzI97+W+PaEIBNTMxRuxz9RF0Hi5nJWHGVJ3Om9d2fRTe1yOBINJyy/ahV95w==}
+
+  d3-drag@3.0.0:
+    resolution: {integrity: sha512-pWbUJLdETVA8lQNJecMxoXfH6x+mO2UQo8rSmZ+QqxcbyA3hfeprFgIT//HW2nlHChWeIIMwS2Fq+gEARkhTkg==}
+    engines: {node: '>=12'}
 
   d3-dsv@1.2.0:
     resolution: {integrity: sha512-9yVlqvZcSOMhCYzniHE7EVUws7Fa1zgw+/EAV2BxJoG3ME19V6BQFBwI855XQDsxyOuG7NibqRMTtiF/Qup46g==}
     hasBin: true
 
+  d3-dsv@3.0.1:
+    resolution: {integrity: sha512-UG6OvdI5afDIFP9w4G0mNq50dSOsXHJaRE8arAS5o9ApWnIElp8GZw1Dun8vP8OyHOZ/QJUKUJwxiiCCnUwm+Q==}
+    engines: {node: '>=12'}
+    hasBin: true
+
   d3-ease@1.0.7:
     resolution: {integrity: sha512-lx14ZPYkhNx0s/2HX5sLFUI3mbasHjSSpwO/KaaNACweVwxUruKyWVcb293wMv1RqTPZyZ8kSZ2NogUZNcLOFQ==}
+
+  d3-ease@3.0.1:
+    resolution: {integrity: sha512-wR/XK3D3XcLIZwpbvQwQ5fK+8Ykds1ip7A2Txe0yxncXSdq1L9skcG7blcedkOX+ZcgxGAmLX1FrRGbADwzi0w==}
+    engines: {node: '>=12'}
 
   d3-fetch@1.2.0:
     resolution: {integrity: sha512-yC78NBVcd2zFAyR/HnUiBS7Lf6inSCoWcSxFfw8FYL7ydiqe80SazNwoffcqOfs95XaLo7yebsmQqDKSsXUtvA==}
 
+  d3-fetch@3.0.1:
+    resolution: {integrity: sha512-kpkQIM20n3oLVBKGg6oHrUchHM3xODkTzjMoj7aWQFq5QEM+R6E4WkzT5+tojDY7yjez8KgCBRoj4aEr99Fdqw==}
+    engines: {node: '>=12'}
+
   d3-force@1.2.1:
     resolution: {integrity: sha512-HHvehyaiUlVo5CxBJ0yF/xny4xoaxFxDnBXNvNcfW9adORGZfyNF1dj6DGLKyk4Yh3brP/1h3rnDzdIAwL08zg==}
+
+  d3-force@3.0.0:
+    resolution: {integrity: sha512-zxV/SsA+U4yte8051P4ECydjD/S+qeYtnaIyAs9tgHCqfguma/aAQDjo85A9Z6EKhBirHRJHXIgJUlffT4wdLg==}
+    engines: {node: '>=12'}
 
   d3-format@1.4.5:
     resolution: {integrity: sha512-J0piedu6Z8iB6TbIGfZgDzfXxUFN3qQRMofy2oPdXzQibYGqPB/9iMcxr/TGalU+2RsyDO+U4f33id8tbnSRMQ==}
 
+  d3-format@3.1.2:
+    resolution: {integrity: sha512-AJDdYOdnyRDV5b6ArilzCPPwc1ejkHcoyFarqlPqT7zRYjhavcT3uSrqcMvsgh2CgoPbK3RCwyHaVyxYcP2Arg==}
+    engines: {node: '>=12'}
+
   d3-geo@1.12.1:
     resolution: {integrity: sha512-XG4d1c/UJSEX9NfU02KwBL6BYPj8YKHxgBEw5om2ZnTRSbIcego6dhHwcxuSR3clxh0EpE38os1DVPOmnYtTPg==}
+
+  d3-geo@3.1.1:
+    resolution: {integrity: sha512-637ln3gXKXOwhalDzinUgY83KzNWZRKbYubaG+fGVuc/dxO64RRljtCTnf5ecMyE1RIdtqpkVcq0IbtU2S8j2Q==}
+    engines: {node: '>=12'}
 
   d3-hierarchy@1.1.9:
     resolution: {integrity: sha512-j8tPxlqh1srJHAtxfvOUwKNYJkQuBFdM1+JAUfq6xqH5eAqf93L7oG1NVqDa4CpFZNvnNKtCYEUC8KY9yEn9lQ==}
 
+  d3-hierarchy@3.1.2:
+    resolution: {integrity: sha512-FX/9frcub54beBdugHjDCdikxThEqjnR93Qt7PvQTOHxyiNCAlvMrHhclk3cD5VeAaq9fxmfRp+CnWw9rEMBuA==}
+    engines: {node: '>=12'}
+
   d3-interpolate@1.4.0:
     resolution: {integrity: sha512-V9znK0zc3jOPV4VD2zZn0sDhZU3WAE2bmlxdIwwQPPzPjvyLkd8B3JUVdS1IDUFDkWZ72c9qnv1GK2ZagTZ8EA==}
+
+  d3-interpolate@3.0.1:
+    resolution: {integrity: sha512-3bYs1rOD33uo8aqJfKP3JWPAibgw8Zm2+L9vBKEHJ2Rg+viTR7o5Mmv5mZcieN+FRYaAOWX5SJATX6k1PWz72g==}
+    engines: {node: '>=12'}
 
   d3-path@1.0.9:
     resolution: {integrity: sha512-VLaYcn81dtHVTjEHd8B+pbe9yHWpXKZUC87PzoFmsFrJqgFwDe/qxfp5MlfsfM1V5E/iVt0MmEbWQ7FVIXh/bg==}
 
+  d3-path@3.1.0:
+    resolution: {integrity: sha512-p3KP5HCf/bvjBSSKuXid6Zqijx7wIfNW+J/maPs+iwR35at5JCbLUT0LzF1cnjbCHWhqzQTIN2Jpe8pRebIEFQ==}
+    engines: {node: '>=12'}
+
   d3-polygon@1.0.6:
     resolution: {integrity: sha512-k+RF7WvI08PC8reEoXa/w2nSg5AUMTi+peBD9cmFc+0ixHfbs4QmxxkarVal1IkVkgxVuk9JSHhJURHiyHKAuQ==}
+
+  d3-polygon@3.0.1:
+    resolution: {integrity: sha512-3vbA7vXYwfe1SYhED++fPUQlWSYTTGmFmQiany/gdbiWgU/iEyQzyymwL9SkJjFFuCS4902BSzewVGsHHmHtXg==}
+    engines: {node: '>=12'}
 
   d3-quadtree@1.0.7:
     resolution: {integrity: sha512-RKPAeXnkC59IDGD0Wu5mANy0Q2V28L+fNe65pOCXVdVuTJS3WPKaJlFHer32Rbh9gIo9qMuJXio8ra4+YmIymA==}
 
+  d3-quadtree@3.0.1:
+    resolution: {integrity: sha512-04xDrxQTDTCFwP5H6hRhsRcb9xxv2RzkcsygFzmkSIOJy3PeRJP7sNk3VRIbKXcog561P9oU0/rVH6vDROAgUw==}
+    engines: {node: '>=12'}
+
   d3-random@1.1.2:
     resolution: {integrity: sha512-6AK5BNpIFqP+cx/sreKzNjWbwZQCSUatxq+pPRmFIQaWuoD+NrbVWw7YWpHiXpCQ/NanKdtGDuB+VQcZDaEmYQ==}
+
+  d3-random@3.0.1:
+    resolution: {integrity: sha512-FXMe9GfxTxqd5D6jFsQ+DJ8BJS4E/fT5mqqdjovykEB2oFbTMDVdg1MGFxfQW+FBOGoB++k8swBrgwSHT1cUXQ==}
+    engines: {node: '>=12'}
 
   d3-scale-chromatic@1.5.0:
     resolution: {integrity: sha512-ACcL46DYImpRFMBcpk9HhtIyC7bTBR4fNOPxwVSl0LfulDAwyiHyPOTqcDG1+t5d4P9W7t/2NAuWu59aKko/cg==}
 
+  d3-scale-chromatic@3.1.0:
+    resolution: {integrity: sha512-A3s5PWiZ9YCXFye1o246KoscMWqf8BsD9eRiJ3He7C9OBaxKhAd5TFCdEx/7VbKtxxTsu//1mMJFrEt572cEyQ==}
+    engines: {node: '>=12'}
+
   d3-scale@2.2.2:
     resolution: {integrity: sha512-LbeEvGgIb8UMcAa0EATLNX0lelKWGYDQiPdHj+gLblGVhGLyNbaCn3EvrJf0A3Y/uOOU5aD6MTh5ZFCdEwGiCw==}
+
+  d3-scale@4.0.2:
+    resolution: {integrity: sha512-GZW464g1SH7ag3Y7hXjf8RoUuAFIqklOAq3MRl4OaWabTFJY9PN/E1YklhXLh+OQ3fM9yS2nOkCoS+WLZ6kvxQ==}
+    engines: {node: '>=12'}
 
   d3-selection@1.4.2:
     resolution: {integrity: sha512-SJ0BqYihzOjDnnlfyeHT0e30k0K1+5sR3d5fNueCNeuhZTnGw4M4o8mqJchSwgKMXCNFo+e2VTChiSJ0vYtXkg==}
 
+  d3-selection@3.0.0:
+    resolution: {integrity: sha512-fmTRWbNMmsmWq6xJV8D19U/gw/bwrHfNXxrIN+HfZgnzqTHp9jOmKMhsTUjXOJnZOdZY9Q28y4yebKzqDKlxlQ==}
+    engines: {node: '>=12'}
+
   d3-shape@1.3.7:
     resolution: {integrity: sha512-EUkvKjqPFUAZyOlhY5gzCxCeI0Aep04LwIRpsZ/mLFelJiUfnK56jo5JMDSE7yyP2kLSb6LtF+S5chMk7uqPqw==}
+
+  d3-shape@3.2.0:
+    resolution: {integrity: sha512-SaLBuwGm3MOViRq2ABk3eLoxwZELpH6zhl3FbAoJ7Vm1gofKx6El1Ib5z23NUEhF9AsGl7y+dzLe5Cw2AArGTA==}
+    engines: {node: '>=12'}
 
   d3-time-format@2.3.0:
     resolution: {integrity: sha512-guv6b2H37s2Uq/GefleCDtbe0XZAuy7Wa49VGkPVPMfLL9qObgBST3lEHJBMUp8S7NdLQAGIvr2KXk8Hc98iKQ==}
 
+  d3-time-format@4.1.0:
+    resolution: {integrity: sha512-dJxPBlzC7NugB2PDLwo9Q8JiTR3M3e4/XANkreKSUxF8vvXKqm1Yfq4Q5dl8budlunRVlUUaDUgFt7eA8D6NLg==}
+    engines: {node: '>=12'}
+
   d3-time@1.1.0:
     resolution: {integrity: sha512-Xh0isrZ5rPYYdqhAVk8VLnMEidhz5aP7htAADH6MfzgmmicPkTo8LhkLxci61/lCB7n7UmE3bN0leRt+qvkLxA==}
+
+  d3-time@3.1.0:
+    resolution: {integrity: sha512-VqKjzBLejbSMT4IgbmVgDjpkYrNWUYJnbCGo874u7MMKIWsILRX+OpX/gTk8MqjpT1A/c6HY2dCA77ZN0lkQ2Q==}
+    engines: {node: '>=12'}
 
   d3-timer@1.0.10:
     resolution: {integrity: sha512-B1JDm0XDaQC+uvo4DT79H0XmBskgS3l6Ve+1SBCfxgmtIb1AVrPIoqd+nPSv+loMX8szQ0sVUhGngL7D5QPiXw==}
 
+  d3-timer@3.0.1:
+    resolution: {integrity: sha512-ndfJ/JxxMd3nw31uyKoY2naivF+r29V+Lc0svZxe1JvvIRmi8hUsrMvdOwgS1o6uBHmiz91geQ0ylPP0aj1VUA==}
+    engines: {node: '>=12'}
+
   d3-transition@1.3.2:
     resolution: {integrity: sha512-sc0gRU4PFqZ47lPVHloMn9tlPcv8jxgOQg+0zjhfZXMQuvppjG6YuwdMBE0TuqCZjeJkLecku/l9R0JPcRhaDA==}
+
+  d3-transition@3.0.1:
+    resolution: {integrity: sha512-ApKvfjsSR6tg06xrL434C0WydLr7JewBB3V+/39RMHsaXTOG0zmt/OAXeng5M5LBm0ojmxJrpomQVZ1aPvBL4w==}
+    engines: {node: '>=12'}
+    peerDependencies:
+      d3-selection: 2 - 3
 
   d3-voronoi@1.1.4:
     resolution: {integrity: sha512-dArJ32hchFsrQ8uMiTBLq256MpnZjeuBtdHpaDlYuQyjU0CVzCJl/BVW+SkszaAeH95D/8gxqAhgx0ouAWAfRg==}
@@ -3082,8 +3455,16 @@ packages:
   d3-zoom@1.8.3:
     resolution: {integrity: sha512-VoLXTK4wvy1a0JpH2Il+F2CiOhVu7VRXWF5M/LroMIh3/zBAC3WAt7QoIvPibOavVo20hN6/37vwAsdBejLyKQ==}
 
+  d3-zoom@3.0.0:
+    resolution: {integrity: sha512-b8AmV3kfQaqWAuacbPuNbL6vahnOJflOhexLzMMNLga62+/nh0JzvJ0aO/5a5MVgUFGS7Hu1P9P03o3fJkDCyw==}
+    engines: {node: '>=12'}
+
   d3@5.16.0:
     resolution: {integrity: sha512-4PL5hHaHwX4m7Zr1UapXW23apo6pexCgdetdJ5kTmADpG/7T9Gkxw0M0tf/pjoB63ezCCm0u5UaFYy2aMt0Mcw==}
+
+  d3@7.9.0:
+    resolution: {integrity: sha512-e1U46jVP+w7Iut8Jt8ri1YsPOvFpg46k+K8TpCb0P+zjCkjkPnV7WzfDJzMHy1LnA+wj5pLT1wjO901gLXeEhA==}
+    engines: {node: '>=12'}
 
   date-fns@2.30.0:
     resolution: {integrity: sha512-fnULvOpxnC5/Vg3NCiWelDsLiUc9bRwAPs/+LfTLNvetFCtCTN+yQz15C/fs4AwX1R9K5GLtLfn8QW+dWisaAw==}
@@ -3091,6 +3472,9 @@ packages:
 
   dayjs@1.11.10:
     resolution: {integrity: sha512-vjAczensTgRcqDERK0SR2XMwsF/tSvnvlv6VcF2GIhg6Sx4yOIt/irsr1RDJsKiIyBzJDpCoXiWWq28MqH2cnQ==}
+
+  dayjs@1.11.20:
+    resolution: {integrity: sha512-YbwwqR/uYpeoP4pu043q+LTDLFBLApUP6VxRihdfNTqu4ubqMlGDLd6ErXhEgsyvY0K6nCs7nggYumAN+9uEuQ==}
 
   debug@2.6.9:
     resolution: {integrity: sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==}
@@ -3159,6 +3543,9 @@ packages:
   define-lazy-prop@3.0.0:
     resolution: {integrity: sha512-N+MeXYoqr3pOgn8xfyRPREN7gHakLYjhsHhWGT3fWAiL4IkAt0iDw14QiiEm2bE30c5XX5q0FtAA3CK5f9/BUg==}
     engines: {node: '>=12'}
+
+  delaunator@5.1.0:
+    resolution: {integrity: sha512-AGrQ4QSgssa1NGmWmLPqN5NY2KajF5MqxetNEO+o0n3ZwZZeTmt7bBnvzHWrmkZFxGgr4HdyFgelzgi06otLuQ==}
 
   delayed-stream@1.0.0:
     resolution: {integrity: sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==}
@@ -3259,6 +3646,9 @@ packages:
   electron-to-chromium@1.5.286:
     resolution: {integrity: sha512-9tfDXhJ4RKFNerfjdCcZfufu49vg620741MNs26a9+bhLThdB+plgMeou98CAaHu/WATj2iHOOHTp1hWtABj2A==}
 
+  electron-to-chromium@1.5.348:
+    resolution: {integrity: sha512-QC2X59nRlycQQMc4ZXjSVBX+tSgJfgRtcrYHbIZLgOV2dCvefoQGegLR7lLXKgpPpSuVmJU19LMzGrSa2C7k3Q==}
+
   email-addresses@5.0.0:
     resolution: {integrity: sha512-4OIPYlA6JXqtVn8zpHpGiI7vE6EQOAg16aGnDMIAlZVinnoZ8208tW1hAbjWydgN/4PLTT9q+O1K6AH/vALJGw==}
 
@@ -3302,8 +3692,16 @@ packages:
     resolution: {integrity: sha512-Qohcme7V1inbAfvjItgw0EaxVX5q2rdVEZHRBrEQdRZTssLDGsL8Lwrznl8oQ/6kuTJONLaDcGjkNP247XEhcA==}
     engines: {node: '>=10.13.0'}
 
+  enhanced-resolve@5.21.0:
+    resolution: {integrity: sha512-otxSQPw4lkOZWkHpB3zaEQs6gWYEsmX4xQF68ElXC/TWvGxGMSGOvoNbaLXm6/cS/fSfHtsEdw90y20PCd+sCA==}
+    engines: {node: '>=10.13.0'}
+
   entities@4.5.0:
     resolution: {integrity: sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw==}
+    engines: {node: '>=0.12'}
+
+  entities@7.0.1:
+    resolution: {integrity: sha512-TWrgLOFUQTH994YUyl1yT4uyavY5nNB5muff+RtWaqNVCAK408b5ZnnbNAUEWLTCpum9w6arT70i1XdQ4UeOPA==}
     engines: {node: '>=0.12'}
 
   env-paths@2.2.1:
@@ -3327,6 +3725,9 @@ packages:
 
   es-module-lexer@2.0.0:
     resolution: {integrity: sha512-5POEcUuZybH7IdmGsD8wlf0AI55wMecM9rVBTI/qEAy2c1kTOm3DjFYjrBdI2K3BaJjJYfYFeRtM0t9ssnRuxw==}
+
+  es-module-lexer@2.1.0:
+    resolution: {integrity: sha512-n27zTYMjYu1aj4MjCWzSP7G9r75utsaoc8m61weK+W8JMBGGQybd43GstCXZ3WNmSFtGT9wi59qQTW6mhTR5LQ==}
 
   es-object-atoms@1.1.1:
     resolution: {integrity: sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA==}
@@ -3609,6 +4010,9 @@ packages:
   flatted@3.3.3:
     resolution: {integrity: sha512-GX+ysw4PBCz0PzosHDepZGANEuFCMLrnRTiEy9McGjmkCQYwRq4A/X786G/fjM/+OjsWSU1ZrY5qyARZmO/uwg==}
 
+  focus-trap@8.1.0:
+    resolution: {integrity: sha512-T65crff26CKV2CZ3csg5y05r+560srp0b8EbAif35euW58hzklVf/Gb4Q+/HCtB8e9III3QFEyk5BWV5XJuOyw==}
+
   follow-redirects@1.16.0:
     resolution: {integrity: sha512-y5rN/uOsadFT/JfYwhxRS5R7Qce+g3zG97+JrtFZlC9klX/W5hD7iiLzScI4nZqUS7DNUdhPgw4xI8W2LuXlUw==}
     engines: {node: '>=4.0'}
@@ -3792,6 +4196,10 @@ packages:
     engines: {node: '>=0.4.7'}
     hasBin: true
 
+  happy-dom@20.9.0:
+    resolution: {integrity: sha512-GZZ9mKe8r646NUAf/zemnGbjYh4Bt8/MqASJY+pSm5ZDtc3YQox+4gsLI7yi1hba6o+eCsGxpHn5+iEVn31/FQ==}
+    engines: {node: '>=20.0.0'}
+
   has-flag@4.0.0:
     resolution: {integrity: sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==}
     engines: {node: '>=8'}
@@ -3808,8 +4216,8 @@ packages:
     resolution: {integrity: sha512-nhQ6ExaOIqti2FDWoEMWARUqIKyjr2VcZzXShrI+A3zpeiuPWzx6iPftt44LhP74E5sW36B75N6VHbvRtpvO6Q==}
     engines: {node: '>=20'}
 
-  hasown@2.0.2:
-    resolution: {integrity: sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==}
+  hasown@2.0.3:
+    resolution: {integrity: sha512-ej4AhfhfL2Q2zpMmLo7U1Uv9+PyhIZpgQLGT1F9miIGmiCJIoCgSmczFdrc97mWT4kVY72KA+WnnhJ5pghSvSg==}
     engines: {node: '>= 0.4'}
 
   he@1.2.0:
@@ -3854,8 +4262,20 @@ packages:
     engines: {node: '>=18'}
     hasBin: true
 
+  i18next@26.0.8:
+    resolution: {integrity: sha512-BRzLom0mhDhV9v0QhgUUHWQJuwFmnr1194xEcNLYD6ym8y8s542n4jXUvRLnhNTbh9PmpU6kGZamyuGHQMsGjw==}
+    peerDependencies:
+      typescript: ^5 || ^6
+    peerDependenciesMeta:
+      typescript:
+        optional: true
+
   iconv-lite@0.4.24:
     resolution: {integrity: sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==}
+    engines: {node: '>=0.10.0'}
+
+  iconv-lite@0.6.3:
+    resolution: {integrity: sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==}
     engines: {node: '>=0.10.0'}
 
   iconv-lite@0.7.0:
@@ -3906,6 +4326,10 @@ packages:
 
   inspect-with-kind@1.0.5:
     resolution: {integrity: sha512-MAQUJuIo7Xqk8EVNP+6d3CKq9c80hi4tjIbIAT6lmGW9W6WzlHiu9PS8uSuUYU+Do+j1baiFp3H25XEVxDIG2g==}
+
+  internmap@2.0.3:
+    resolution: {integrity: sha512-5Hh7Y1wQbvY5ooGgPbDaL5iYLAPzMTUrjMulskHLH6wnv/A+1q5rgEaiuqEjB+oxGXIVZs1FF+R/KPN3ZSQYYg==}
+    engines: {node: '>=12'}
 
   ipaddr.js@1.9.1:
     resolution: {integrity: sha512-0KI/607xoxSToH7GjN1FfSbLoU0+btTicjsQSWQlh/hZykN8KpmMf7uYwPW3R+akZ6R/w18ZlXSHBYXiYUPO3g==}
@@ -4241,6 +4665,10 @@ packages:
   jws@4.0.1:
     resolution: {integrity: sha512-EKI/M/yqPncGUUh44xz0PxSidXFr/+r0pA70+gIYhjv+et7yxM+s29Y+VGDkovRofQem0fs7Uvf4+YmAdyRduA==}
 
+  jwt-decode@4.0.0:
+    resolution: {integrity: sha512-+KJGIyHgkGuIq3IEBNftfhW/LfWhXUIY6OmyVWjliu5KH1y0fw7VQ8YndE2O4qZdMSd9SqbnC8GOcZEy0Om7sA==}
+    engines: {node: '>=18'}
+
   keyv@4.5.4:
     resolution: {integrity: sha512-oxVHkHR/EJf2CNXnWxRLW6mg7JyCCUcG0DtEGmL2ctUo1PNTin1PUil+r/+4r5MpVgC/fn1kjsx7mjSujKqIpw==}
 
@@ -4366,6 +4794,10 @@ packages:
 
   loader-runner@4.3.1:
     resolution: {integrity: sha512-IWqP2SCPhyVFTBtRcgMHdzlf9ul25NwaFx4wCEH/KjAXuuHY4yNjvPXsBokp8jCB936PyWRaPKUNh8NvylLp2Q==}
+    engines: {node: '>=6.11.5'}
+
+  loader-runner@4.3.2:
+    resolution: {integrity: sha512-DFEqQ3ihfS9blba08cLfYf1NRAIEm+dDjic073DRDc3/JspI/8wYmtDsHwd3+4hwvdxSK7PGaElfTmm0awWJ4w==}
     engines: {node: '>=6.11.5'}
 
   locate-path@5.0.0:
@@ -4618,6 +5050,11 @@ packages:
     engines: {node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1}
     hasBin: true
 
+  nanoid@3.3.12:
+    resolution: {integrity: sha512-ZB9RH/39qpq5Vu6Y+NmUaFhQR6pp+M2Xt76XBnEwDaGcVAqhlvxrl3B2bKS5D3NH3QR76v3aSrKaF/Kiy7lEtQ==}
+    engines: {node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1}
+    hasBin: true
+
   napi-macros@2.2.2:
     resolution: {integrity: sha512-hmEVtAGYzVQpCKdbQea4skABsdXW4RUh5t5mJ2zzqowJS2OyXZTU1KhDVFhx+NlWZ4ap9mqR9TcDO3LTTttd+g==}
 
@@ -4628,6 +5065,9 @@ packages:
 
   natural-compare@1.4.0:
     resolution: {integrity: sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==}
+
+  navigo@8.11.1:
+    resolution: {integrity: sha512-e3sc1UzakF+bWquC8/dbPCgo7LgPEW1ekgwb4pmEcl8tOc/I7lML8r7HBql+b0VRk7tJWTZqtkeObwJAVR1pxg==}
 
   negotiator@0.6.3:
     resolution: {integrity: sha512-+EUsqGPLsM+j/zdChZjsnX51g4XrHFOIXwfnCVPGlQk/k5giakcKsuxCObBRu6DSm9opw/O6slWbJdghQM4bBg==}
@@ -4662,6 +5102,9 @@ packages:
 
   node-releases@2.0.27:
     resolution: {integrity: sha512-nmh3lCkYZ3grZvqcCH+fjmQ7X+H0OeZgP40OierEaAptX4XofMh5kwNbWh7lBduUzCcV/8kZ+NDLCwm2iorIlA==}
+
+  node-releases@2.0.38:
+    resolution: {integrity: sha512-3qT/88Y3FbH/Kx4szpQQ4HzUbVrHPKTLVpVocKiLfoYvw9XSGOX2FmD2d6DrXbVYyAQTF2HeF6My8jmzx7/CRw==}
 
   normalize-path@3.0.0:
     resolution: {integrity: sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==}
@@ -4917,6 +5360,10 @@ packages:
     resolution: {integrity: sha512-pMMHxBOZKFU6HgAZ4eyGnwXF/EvPGGqUr0MnZ5+99485wwW41kW91A4LOGxSHhgugZmSChL5AlElNdwlNgcnLQ==}
     engines: {node: ^10 || ^12 || >=14}
 
+  postcss@8.5.13:
+    resolution: {integrity: sha512-qif0+jGGZoLWdHey3UFHHWP0H7Gbmsk8T5VEqyYFbWqPr1XqvLGBbk/sl8V5exGmcYJklJOhOQq1pV9IcsiFag==}
+    engines: {node: ^10 || ^12 || >=14}
+
   postgres-array@2.0.0:
     resolution: {integrity: sha512-VpZrUqU5A69eQyW2c5CA1jtLecCsN2U/bD6VilrFDWq5+5UIEVO7nazS3TEcHf1zuPYO/sqGvUvW62g86RXZuA==}
     engines: {node: '>=4'}
@@ -5013,6 +5460,11 @@ packages:
     peerDependencies:
       react: ^19.2.4
 
+  react-dom@19.2.5:
+    resolution: {integrity: sha512-J5bAZz+DXMMwW/wV3xzKke59Af6CHY7G4uYLN1OvBcKEsWOs4pQExj86BBKamxl/Ik5bx9whOrvBlSDfWzgSag==}
+    peerDependencies:
+      react: ^19.2.5
+
   react-is@17.0.2:
     resolution: {integrity: sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==}
 
@@ -5021,6 +5473,10 @@ packages:
 
   react@19.2.4:
     resolution: {integrity: sha512-9nfp2hYpCwOjAN+8TZFGhtWEwgvWHXqESH8qT89AT/lWklpLON22Lc8pEtnpsZz7VmawabSU0gCjnj8aC0euHQ==}
+    engines: {node: '>=0.10.0'}
+
+  react@19.2.5:
+    resolution: {integrity: sha512-llUJLzz1zTUBrskt2pwZgLq59AemifIftw4aB7JxOqf1HY2FDaGDxgwpAPVzHU1kdWabH7FauP4i1oEeer2WCA==}
     engines: {node: '>=0.10.0'}
 
   readable-stream@3.6.2:
@@ -5104,8 +5560,16 @@ packages:
     engines: {node: 20 || >=22}
     hasBin: true
 
+  robust-predicates@3.0.3:
+    resolution: {integrity: sha512-NS3levdsRIUOmiJ8FZWCP7LG3QpJyrs/TE0Zpf1yvZu8cAJJ6QMW92H1c7kWpdIHo8RvmLxN/o2JXTKHp74lUA==}
+
   rolldown@1.0.0-rc.12:
     resolution: {integrity: sha512-yP4USLIMYrwpPHEFB5JGH1uxhcslv6/hL0OyvTuY+3qlOSJvZ7ntYnoWpehBxufkgN0cvXxppuTu5hHa/zPh+A==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    hasBin: true
+
+  rolldown@1.0.0-rc.17:
+    resolution: {integrity: sha512-ZrT53oAKrtA4+YtBWPQbtPOxIbVDbxT0orcYERKd63VJTF13zPcgXTvD4843L8pcsI7M6MErt8QtON6lrB9tyA==}
     engines: {node: ^20.19.0 || >=22.12.0}
     hasBin: true
 
@@ -5315,6 +5779,18 @@ packages:
       prettier:
         optional: true
 
+  storybook@10.3.6:
+    resolution: {integrity: sha512-vbSz7g/1rGMC1uAULqMZjALkIuLu2QABqfhRYhyr/11kzyesi+vAmwyJLukZP1FfecxGOgMwOh6GS0YsGpHAvQ==}
+    hasBin: true
+    peerDependencies:
+      prettier: ^2 || ^3
+      vite-plus: ^0.1.15
+    peerDependenciesMeta:
+      prettier:
+        optional: true
+      vite-plus:
+        optional: true
+
   streamsearch@1.1.0:
     resolution: {integrity: sha512-Mcc5wHehp9aXz1ax6bZUyY5afg9u2rv5cqQI3mRrYkGC8rW2hM02jWuwjtL++LS5qinSyhj2QfLyNsuc+VsExg==}
     engines: {node: '>=10.0.0'}
@@ -5427,8 +5903,18 @@ packages:
     resolution: {integrity: sha512-Bh7QjT8/SuKUIfObSXNHNSK6WHo6J1tHCqJsuaFDP7gP0fkzSfTxI8y85JrppZ0h8l0maIgc2tfuZQ6/t3GtnQ==}
     engines: {node: ^14.18.0 || >=16.0.0}
 
+  tabbable@6.4.0:
+    resolution: {integrity: sha512-05PUHKSNE8ou2dwIxTngl4EzcnsCDZGJ/iCLtDflR/SHB/ny14rXc+qU5P4mG9JkusiV7EivzY9Mhm55AzAvCg==}
+
+  tabulator-tables@6.4.0:
+    resolution: {integrity: sha512-Lxh+leFNoBo/Yyr4USs6gxqbfo8anYUaUMmoT91pfVLtoUgl/dE+qV7ahnFrKVMCYYqGG33aIMPR7FzpPBaNYA==}
+
   tapable@2.3.0:
     resolution: {integrity: sha512-g9ljZiwki/LfxmQADO3dEY1CbpmXT5Hm2fJ+QaGKwSXUylMybePR7/67YW7jOrrvjEgL1Fmz5kzyAjWVWLlucg==}
+    engines: {node: '>=6'}
+
+  tapable@2.3.3:
+    resolution: {integrity: sha512-uxc/zpqFg6x7C8vOE7lh6Lbda8eEL9zmVm/PLeTPBRhh1xCgdWaQ+J1CUieGpIfm2HdtsUpRv+HshiasBMcc6A==}
     engines: {node: '>=6'}
 
   tar-stream@3.1.7:
@@ -5436,6 +5922,22 @@ packages:
 
   terser-webpack-plugin@5.4.0:
     resolution: {integrity: sha512-Bn5vxm48flOIfkdl5CaD2+1CiUVbonWQ3KQPyP7/EuIl9Gbzq/gQFOzaMFUEgVjB1396tcK0SG8XcNJ/2kDH8g==}
+    engines: {node: '>= 10.13.0'}
+    peerDependencies:
+      '@swc/core': '*'
+      esbuild: '*'
+      uglify-js: '*'
+      webpack: ^5.1.0
+    peerDependenciesMeta:
+      '@swc/core':
+        optional: true
+      esbuild:
+        optional: true
+      uglify-js:
+        optional: true
+
+  terser-webpack-plugin@5.5.0:
+    resolution: {integrity: sha512-UYhptBwhWvfIjKd/UuFo6D8uq9xpGLDK+z8EDsj/zWhrTaH34cKEbrkMKfV5YWqGBvAYA3tlzZbs2R+qYrbQJA==}
     engines: {node: '>= 10.13.0'}
     peerDependencies:
       '@swc/core': '*'
@@ -5469,6 +5971,9 @@ packages:
     resolution: {integrity: sha512-75voc/9G4rDIJleOo4jPvN4/YC4GRZrY8yy1uU4lwrB3XEQbWve8zXoO5No4eFrGcTAMYyoY67p8jRQdtA1HbA==}
     engines: {node: '>=12'}
 
+  timepicker-ui@4.3.0:
+    resolution: {integrity: sha512-Gw6QFGKvgrs9OOqFGT84/5g27t/YHMzTY1n0BOSZitnBLWH+ZKBxT73Nn/J7qMKGwZ70eqX+Jn99NzGAvwrwEA==}
+
   tiny-invariant@1.3.3:
     resolution: {integrity: sha512-+FbBPE1o9QAYvviau/qC5SE3caw21q3xkvWKBtja5vgqOWIHHJ3ioaq1VPfn/Szqctz2bU/oYeKd9/z5BL+PVg==}
 
@@ -5481,6 +5986,10 @@ packages:
 
   tinyexec@1.1.1:
     resolution: {integrity: sha512-VKS/ZaQhhkKFMANmAOhhXVoIfBXblQxGX1myCQ2faQrfmobMftXeJPcZGp0gS07ocvGJWDLZGyOZDadDBqYIJg==}
+    engines: {node: '>=18'}
+
+  tinyexec@1.1.2:
+    resolution: {integrity: sha512-dAqSqE/RabpBKI8+h26GfLq6Vb3JVXs30XYQjdMjaj/c2tS8IYYMbIzP599KtRj7c57/wYApb3QjgRgXmrCukA==}
     engines: {node: '>=18'}
 
   tinyglobby@0.2.15:
@@ -5502,6 +6011,9 @@ packages:
   tinyspy@4.0.4:
     resolution: {integrity: sha512-azl+t0z7pw/z958Gy9svOTuzqIk6xq+NSheJzn5MMWtWTFywIacg2wUlzKFGtt3cthx0r2SxMK0yzJOR0IES7Q==}
     engines: {node: '>=14.0.0'}
+
+  tippy.js@6.3.7:
+    resolution: {integrity: sha512-E1d3oP2emgJ9dRQZdf3Kkn0qJgI6ZLpyS5z6ZkY1DF3kaQaBsGZsndEpHwx+eC+tYM41HaSNvNtLx8tU57FzTQ==}
 
   tmpl@1.0.5:
     resolution: {integrity: sha512-3f0uOEAQwIqGuWW2MVzYg8fV/QNnc/IpuJNG837rLuczAaLVHslWHZQj4IGiEl5Hs3kkbhwL9Ab7Hrsmuj+Smw==}
@@ -5710,9 +6222,55 @@ packages:
     resolution: {integrity: sha512-spH26xU080ydGggxRyR1Yhcbgx+j3y5jbNXk/8L+iRvdIEQ4uTRH2Sgf2dokud6Q4oAtsbNvJ1Ft+9xmm6IZcA==}
     engines: {node: '>= 0.10'}
 
+  vanillajs-datepicker@1.3.4:
+    resolution: {integrity: sha512-waOyp2Ay+K1VA/B5cNlFgSNzFR9efCVKaoyMyNEAhAwmKLzMB9nCJs6Vqmo6HuHWA98VEHXbgz5thZ7hH/uohA==}
+
   vary@1.1.2:
     resolution: {integrity: sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg==}
     engines: {node: '>= 0.8'}
+
+  vite@8.0.10:
+    resolution: {integrity: sha512-rZuUu9j6J5uotLDs+cAA4O5H4K1SfPliUlQwqa6YEwSrWDZzP4rhm00oJR5snMewjxF5V/K3D4kctsUTsIU9Mw==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    hasBin: true
+    peerDependencies:
+      '@types/node': ^20.19.0 || >=22.12.0
+      '@vitejs/devtools': ^0.1.0
+      esbuild: ^0.27.0 || ^0.28.0
+      jiti: '>=1.21.0'
+      less: ^4.0.0
+      sass: ^1.70.0
+      sass-embedded: ^1.70.0
+      stylus: '>=0.54.8'
+      sugarss: ^5.0.0
+      terser: ^5.16.0
+      tsx: ^4.8.1
+      yaml: ^2.4.2
+    peerDependenciesMeta:
+      '@types/node':
+        optional: true
+      '@vitejs/devtools':
+        optional: true
+      esbuild:
+        optional: true
+      jiti:
+        optional: true
+      less:
+        optional: true
+      sass:
+        optional: true
+      sass-embedded:
+        optional: true
+      stylus:
+        optional: true
+      sugarss:
+        optional: true
+      terser:
+        optional: true
+      tsx:
+        optional: true
+      yaml:
+        optional: true
 
   vite@8.0.3:
     resolution: {integrity: sha512-B9ifbFudT1TFhfltfaIPgjo9Z3mDynBTJSUYxTjOQruf/zHH+ezCQKcoqO+h7a9Pw9Nm/OtlXAiGT1axBgwqrQ==}
@@ -5819,6 +6377,10 @@ packages:
     resolution: {integrity: sha512-7tP1PdV4vF+lYPnkMR0jMY5/la2ub5Fc/8VQrrU+lXkiM6C4TjVfGw7iKfyhnTQOsD+6Q/iKw0eFciziRgD58Q==}
     engines: {node: '>=10.13.0'}
 
+  webpack-sources@3.4.1:
+    resolution: {integrity: sha512-eACpxRN02yaawnt+uUNIF7Qje6A9zArxBbcAJjK1PK3S9Ycg5jIuJ8pW4q8EMnwNZCEGltcjkRx1QzOxOkKD8A==}
+    engines: {node: '>=10.13.0'}
+
   webpack-virtual-modules@0.6.2:
     resolution: {integrity: sha512-66/V2i5hQanC51vBQKPH4aI8NMAcBW59FVBs+rC7eGHupMyfn34q7rZIE+ETlJ+XTevqfUhVVBgSUNSW2flEUQ==}
 
@@ -5831,6 +6393,10 @@ packages:
     peerDependenciesMeta:
       webpack-cli:
         optional: true
+
+  whatwg-mimetype@3.0.0:
+    resolution: {integrity: sha512-nt+N2dzIutVRxARx1nghPKGv1xHikU7HKdfafKkLNLindmPU/ch3U31NOCGGA/dmPcmb1VlofO0vnKAcsm0o/Q==}
+    engines: {node: '>=12'}
 
   which@2.0.2:
     resolution: {integrity: sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==}
@@ -6326,9 +6892,20 @@ snapshots:
     dependencies:
       '@jridgewell/trace-mapping': 0.3.9
 
+  '@emnapi/core@1.10.0':
+    dependencies:
+      '@emnapi/wasi-threads': 1.2.1
+      tslib: 2.8.1
+    optional: true
+
   '@emnapi/core@1.7.0':
     dependencies:
       '@emnapi/wasi-threads': 1.1.0
+      tslib: 2.8.1
+    optional: true
+
+  '@emnapi/runtime@1.10.0':
+    dependencies:
       tslib: 2.8.1
     optional: true
 
@@ -6338,6 +6915,11 @@ snapshots:
     optional: true
 
   '@emnapi/wasi-threads@1.1.0':
+    dependencies:
+      tslib: 2.8.1
+    optional: true
+
+  '@emnapi/wasi-threads@1.2.1':
     dependencies:
       tslib: 2.8.1
     optional: true
@@ -6892,6 +7474,12 @@ snapshots:
       '@types/react': 19.2.14
       react: 19.2.4
 
+  '@mdx-js/react@3.1.1(@types/react@19.2.14)(react@19.2.5)':
+    dependencies:
+      '@types/mdx': 2.0.13
+      '@types/react': 19.2.14
+      react: 19.2.5
+
   '@microsoft/tsdoc@0.16.0': {}
 
   '@napi-rs/nice-android-arm-eabi@1.1.1':
@@ -6970,6 +7558,13 @@ snapshots:
     dependencies:
       '@emnapi/core': 1.7.0
       '@emnapi/runtime': 1.7.0
+      '@tybys/wasm-util': 0.10.1
+    optional: true
+
+  '@napi-rs/wasm-runtime@1.1.4(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)':
+    dependencies:
+      '@emnapi/core': 1.10.0
+      '@emnapi/runtime': 1.10.0
       '@tybys/wasm-util': 0.10.1
     optional: true
 
@@ -7185,6 +7780,8 @@ snapshots:
 
   '@oxc-project/types@0.122.0': {}
 
+  '@oxc-project/types@0.127.0': {}
+
   '@paralleldrive/cuid2@2.3.1':
     dependencies:
       '@noble/hashes': 1.8.0
@@ -7197,6 +7794,8 @@ snapshots:
   '@playwright/test@1.59.1':
     dependencies:
       playwright: 1.59.1
+
+  '@popperjs/core@2.11.8': {}
 
   '@redis/bloom@5.12.1(@redis/client@5.12.1)':
     dependencies:
@@ -7225,37 +7824,73 @@ snapshots:
   '@rolldown/binding-android-arm64@1.0.0-rc.12':
     optional: true
 
+  '@rolldown/binding-android-arm64@1.0.0-rc.17':
+    optional: true
+
   '@rolldown/binding-darwin-arm64@1.0.0-rc.12':
+    optional: true
+
+  '@rolldown/binding-darwin-arm64@1.0.0-rc.17':
     optional: true
 
   '@rolldown/binding-darwin-x64@1.0.0-rc.12':
     optional: true
 
+  '@rolldown/binding-darwin-x64@1.0.0-rc.17':
+    optional: true
+
   '@rolldown/binding-freebsd-x64@1.0.0-rc.12':
+    optional: true
+
+  '@rolldown/binding-freebsd-x64@1.0.0-rc.17':
     optional: true
 
   '@rolldown/binding-linux-arm-gnueabihf@1.0.0-rc.12':
     optional: true
 
+  '@rolldown/binding-linux-arm-gnueabihf@1.0.0-rc.17':
+    optional: true
+
   '@rolldown/binding-linux-arm64-gnu@1.0.0-rc.12':
+    optional: true
+
+  '@rolldown/binding-linux-arm64-gnu@1.0.0-rc.17':
     optional: true
 
   '@rolldown/binding-linux-arm64-musl@1.0.0-rc.12':
     optional: true
 
+  '@rolldown/binding-linux-arm64-musl@1.0.0-rc.17':
+    optional: true
+
   '@rolldown/binding-linux-ppc64-gnu@1.0.0-rc.12':
+    optional: true
+
+  '@rolldown/binding-linux-ppc64-gnu@1.0.0-rc.17':
     optional: true
 
   '@rolldown/binding-linux-s390x-gnu@1.0.0-rc.12':
     optional: true
 
+  '@rolldown/binding-linux-s390x-gnu@1.0.0-rc.17':
+    optional: true
+
   '@rolldown/binding-linux-x64-gnu@1.0.0-rc.12':
+    optional: true
+
+  '@rolldown/binding-linux-x64-gnu@1.0.0-rc.17':
     optional: true
 
   '@rolldown/binding-linux-x64-musl@1.0.0-rc.12':
     optional: true
 
+  '@rolldown/binding-linux-x64-musl@1.0.0-rc.17':
+    optional: true
+
   '@rolldown/binding-openharmony-arm64@1.0.0-rc.12':
+    optional: true
+
+  '@rolldown/binding-openharmony-arm64@1.0.0-rc.17':
     optional: true
 
   '@rolldown/binding-wasm32-wasi@1.0.0-rc.12(@emnapi/core@1.7.0)(@emnapi/runtime@1.7.0)':
@@ -7266,13 +7901,28 @@ snapshots:
       - '@emnapi/runtime'
     optional: true
 
+  '@rolldown/binding-wasm32-wasi@1.0.0-rc.17':
+    dependencies:
+      '@emnapi/core': 1.10.0
+      '@emnapi/runtime': 1.10.0
+      '@napi-rs/wasm-runtime': 1.1.4(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)
+    optional: true
+
   '@rolldown/binding-win32-arm64-msvc@1.0.0-rc.12':
+    optional: true
+
+  '@rolldown/binding-win32-arm64-msvc@1.0.0-rc.17':
     optional: true
 
   '@rolldown/binding-win32-x64-msvc@1.0.0-rc.12':
     optional: true
 
+  '@rolldown/binding-win32-x64-msvc@1.0.0-rc.17':
+    optional: true
+
   '@rolldown/pluginutils@1.0.0-rc.12': {}
+
+  '@rolldown/pluginutils@1.0.0-rc.17': {}
 
   '@rollup/rollup-android-arm-eabi@4.60.0':
     optional: true
@@ -7394,12 +8044,40 @@ snapshots:
       - vite
       - webpack
 
+  '@storybook/addon-docs@10.3.6(@types/react@19.2.14)(esbuild@0.27.7)(rollup@4.60.0)(storybook@10.3.6(@testing-library/dom@10.4.1)(prettier@3.8.3)(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(vite@8.0.10(@types/node@25.6.0)(esbuild@0.27.7)(jiti@2.6.1)(terser@5.44.0)(tsx@4.21.0)(yaml@2.8.2))(webpack@5.106.0(esbuild@0.27.7))':
+    dependencies:
+      '@mdx-js/react': 3.1.1(@types/react@19.2.14)(react@19.2.5)
+      '@storybook/csf-plugin': 10.3.6(esbuild@0.27.7)(rollup@4.60.0)(storybook@10.3.6(@testing-library/dom@10.4.1)(prettier@3.8.3)(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(vite@8.0.10(@types/node@25.6.0)(esbuild@0.27.7)(jiti@2.6.1)(terser@5.44.0)(tsx@4.21.0)(yaml@2.8.2))(webpack@5.106.0(esbuild@0.27.7))
+      '@storybook/icons': 2.0.1(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
+      '@storybook/react-dom-shim': 10.3.6(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(storybook@10.3.6(@testing-library/dom@10.4.1)(prettier@3.8.3)(react-dom@19.2.5(react@19.2.5))(react@19.2.5))
+      react: 19.2.5
+      react-dom: 19.2.5(react@19.2.5)
+      storybook: 10.3.6(@testing-library/dom@10.4.1)(prettier@3.8.3)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
+      ts-dedent: 2.2.0
+    transitivePeerDependencies:
+      - '@types/react'
+      - esbuild
+      - rollup
+      - vite
+      - webpack
+
   '@storybook/builder-vite@10.3.5(esbuild@0.27.7)(rollup@4.60.0)(storybook@10.3.5(@testing-library/dom@10.4.1)(prettier@3.8.3)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(vite@8.0.3(@emnapi/core@1.7.0)(@emnapi/runtime@1.7.0)(@types/node@25.6.0)(esbuild@0.27.7)(jiti@2.6.1)(terser@5.44.0)(tsx@4.21.0)(yaml@2.8.2))(webpack@5.106.0(@swc/core@1.15.32)(esbuild@0.27.7))':
     dependencies:
       '@storybook/csf-plugin': 10.3.5(esbuild@0.27.7)(rollup@4.60.0)(storybook@10.3.5(@testing-library/dom@10.4.1)(prettier@3.8.3)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(vite@8.0.3(@emnapi/core@1.7.0)(@emnapi/runtime@1.7.0)(@types/node@25.6.0)(esbuild@0.27.7)(jiti@2.6.1)(terser@5.44.0)(tsx@4.21.0)(yaml@2.8.2))(webpack@5.106.0(@swc/core@1.15.32)(esbuild@0.27.7))
       storybook: 10.3.5(@testing-library/dom@10.4.1)(prettier@3.8.3)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       ts-dedent: 2.2.0
       vite: 8.0.3(@emnapi/core@1.7.0)(@emnapi/runtime@1.7.0)(@types/node@25.6.0)(esbuild@0.27.7)(jiti@2.6.1)(terser@5.44.0)(tsx@4.21.0)(yaml@2.8.2)
+    transitivePeerDependencies:
+      - esbuild
+      - rollup
+      - webpack
+
+  '@storybook/builder-vite@10.3.6(esbuild@0.27.7)(rollup@4.60.0)(storybook@10.3.6(@testing-library/dom@10.4.1)(prettier@3.8.3)(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(vite@8.0.10(@types/node@25.6.0)(esbuild@0.27.7)(jiti@2.6.1)(terser@5.44.0)(tsx@4.21.0)(yaml@2.8.2))(webpack@5.106.0(esbuild@0.27.7))':
+    dependencies:
+      '@storybook/csf-plugin': 10.3.6(esbuild@0.27.7)(rollup@4.60.0)(storybook@10.3.6(@testing-library/dom@10.4.1)(prettier@3.8.3)(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(vite@8.0.10(@types/node@25.6.0)(esbuild@0.27.7)(jiti@2.6.1)(terser@5.44.0)(tsx@4.21.0)(yaml@2.8.2))(webpack@5.106.0(esbuild@0.27.7))
+      storybook: 10.3.6(@testing-library/dom@10.4.1)(prettier@3.8.3)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
+      ts-dedent: 2.2.0
+      vite: 8.0.10(@types/node@25.6.0)(esbuild@0.27.7)(jiti@2.6.1)(terser@5.44.0)(tsx@4.21.0)(yaml@2.8.2)
     transitivePeerDependencies:
       - esbuild
       - rollup
@@ -7415,6 +8093,16 @@ snapshots:
       vite: 8.0.3(@emnapi/core@1.7.0)(@emnapi/runtime@1.7.0)(@types/node@25.6.0)(esbuild@0.27.7)(jiti@2.6.1)(terser@5.44.0)(tsx@4.21.0)(yaml@2.8.2)
       webpack: 5.106.0(@swc/core@1.15.32)(esbuild@0.27.7)
 
+  '@storybook/csf-plugin@10.3.6(esbuild@0.27.7)(rollup@4.60.0)(storybook@10.3.6(@testing-library/dom@10.4.1)(prettier@3.8.3)(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(vite@8.0.10(@types/node@25.6.0)(esbuild@0.27.7)(jiti@2.6.1)(terser@5.44.0)(tsx@4.21.0)(yaml@2.8.2))(webpack@5.106.0(esbuild@0.27.7))':
+    dependencies:
+      storybook: 10.3.6(@testing-library/dom@10.4.1)(prettier@3.8.3)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
+      unplugin: 2.3.11
+    optionalDependencies:
+      esbuild: 0.27.7
+      rollup: 4.60.0
+      vite: 8.0.10(@types/node@25.6.0)(esbuild@0.27.7)(jiti@2.6.1)(terser@5.44.0)(tsx@4.21.0)(yaml@2.8.2)
+      webpack: 5.106.0(esbuild@0.27.7)
+
   '@storybook/global@5.0.0': {}
 
   '@storybook/html-vite@10.3.5(esbuild@0.27.7)(rollup@4.60.0)(storybook@10.3.5(@testing-library/dom@10.4.1)(prettier@3.8.3)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(vite@8.0.3(@emnapi/core@1.7.0)(@emnapi/runtime@1.7.0)(@types/node@25.6.0)(esbuild@0.27.7)(jiti@2.6.1)(terser@5.44.0)(tsx@4.21.0)(yaml@2.8.2))(webpack@5.106.0(@swc/core@1.15.32)(esbuild@0.27.7))':
@@ -7428,10 +8116,27 @@ snapshots:
       - vite
       - webpack
 
+  '@storybook/html-vite@10.3.6(esbuild@0.27.7)(rollup@4.60.0)(storybook@10.3.6(@testing-library/dom@10.4.1)(prettier@3.8.3)(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(vite@8.0.10(@types/node@25.6.0)(esbuild@0.27.7)(jiti@2.6.1)(terser@5.44.0)(tsx@4.21.0)(yaml@2.8.2))(webpack@5.106.0(esbuild@0.27.7))':
+    dependencies:
+      '@storybook/builder-vite': 10.3.6(esbuild@0.27.7)(rollup@4.60.0)(storybook@10.3.6(@testing-library/dom@10.4.1)(prettier@3.8.3)(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(vite@8.0.10(@types/node@25.6.0)(esbuild@0.27.7)(jiti@2.6.1)(terser@5.44.0)(tsx@4.21.0)(yaml@2.8.2))(webpack@5.106.0(esbuild@0.27.7))
+      '@storybook/html': 10.3.6(storybook@10.3.6(@testing-library/dom@10.4.1)(prettier@3.8.3)(react-dom@19.2.5(react@19.2.5))(react@19.2.5))
+      storybook: 10.3.6(@testing-library/dom@10.4.1)(prettier@3.8.3)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
+    transitivePeerDependencies:
+      - esbuild
+      - rollup
+      - vite
+      - webpack
+
   '@storybook/html@10.3.5(storybook@10.3.5(@testing-library/dom@10.4.1)(prettier@3.8.3)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))':
     dependencies:
       '@storybook/global': 5.0.0
       storybook: 10.3.5(@testing-library/dom@10.4.1)(prettier@3.8.3)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      ts-dedent: 2.2.0
+
+  '@storybook/html@10.3.6(storybook@10.3.6(@testing-library/dom@10.4.1)(prettier@3.8.3)(react-dom@19.2.5(react@19.2.5))(react@19.2.5))':
+    dependencies:
+      '@storybook/global': 5.0.0
+      storybook: 10.3.6(@testing-library/dom@10.4.1)(prettier@3.8.3)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
       ts-dedent: 2.2.0
 
   '@storybook/icons@2.0.1(react-dom@19.2.4(react@19.2.4))(react@19.2.4)':
@@ -7439,11 +8144,22 @@ snapshots:
       react: 19.2.4
       react-dom: 19.2.4(react@19.2.4)
 
+  '@storybook/icons@2.0.1(react-dom@19.2.5(react@19.2.5))(react@19.2.5)':
+    dependencies:
+      react: 19.2.5
+      react-dom: 19.2.5(react@19.2.5)
+
   '@storybook/react-dom-shim@10.3.5(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(storybook@10.3.5(@testing-library/dom@10.4.1)(prettier@3.8.3)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))':
     dependencies:
       react: 19.2.4
       react-dom: 19.2.4(react@19.2.4)
       storybook: 10.3.5(@testing-library/dom@10.4.1)(prettier@3.8.3)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+
+  '@storybook/react-dom-shim@10.3.6(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(storybook@10.3.6(@testing-library/dom@10.4.1)(prettier@3.8.3)(react-dom@19.2.5(react@19.2.5))(react@19.2.5))':
+    dependencies:
+      react: 19.2.5
+      react-dom: 19.2.5(react@19.2.5)
+      storybook: 10.3.6(@testing-library/dom@10.4.1)(prettier@3.8.3)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
 
   '@swc/cli@0.8.1(@swc/core@1.15.32)(chokidar@4.0.3)':
     dependencies:
@@ -7717,6 +8433,12 @@ snapshots:
 
   '@types/validator@13.15.10': {}
 
+  '@types/whatwg-mimetype@3.0.2': {}
+
+  '@types/ws@8.18.1':
+    dependencies:
+      '@types/node': 25.6.0
+
   '@types/yargs-parser@21.0.3': {}
 
   '@types/yargs@17.0.34':
@@ -7891,6 +8613,14 @@ snapshots:
       '@vitest/utils': 4.1.5
       chai: 6.2.2
       tinyrainbow: 3.1.0
+
+  '@vitest/mocker@4.1.5(vite@8.0.10(@types/node@25.6.0)(esbuild@0.27.7)(jiti@2.6.1)(terser@5.44.0)(tsx@4.21.0)(yaml@2.8.2))':
+    dependencies:
+      '@vitest/spy': 4.1.5
+      estree-walker: 3.0.3
+      magic-string: 0.30.21
+    optionalDependencies:
+      vite: 8.0.10(@types/node@25.6.0)(esbuild@0.27.7)(jiti@2.6.1)(terser@5.44.0)(tsx@4.21.0)(yaml@2.8.2)
 
   '@vitest/mocker@4.1.5(vite@8.0.3(@emnapi/core@1.7.0)(@emnapi/runtime@1.7.0)(@types/node@25.6.0)(esbuild@0.27.7)(jiti@2.6.1)(terser@5.44.0)(tsx@4.21.0)(yaml@2.8.2))':
     dependencies:
@@ -8189,6 +8919,8 @@ snapshots:
       json-schema-traverse: 1.0.0
       require-from-string: 2.0.2
 
+  animate.css@4.1.1: {}
+
   ansi-colors@4.1.3: {}
 
   ansi-escapes@4.3.2:
@@ -8255,6 +8987,8 @@ snapshots:
   async@3.2.6: {}
 
   asynckit@0.4.0: {}
+
+  awesomplete@1.1.7: {}
 
   axios@1.15.2:
     dependencies:
@@ -8331,6 +9065,9 @@ snapshots:
   base64-js@1.5.1: {}
 
   base64id@2.0.0: {}
+
+  baseline-browser-mapping@2.10.24:
+    optional: true
 
   baseline-browser-mapping@2.9.19: {}
 
@@ -8422,6 +9159,15 @@ snapshots:
       node-releases: 2.0.27
       update-browserslist-db: 1.2.3(browserslist@4.28.1)
 
+  browserslist@4.28.2:
+    dependencies:
+      baseline-browser-mapping: 2.10.24
+      caniuse-lite: 1.0.30001791
+      electron-to-chromium: 1.5.348
+      node-releases: 2.0.38
+      update-browserslist-db: 1.2.3(browserslist@4.28.2)
+    optional: true
+
   bs-logger@0.2.6:
     dependencies:
       fast-json-stable-stringify: 2.1.0
@@ -8495,6 +9241,9 @@ snapshots:
 
   caniuse-lite@1.0.30001767: {}
 
+  caniuse-lite@1.0.30001791:
+    optional: true
+
   catering@2.1.1: {}
 
   chai@5.3.3:
@@ -8536,6 +9285,10 @@ snapshots:
       libphonenumber-js: 1.12.37
       validator: 13.15.26
 
+  class-variance-authority@0.7.1:
+    dependencies:
+      clsx: 2.1.1
+
   classic-level@1.4.1:
     dependencies:
       abstract-level: 1.0.4
@@ -8543,6 +9296,8 @@ snapshots:
       module-error: 1.0.2
       napi-macros: 2.2.2
       node-gyp-build: 4.8.4
+
+  classnames@2.5.1: {}
 
   cli-cursor@3.1.0:
     dependencies:
@@ -8579,6 +9334,8 @@ snapshots:
 
   clone@1.0.4: {}
 
+  clsx@2.1.1: {}
+
   cluster-key-slot@1.1.2: {}
 
   co@4.6.0: {}
@@ -8608,6 +9365,8 @@ snapshots:
   commander@4.1.1: {}
 
   commander@6.2.1: {}
+
+  commander@7.2.0: {}
 
   commander@8.3.0: {}
 
@@ -8724,6 +9483,19 @@ snapshots:
     optionalDependencies:
       typescript: 6.0.3
 
+  courthive-components@1.1.1:
+    dependencies:
+      awesomplete: 1.1.7
+      class-variance-authority: 0.7.1
+      classnames: 2.5.1
+      d3: 7.9.0
+      dayjs: 1.11.20
+      focus-trap: 8.1.0
+      timepicker-ui: 4.3.0
+      tippy.js: 6.3.7
+      tods-competition-factory: link:../factory
+      vanillajs-datepicker: 1.3.4
+
   create-require@1.1.1: {}
 
   cross-spawn@7.0.6:
@@ -8748,7 +9520,13 @@ snapshots:
 
   d3-array@1.2.4: {}
 
+  d3-array@3.2.4:
+    dependencies:
+      internmap: 2.0.3
+
   d3-axis@1.0.12: {}
+
+  d3-axis@3.0.0: {}
 
   d3-brush@1.1.6:
     dependencies:
@@ -8758,25 +9536,54 @@ snapshots:
       d3-selection: 1.4.2
       d3-transition: 1.3.2
 
+  d3-brush@3.0.0:
+    dependencies:
+      d3-dispatch: 3.0.1
+      d3-drag: 3.0.0
+      d3-interpolate: 3.0.1
+      d3-selection: 3.0.0
+      d3-transition: 3.0.1(d3-selection@3.0.0)
+
   d3-chord@1.0.6:
     dependencies:
       d3-array: 1.2.4
       d3-path: 1.0.9
 
+  d3-chord@3.0.1:
+    dependencies:
+      d3-path: 3.1.0
+
   d3-collection@1.0.7: {}
 
   d3-color@1.4.1: {}
+
+  d3-color@3.1.0: {}
 
   d3-contour@1.3.2:
     dependencies:
       d3-array: 1.2.4
 
+  d3-contour@4.0.2:
+    dependencies:
+      d3-array: 3.2.4
+
+  d3-delaunay@6.0.4:
+    dependencies:
+      delaunator: 5.1.0
+
   d3-dispatch@1.0.6: {}
+
+  d3-dispatch@3.0.1: {}
 
   d3-drag@1.2.5:
     dependencies:
       d3-dispatch: 1.0.6
       d3-selection: 1.4.2
+
+  d3-drag@3.0.0:
+    dependencies:
+      d3-dispatch: 3.0.1
+      d3-selection: 3.0.0
 
   d3-dsv@1.2.0:
     dependencies:
@@ -8784,11 +9591,23 @@ snapshots:
       iconv-lite: 0.4.24
       rw: 1.3.3
 
+  d3-dsv@3.0.1:
+    dependencies:
+      commander: 7.2.0
+      iconv-lite: 0.6.3
+      rw: 1.3.3
+
   d3-ease@1.0.7: {}
+
+  d3-ease@3.0.1: {}
 
   d3-fetch@1.2.0:
     dependencies:
       d3-dsv: 1.2.0
+
+  d3-fetch@3.0.1:
+    dependencies:
+      d3-dsv: 3.0.1
 
   d3-force@1.2.1:
     dependencies:
@@ -8797,30 +9616,61 @@ snapshots:
       d3-quadtree: 1.0.7
       d3-timer: 1.0.10
 
+  d3-force@3.0.0:
+    dependencies:
+      d3-dispatch: 3.0.1
+      d3-quadtree: 3.0.1
+      d3-timer: 3.0.1
+
   d3-format@1.4.5: {}
+
+  d3-format@3.1.2: {}
 
   d3-geo@1.12.1:
     dependencies:
       d3-array: 1.2.4
 
+  d3-geo@3.1.1:
+    dependencies:
+      d3-array: 3.2.4
+
   d3-hierarchy@1.1.9: {}
+
+  d3-hierarchy@3.1.2: {}
 
   d3-interpolate@1.4.0:
     dependencies:
       d3-color: 1.4.1
 
+  d3-interpolate@3.0.1:
+    dependencies:
+      d3-color: 3.1.0
+
   d3-path@1.0.9: {}
+
+  d3-path@3.1.0: {}
 
   d3-polygon@1.0.6: {}
 
+  d3-polygon@3.0.1: {}
+
   d3-quadtree@1.0.7: {}
 
+  d3-quadtree@3.0.1: {}
+
   d3-random@1.1.2: {}
+
+  d3-random@3.0.1: {}
 
   d3-scale-chromatic@1.5.0:
     dependencies:
       d3-color: 1.4.1
       d3-interpolate: 1.4.0
+
+  d3-scale-chromatic@3.1.0:
+    dependencies:
+      d3-color: 3.1.0
+      d3-interpolate: 3.0.1
 
   d3-scale@2.2.2:
     dependencies:
@@ -8831,19 +9681,43 @@ snapshots:
       d3-time: 1.1.0
       d3-time-format: 2.3.0
 
+  d3-scale@4.0.2:
+    dependencies:
+      d3-array: 3.2.4
+      d3-format: 3.1.2
+      d3-interpolate: 3.0.1
+      d3-time: 3.1.0
+      d3-time-format: 4.1.0
+
   d3-selection@1.4.2: {}
+
+  d3-selection@3.0.0: {}
 
   d3-shape@1.3.7:
     dependencies:
       d3-path: 1.0.9
 
+  d3-shape@3.2.0:
+    dependencies:
+      d3-path: 3.1.0
+
   d3-time-format@2.3.0:
     dependencies:
       d3-time: 1.1.0
 
+  d3-time-format@4.1.0:
+    dependencies:
+      d3-time: 3.1.0
+
   d3-time@1.1.0: {}
 
+  d3-time@3.1.0:
+    dependencies:
+      d3-array: 3.2.4
+
   d3-timer@1.0.10: {}
+
+  d3-timer@3.0.1: {}
 
   d3-transition@1.3.2:
     dependencies:
@@ -8854,6 +9728,15 @@ snapshots:
       d3-selection: 1.4.2
       d3-timer: 1.0.10
 
+  d3-transition@3.0.1(d3-selection@3.0.0):
+    dependencies:
+      d3-color: 3.1.0
+      d3-dispatch: 3.0.1
+      d3-ease: 3.0.1
+      d3-interpolate: 3.0.1
+      d3-selection: 3.0.0
+      d3-timer: 3.0.1
+
   d3-voronoi@1.1.4: {}
 
   d3-zoom@1.8.3:
@@ -8863,6 +9746,14 @@ snapshots:
       d3-interpolate: 1.4.0
       d3-selection: 1.4.2
       d3-transition: 1.3.2
+
+  d3-zoom@3.0.0:
+    dependencies:
+      d3-dispatch: 3.0.1
+      d3-drag: 3.0.0
+      d3-interpolate: 3.0.1
+      d3-selection: 3.0.0
+      d3-transition: 3.0.1(d3-selection@3.0.0)
 
   d3@5.16.0:
     dependencies:
@@ -8898,11 +9789,46 @@ snapshots:
       d3-voronoi: 1.1.4
       d3-zoom: 1.8.3
 
+  d3@7.9.0:
+    dependencies:
+      d3-array: 3.2.4
+      d3-axis: 3.0.0
+      d3-brush: 3.0.0
+      d3-chord: 3.0.1
+      d3-color: 3.1.0
+      d3-contour: 4.0.2
+      d3-delaunay: 6.0.4
+      d3-dispatch: 3.0.1
+      d3-drag: 3.0.0
+      d3-dsv: 3.0.1
+      d3-ease: 3.0.1
+      d3-fetch: 3.0.1
+      d3-force: 3.0.0
+      d3-format: 3.1.2
+      d3-geo: 3.1.1
+      d3-hierarchy: 3.1.2
+      d3-interpolate: 3.0.1
+      d3-path: 3.1.0
+      d3-polygon: 3.0.1
+      d3-quadtree: 3.0.1
+      d3-random: 3.0.1
+      d3-scale: 4.0.2
+      d3-scale-chromatic: 3.1.0
+      d3-selection: 3.0.0
+      d3-shape: 3.2.0
+      d3-time: 3.1.0
+      d3-time-format: 4.1.0
+      d3-timer: 3.0.1
+      d3-transition: 3.0.1(d3-selection@3.0.0)
+      d3-zoom: 3.0.0
+
   date-fns@2.30.0:
     dependencies:
       '@babel/runtime': 7.28.4
 
   dayjs@1.11.10: {}
+
+  dayjs@1.11.20: {}
 
   debug@2.6.9:
     dependencies:
@@ -8942,6 +9868,10 @@ snapshots:
   defaults@2.0.2: {}
 
   define-lazy-prop@3.0.0: {}
+
+  delaunator@5.1.0:
+    dependencies:
+      robust-predicates: 3.0.3
 
   delayed-stream@1.0.0: {}
 
@@ -9022,6 +9952,9 @@ snapshots:
 
   electron-to-chromium@1.5.286: {}
 
+  electron-to-chromium@1.5.348:
+    optional: true
+
   email-addresses@5.0.0: {}
 
   emittery@0.13.1: {}
@@ -9076,7 +10009,15 @@ snapshots:
       graceful-fs: 4.2.11
       tapable: 2.3.0
 
+  enhanced-resolve@5.21.0:
+    dependencies:
+      graceful-fs: 4.2.11
+      tapable: 2.3.3
+    optional: true
+
   entities@4.5.0: {}
+
+  entities@7.0.1: {}
 
   env-paths@2.2.1: {}
 
@@ -9092,6 +10033,8 @@ snapshots:
 
   es-module-lexer@2.0.0: {}
 
+  es-module-lexer@2.1.0: {}
+
   es-object-atoms@1.1.1:
     dependencies:
       es-errors: 1.3.0
@@ -9101,7 +10044,7 @@ snapshots:
       es-errors: 1.3.0
       get-intrinsic: 1.3.0
       has-tostringtag: 1.0.2
-      hasown: 2.0.2
+      hasown: 2.0.3
 
   esbuild-register@3.6.0(esbuild@0.27.7):
     dependencies:
@@ -9530,6 +10473,10 @@ snapshots:
 
   flatted@3.3.3: {}
 
+  focus-trap@8.1.0:
+    dependencies:
+      tabbable: 6.4.0
+
   follow-redirects@1.16.0: {}
 
   foreground-child@3.3.1:
@@ -9561,7 +10508,7 @@ snapshots:
       asynckit: 0.4.0
       combined-stream: 1.0.8
       es-set-tostringtag: 2.1.0
-      hasown: 2.0.2
+      hasown: 2.0.3
       mime-types: 2.1.35
 
   formidable@3.5.4:
@@ -9620,7 +10567,7 @@ snapshots:
       get-proto: 1.0.1
       gopd: 1.2.0
       has-symbols: 1.1.0
-      hasown: 2.0.2
+      hasown: 2.0.3
       math-intrinsics: 1.1.0
 
   get-package-type@0.1.0: {}
@@ -9744,6 +10691,18 @@ snapshots:
     optionalDependencies:
       uglify-js: 3.19.3
 
+  happy-dom@20.9.0:
+    dependencies:
+      '@types/node': 25.6.0
+      '@types/whatwg-mimetype': 3.0.2
+      '@types/ws': 8.18.1
+      entities: 7.0.1
+      whatwg-mimetype: 3.0.0
+      ws: 8.20.0
+    transitivePeerDependencies:
+      - bufferutil
+      - utf-8-validate
+
   has-flag@4.0.0: {}
 
   has-symbols@1.1.0: {}
@@ -9756,7 +10715,7 @@ snapshots:
     dependencies:
       hookified: 1.15.1
 
-  hasown@2.0.2:
+  hasown@2.0.3:
     dependencies:
       function-bind: 1.1.2
 
@@ -9797,7 +10756,15 @@ snapshots:
 
   husky@9.1.7: {}
 
+  i18next@26.0.8(typescript@6.0.3):
+    optionalDependencies:
+      typescript: 6.0.3
+
   iconv-lite@0.4.24:
+    dependencies:
+      safer-buffer: 2.1.2
+
+  iconv-lite@0.6.3:
     dependencies:
       safer-buffer: 2.1.2
 
@@ -9839,6 +10806,8 @@ snapshots:
   inspect-with-kind@1.0.5:
     dependencies:
       kind-of: 6.0.3
+
+  internmap@2.0.3: {}
 
   ipaddr.js@1.9.1: {}
 
@@ -10355,6 +11324,8 @@ snapshots:
       jwa: 2.0.1
       safe-buffer: 5.2.1
 
+  jwt-decode@4.0.0: {}
+
   keyv@4.5.4:
     dependencies:
       json-buffer: 3.0.1
@@ -10459,6 +11430,9 @@ snapshots:
   load-esm@1.0.3: {}
 
   loader-runner@4.3.1: {}
+
+  loader-runner@4.3.2:
+    optional: true
 
   locate-path@5.0.0:
     dependencies:
@@ -10655,11 +11629,15 @@ snapshots:
 
   nanoid@3.3.11: {}
 
+  nanoid@3.3.12: {}
+
   napi-macros@2.2.2: {}
 
   napi-postinstall@0.3.4: {}
 
   natural-compare@1.4.0: {}
+
+  navigo@8.11.1: {}
 
   negotiator@0.6.3: {}
 
@@ -10685,6 +11663,9 @@ snapshots:
   node-int64@0.4.0: {}
 
   node-releases@2.0.27: {}
+
+  node-releases@2.0.38:
+    optional: true
 
   normalize-path@3.0.0: {}
 
@@ -10914,6 +11895,12 @@ snapshots:
       picocolors: 1.1.1
       source-map-js: 1.2.1
 
+  postcss@8.5.13:
+    dependencies:
+      nanoid: 3.3.12
+      picocolors: 1.1.1
+      source-map-js: 1.2.1
+
   postgres-array@2.0.0: {}
 
   postgres-bytea@1.0.1: {}
@@ -11002,11 +11989,18 @@ snapshots:
       react: 19.2.4
       scheduler: 0.27.0
 
+  react-dom@19.2.5(react@19.2.5):
+    dependencies:
+      react: 19.2.5
+      scheduler: 0.27.0
+
   react-is@17.0.2: {}
 
   react-is@18.3.1: {}
 
   react@19.2.4: {}
+
+  react@19.2.5: {}
 
   readable-stream@3.6.2:
     dependencies:
@@ -11090,6 +12084,8 @@ snapshots:
       glob: 13.0.5
       package-json-from-dist: 1.0.1
 
+  robust-predicates@3.0.3: {}
+
   rolldown@1.0.0-rc.12(@emnapi/core@1.7.0)(@emnapi/runtime@1.7.0):
     dependencies:
       '@oxc-project/types': 0.122.0
@@ -11113,6 +12109,27 @@ snapshots:
     transitivePeerDependencies:
       - '@emnapi/core'
       - '@emnapi/runtime'
+
+  rolldown@1.0.0-rc.17:
+    dependencies:
+      '@oxc-project/types': 0.127.0
+      '@rolldown/pluginutils': 1.0.0-rc.17
+    optionalDependencies:
+      '@rolldown/binding-android-arm64': 1.0.0-rc.17
+      '@rolldown/binding-darwin-arm64': 1.0.0-rc.17
+      '@rolldown/binding-darwin-x64': 1.0.0-rc.17
+      '@rolldown/binding-freebsd-x64': 1.0.0-rc.17
+      '@rolldown/binding-linux-arm-gnueabihf': 1.0.0-rc.17
+      '@rolldown/binding-linux-arm64-gnu': 1.0.0-rc.17
+      '@rolldown/binding-linux-arm64-musl': 1.0.0-rc.17
+      '@rolldown/binding-linux-ppc64-gnu': 1.0.0-rc.17
+      '@rolldown/binding-linux-s390x-gnu': 1.0.0-rc.17
+      '@rolldown/binding-linux-x64-gnu': 1.0.0-rc.17
+      '@rolldown/binding-linux-x64-musl': 1.0.0-rc.17
+      '@rolldown/binding-openharmony-arm64': 1.0.0-rc.17
+      '@rolldown/binding-wasm32-wasi': 1.0.0-rc.17
+      '@rolldown/binding-win32-arm64-msvc': 1.0.0-rc.17
+      '@rolldown/binding-win32-x64-msvc': 1.0.0-rc.17
 
   rollup@4.60.0:
     dependencies:
@@ -11414,6 +12431,30 @@ snapshots:
       - react-dom
       - utf-8-validate
 
+  storybook@10.3.6(@testing-library/dom@10.4.1)(prettier@3.8.3)(react-dom@19.2.5(react@19.2.5))(react@19.2.5):
+    dependencies:
+      '@storybook/global': 5.0.0
+      '@storybook/icons': 2.0.1(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
+      '@testing-library/jest-dom': 6.9.1
+      '@testing-library/user-event': 14.6.1(@testing-library/dom@10.4.1)
+      '@vitest/expect': 3.2.4
+      '@vitest/spy': 3.2.4
+      '@webcontainer/env': 1.1.1
+      esbuild: 0.27.7
+      open: 10.2.0
+      recast: 0.23.11
+      semver: 7.7.4
+      use-sync-external-store: 1.6.0(react@19.2.5)
+      ws: 8.20.0
+    optionalDependencies:
+      prettier: 3.8.3
+    transitivePeerDependencies:
+      - '@testing-library/dom'
+      - bufferutil
+      - react
+      - react-dom
+      - utf-8-validate
+
   streamsearch@1.1.0: {}
 
   streamx@2.23.0:
@@ -11542,7 +12583,14 @@ snapshots:
     dependencies:
       '@pkgr/core': 0.2.9
 
+  tabbable@6.4.0: {}
+
+  tabulator-tables@6.4.0: {}
+
   tapable@2.3.0: {}
+
+  tapable@2.3.3:
+    optional: true
 
   tar-stream@3.1.7:
     dependencies:
@@ -11563,6 +12611,17 @@ snapshots:
     optionalDependencies:
       '@swc/core': 1.15.32
       esbuild: 0.27.7
+
+  terser-webpack-plugin@5.5.0(esbuild@0.27.7)(webpack@5.106.0(esbuild@0.27.7)):
+    dependencies:
+      '@jridgewell/trace-mapping': 0.3.31
+      jest-worker: 27.5.1
+      schema-utils: 4.3.3
+      terser: 5.44.0
+      webpack: 5.106.0(esbuild@0.27.7)
+    optionalDependencies:
+      esbuild: 0.27.7
+    optional: true
 
   terser@5.44.0:
     dependencies:
@@ -11589,6 +12648,8 @@ snapshots:
     dependencies:
       convert-hrtime: 5.0.0
 
+  timepicker-ui@4.3.0: {}
+
   tiny-invariant@1.3.3: {}
 
   tinybench@2.9.0: {}
@@ -11596,6 +12657,8 @@ snapshots:
   tinyexec@1.0.4: {}
 
   tinyexec@1.1.1: {}
+
+  tinyexec@1.1.2: {}
 
   tinyglobby@0.2.15:
     dependencies:
@@ -11612,6 +12675,10 @@ snapshots:
   tinyrainbow@3.1.0: {}
 
   tinyspy@4.0.4: {}
+
+  tippy.js@6.3.7:
+    dependencies:
+      '@popperjs/core': 2.11.8
 
   tmpl@1.0.5: {}
 
@@ -11804,6 +12871,13 @@ snapshots:
       escalade: 3.2.0
       picocolors: 1.1.1
 
+  update-browserslist-db@1.2.3(browserslist@4.28.2):
+    dependencies:
+      browserslist: 4.28.2
+      escalade: 3.2.0
+      picocolors: 1.1.1
+    optional: true
+
   uri-js@4.4.1:
     dependencies:
       punycode: 2.3.1
@@ -11813,6 +12887,10 @@ snapshots:
   use-sync-external-store@1.6.0(react@19.2.4):
     dependencies:
       react: 19.2.4
+
+  use-sync-external-store@1.6.0(react@19.2.5):
+    dependencies:
+      react: 19.2.5
 
   util-deprecate@1.0.2: {}
 
@@ -11828,7 +12906,25 @@ snapshots:
 
   validator@13.15.26: {}
 
+  vanillajs-datepicker@1.3.4: {}
+
   vary@1.1.2: {}
+
+  vite@8.0.10(@types/node@25.6.0)(esbuild@0.27.7)(jiti@2.6.1)(terser@5.44.0)(tsx@4.21.0)(yaml@2.8.2):
+    dependencies:
+      lightningcss: 1.32.0
+      picomatch: 4.0.4
+      postcss: 8.5.13
+      rolldown: 1.0.0-rc.17
+      tinyglobby: 0.2.16
+    optionalDependencies:
+      '@types/node': 25.6.0
+      esbuild: 0.27.7
+      fsevents: 2.3.3
+      jiti: 2.6.1
+      terser: 5.44.0
+      tsx: 4.21.0
+      yaml: 2.8.2
 
   vite@8.0.3(@emnapi/core@1.7.0)(@emnapi/runtime@1.7.0)(@types/node@25.6.0)(esbuild@0.27.7)(jiti@2.6.1)(terser@5.44.0)(tsx@4.21.0)(yaml@2.8.2):
     dependencies:
@@ -11848,6 +12944,34 @@ snapshots:
     transitivePeerDependencies:
       - '@emnapi/core'
       - '@emnapi/runtime'
+
+  vitest@4.1.5(@types/node@25.6.0)(happy-dom@20.9.0)(vite@8.0.10(@types/node@25.6.0)(esbuild@0.27.7)(jiti@2.6.1)(terser@5.44.0)(tsx@4.21.0)(yaml@2.8.2)):
+    dependencies:
+      '@vitest/expect': 4.1.5
+      '@vitest/mocker': 4.1.5(vite@8.0.10(@types/node@25.6.0)(esbuild@0.27.7)(jiti@2.6.1)(terser@5.44.0)(tsx@4.21.0)(yaml@2.8.2))
+      '@vitest/pretty-format': 4.1.5
+      '@vitest/runner': 4.1.5
+      '@vitest/snapshot': 4.1.5
+      '@vitest/spy': 4.1.5
+      '@vitest/utils': 4.1.5
+      es-module-lexer: 2.1.0
+      expect-type: 1.3.0
+      magic-string: 0.30.21
+      obug: 2.1.1
+      pathe: 2.0.3
+      picomatch: 4.0.4
+      std-env: 4.1.0
+      tinybench: 2.9.0
+      tinyexec: 1.1.2
+      tinyglobby: 0.2.16
+      tinyrainbow: 3.1.0
+      vite: 8.0.10(@types/node@25.6.0)(esbuild@0.27.7)(jiti@2.6.1)(terser@5.44.0)(tsx@4.21.0)(yaml@2.8.2)
+      why-is-node-running: 2.3.0
+    optionalDependencies:
+      '@types/node': 25.6.0
+      happy-dom: 20.9.0
+    transitivePeerDependencies:
+      - msw
 
   vitest@4.1.5(@types/node@25.6.0)(vite@8.0.3(@emnapi/core@1.7.0)(@emnapi/runtime@1.7.0)(@types/node@25.6.0)(esbuild@0.27.7)(jiti@2.6.1)(terser@5.44.0)(tsx@4.21.0)(yaml@2.8.2)):
     dependencies:
@@ -11895,6 +13019,9 @@ snapshots:
 
   webpack-sources@3.3.4: {}
 
+  webpack-sources@3.4.1:
+    optional: true
+
   webpack-virtual-modules@0.6.2: {}
 
   webpack@5.106.0(@swc/core@1.15.32)(esbuild@0.27.7):
@@ -11928,6 +13055,41 @@ snapshots:
       - '@swc/core'
       - esbuild
       - uglify-js
+
+  webpack@5.106.0(esbuild@0.27.7):
+    dependencies:
+      '@types/eslint-scope': 3.7.7
+      '@types/estree': 1.0.8
+      '@types/json-schema': 7.0.15
+      '@webassemblyjs/ast': 1.14.1
+      '@webassemblyjs/wasm-edit': 1.14.1
+      '@webassemblyjs/wasm-parser': 1.14.1
+      acorn: 8.16.0
+      acorn-import-phases: 1.0.4(acorn@8.16.0)
+      browserslist: 4.28.2
+      chrome-trace-event: 1.0.4
+      enhanced-resolve: 5.21.0
+      es-module-lexer: 2.1.0
+      eslint-scope: 5.1.1
+      events: 3.3.0
+      glob-to-regexp: 0.4.1
+      graceful-fs: 4.2.11
+      json-parse-even-better-errors: 2.3.1
+      loader-runner: 4.3.2
+      mime-types: 2.1.35
+      neo-async: 2.6.2
+      schema-utils: 4.3.3
+      tapable: 2.3.3
+      terser-webpack-plugin: 5.5.0(esbuild@0.27.7)(webpack@5.106.0(esbuild@0.27.7))
+      watchpack: 2.5.1
+      webpack-sources: 3.4.1
+    transitivePeerDependencies:
+      - '@swc/core'
+      - esbuild
+      - uglify-js
+    optional: true
+
+  whatwg-mimetype@3.0.0: {}
 
   which@2.0.2:
     dependencies:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -156,10 +156,10 @@ importers:
         version: 1.59.1
       '@storybook/addon-docs':
         specifier: ^10.2.17
-        version: 10.3.5(@types/react@19.2.14)(esbuild@0.27.7)(rollup@4.60.0)(storybook@10.3.5(@testing-library/dom@10.4.1)(prettier@3.8.3)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(vite@8.0.3(@emnapi/core@1.7.0)(@emnapi/runtime@1.7.0)(@types/node@25.6.0)(esbuild@0.27.7)(jiti@2.6.1)(terser@5.44.0)(tsx@4.21.0)(yaml@2.8.2))(webpack@5.106.0(@swc/core@1.15.32)(esbuild@0.27.7))
+        version: 10.3.5(@types/react@19.2.14)(esbuild@0.27.7)(rollup@4.60.0)(storybook@10.3.5(@testing-library/dom@10.4.1)(prettier@3.8.3)(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(vite@8.0.10(@types/node@25.6.0)(esbuild@0.27.7)(jiti@2.6.1)(terser@5.44.0)(tsx@4.21.0)(yaml@2.8.2))(webpack@5.106.0(@swc/core@1.15.32)(esbuild@0.27.7))
       '@storybook/html-vite':
         specifier: ^10.2.17
-        version: 10.3.5(esbuild@0.27.7)(rollup@4.60.0)(storybook@10.3.5(@testing-library/dom@10.4.1)(prettier@3.8.3)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(vite@8.0.3(@emnapi/core@1.7.0)(@emnapi/runtime@1.7.0)(@types/node@25.6.0)(esbuild@0.27.7)(jiti@2.6.1)(terser@5.44.0)(tsx@4.21.0)(yaml@2.8.2))(webpack@5.106.0(@swc/core@1.15.32)(esbuild@0.27.7))
+        version: 10.3.5(esbuild@0.27.7)(rollup@4.60.0)(storybook@10.3.5(@testing-library/dom@10.4.1)(prettier@3.8.3)(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(vite@8.0.10(@types/node@25.6.0)(esbuild@0.27.7)(jiti@2.6.1)(terser@5.44.0)(tsx@4.21.0)(yaml@2.8.2))(webpack@5.106.0(@swc/core@1.15.32)(esbuild@0.27.7))
       '@swc/cli':
         specifier: 0.8.1
         version: 0.8.1(@swc/core@1.15.32)(chokidar@4.0.3)
@@ -231,7 +231,7 @@ importers:
         version: 0.5.21
       storybook:
         specifier: ^10.2.17
-        version: 10.3.5(@testing-library/dom@10.4.1)(prettier@3.8.3)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+        version: 10.3.5(@testing-library/dom@10.4.1)(prettier@3.8.3)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
       supertest:
         specifier: 7.2.2
         version: 7.2.2
@@ -250,58 +250,6 @@ importers:
       typescript:
         specifier: 6.0.3
         version: 6.0.3
-
-  admin-client:
-    dependencies:
-      animate.css:
-        specifier: ^4.1.1
-        version: 4.1.1
-      axios:
-        specifier: ^1.13.0
-        version: 1.15.2
-      courthive-components:
-        specifier: ^1.1.1
-        version: 1.1.1
-      i18next:
-        specifier: ^26.0.0
-        version: 26.0.8(typescript@6.0.3)
-      jwt-decode:
-        specifier: ^4.0.0
-        version: 4.0.0
-      navigo:
-        specifier: ^8.11.1
-        version: 8.11.1
-      tabulator-tables:
-        specifier: ^6.3.1
-        version: 6.4.0
-    devDependencies:
-      '@playwright/test':
-        specifier: ^1.59.1
-        version: 1.59.1
-      '@storybook/addon-docs':
-        specifier: ^10.2.17
-        version: 10.3.6(@types/react@19.2.14)(esbuild@0.27.7)(rollup@4.60.0)(storybook@10.3.6(@testing-library/dom@10.4.1)(prettier@3.8.3)(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(vite@8.0.10(@types/node@25.6.0)(esbuild@0.27.7)(jiti@2.6.1)(terser@5.44.0)(tsx@4.21.0)(yaml@2.8.2))(webpack@5.106.0(esbuild@0.27.7))
-      '@storybook/html':
-        specifier: ^10.2.17
-        version: 10.3.6(storybook@10.3.6(@testing-library/dom@10.4.1)(prettier@3.8.3)(react-dom@19.2.5(react@19.2.5))(react@19.2.5))
-      '@storybook/html-vite':
-        specifier: ^10.2.17
-        version: 10.3.6(esbuild@0.27.7)(rollup@4.60.0)(storybook@10.3.6(@testing-library/dom@10.4.1)(prettier@3.8.3)(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(vite@8.0.10(@types/node@25.6.0)(esbuild@0.27.7)(jiti@2.6.1)(terser@5.44.0)(tsx@4.21.0)(yaml@2.8.2))(webpack@5.106.0(esbuild@0.27.7))
-      happy-dom:
-        specifier: ^20.8.3
-        version: 20.9.0
-      storybook:
-        specifier: ^10.2.17
-        version: 10.3.6(@testing-library/dom@10.4.1)(prettier@3.8.3)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
-      typescript:
-        specifier: ^6.0.0
-        version: 6.0.3
-      vite:
-        specifier: ^8.0.0
-        version: 8.0.10(@types/node@25.6.0)(esbuild@0.27.7)(jiti@2.6.1)(terser@5.44.0)(tsx@4.21.0)(yaml@2.8.2)
-      vitest:
-        specifier: ^4.0.16
-        version: 4.1.5(@types/node@25.6.0)(happy-dom@20.9.0)(vite@8.0.10(@types/node@25.6.0)(esbuild@0.27.7)(jiti@2.6.1)(terser@5.44.0)(tsx@4.21.0)(yaml@2.8.2))
 
   audit-worker:
     dependencies:
@@ -332,7 +280,7 @@ importers:
         version: 6.0.3
       vitest:
         specifier: ^4.0.16
-        version: 4.1.5(@types/node@25.6.0)(vite@8.0.3(@emnapi/core@1.7.0)(@emnapi/runtime@1.7.0)(@types/node@25.6.0)(esbuild@0.27.7)(jiti@2.6.1)(terser@5.44.0)(tsx@4.21.0)(yaml@2.8.2))
+        version: 4.1.5(@types/node@25.6.0)(happy-dom@20.9.0)(vite@8.0.10(@types/node@25.6.0)(esbuild@0.27.7)(jiti@2.6.1)(terser@5.44.0)(tsx@4.21.0)(yaml@2.8.2))
 
 packages:
 
@@ -1459,9 +1407,6 @@ packages:
     engines: {node: ^14.18.0 || >=16.10.0, npm: '>=5.10.0'}
     hasBin: true
 
-  '@oxc-project/types@0.122.0':
-    resolution: {integrity: sha512-oLAl5kBpV4w69UtFZ9xqcmTi+GENWOcPF7FCrczTiBbmC0ibXxCwyvZGbO39rCVEuLGAZM84DH0pUIyyv/YJzA==}
-
   '@oxc-project/types@0.127.0':
     resolution: {integrity: sha512-aIYXQBo4lCbO4z0R3FHeucQHpF46l2LbMdxRvqvuRuW2OxdnSkcng5B8+K12spgLDj93rtN3+J2Vac/TIO+ciQ==}
 
@@ -1480,9 +1425,6 @@ packages:
     resolution: {integrity: sha512-PG6q63nQg5c9rIi4/Z5lR5IVF7yU5MqmKaPOe0HSc0O2cX1fPi96sUQu5j7eo4gKCkB2AnNGoWt7y4/Xx3Kcqg==}
     engines: {node: '>=18'}
     hasBin: true
-
-  '@popperjs/core@2.11.8':
-    resolution: {integrity: sha512-P1st0aksCrn9sGZhp8GMYwBnQsbvAWsZAX44oXNNvLHGqAOcoVxmjZiohstwQ7SqKnbR47akdNi+uleWD8+g6A==}
 
   '@redis/bloom@5.12.1':
     resolution: {integrity: sha512-PUUfv+ms7jgPSBVoo/DN4AkPHj4D5TZSd6SbJX7egzBplkYUcKmHRE8RKia7UtZ8bSQbLguLvxVO+asKtQfZWA==}
@@ -1524,34 +1466,16 @@ packages:
     peerDependencies:
       '@redis/client': ^5.12.1
 
-  '@rolldown/binding-android-arm64@1.0.0-rc.12':
-    resolution: {integrity: sha512-pv1y2Fv0JybcykuiiD3qBOBdz6RteYojRFY1d+b95WVuzx211CRh+ytI/+9iVyWQ6koTh5dawe4S/yRfOFjgaA==}
-    engines: {node: ^20.19.0 || >=22.12.0}
-    cpu: [arm64]
-    os: [android]
-
   '@rolldown/binding-android-arm64@1.0.0-rc.17':
     resolution: {integrity: sha512-s70pVGhw4zqGeFnXWvAzJDlvxhlRollagdCCKRgOsgUOH3N1l0LIxf83AtGzmb5SiVM4Hjl5HyarMRfdfj3DaQ==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [android]
 
-  '@rolldown/binding-darwin-arm64@1.0.0-rc.12':
-    resolution: {integrity: sha512-cFYr6zTG/3PXXF3pUO+umXxt1wkRK/0AYT8lDwuqvRC+LuKYWSAQAQZjCWDQpAH172ZV6ieYrNnFzVVcnSflAg==}
-    engines: {node: ^20.19.0 || >=22.12.0}
-    cpu: [arm64]
-    os: [darwin]
-
   '@rolldown/binding-darwin-arm64@1.0.0-rc.17':
     resolution: {integrity: sha512-4ksWc9n0mhlZpZ9PMZgTGjeOPRu8MB1Z3Tz0Mo02eWfWCHMW1zN82Qz/pL/rC+yQa+8ZnutMF0JjJe7PjwasYw==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
-    os: [darwin]
-
-  '@rolldown/binding-darwin-x64@1.0.0-rc.12':
-    resolution: {integrity: sha512-ZCsYknnHzeXYps0lGBz8JrF37GpE9bFVefrlmDrAQhOEi4IOIlcoU1+FwHEtyXGx2VkYAvhu7dyBf75EJQffBw==}
-    engines: {node: ^20.19.0 || >=22.12.0}
-    cpu: [x64]
     os: [darwin]
 
   '@rolldown/binding-darwin-x64@1.0.0-rc.17':
@@ -1560,36 +1484,17 @@ packages:
     cpu: [x64]
     os: [darwin]
 
-  '@rolldown/binding-freebsd-x64@1.0.0-rc.12':
-    resolution: {integrity: sha512-dMLeprcVsyJsKolRXyoTH3NL6qtsT0Y2xeuEA8WQJquWFXkEC4bcu1rLZZSnZRMtAqwtrF/Ib9Ddtpa/Gkge9Q==}
-    engines: {node: ^20.19.0 || >=22.12.0}
-    cpu: [x64]
-    os: [freebsd]
-
   '@rolldown/binding-freebsd-x64@1.0.0-rc.17':
     resolution: {integrity: sha512-hwnz3nw9dbJ05EDO/PvcjaaewqqDy7Y1rn1UO81l8iIK1GjenME75dl16ajbvSSMfv66WXSRCYKIqfgq2KCfxw==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [freebsd]
 
-  '@rolldown/binding-linux-arm-gnueabihf@1.0.0-rc.12':
-    resolution: {integrity: sha512-YqWjAgGC/9M1lz3GR1r1rP79nMgo3mQiiA+Hfo+pvKFK1fAJ1bCi0ZQVh8noOqNacuY1qIcfyVfP6HoyBRZ85Q==}
-    engines: {node: ^20.19.0 || >=22.12.0}
-    cpu: [arm]
-    os: [linux]
-
   '@rolldown/binding-linux-arm-gnueabihf@1.0.0-rc.17':
     resolution: {integrity: sha512-IS+W7epTcwANmFSQFrS1SivEXHtl1JtuQA9wlxrZTcNi6mx+FDOYrakGevvvTwgj2JvWiK8B29/qD9BELZPyXQ==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm]
     os: [linux]
-
-  '@rolldown/binding-linux-arm64-gnu@1.0.0-rc.12':
-    resolution: {integrity: sha512-/I5AS4cIroLpslsmzXfwbe5OmWvSsrFuEw3mwvbQ1kDxJ822hFHIx+vsN/TAzNVyepI/j/GSzrtCIwQPeKCLIg==}
-    engines: {node: ^20.19.0 || >=22.12.0}
-    cpu: [arm64]
-    os: [linux]
-    libc: [glibc]
 
   '@rolldown/binding-linux-arm64-gnu@1.0.0-rc.17':
     resolution: {integrity: sha512-e6usGaHKW5BMNZOymS1UcEYGowQMWcgZ71Z17Sl/h2+ZziNJ1a9n3Zvcz6LdRyIW5572wBCTH/Z+bKuZouGk9Q==}
@@ -1598,13 +1503,6 @@ packages:
     os: [linux]
     libc: [glibc]
 
-  '@rolldown/binding-linux-arm64-musl@1.0.0-rc.12':
-    resolution: {integrity: sha512-V6/wZztnBqlx5hJQqNWwFdxIKN0m38p8Jas+VoSfgH54HSj9tKTt1dZvG6JRHcjh6D7TvrJPWFGaY9UBVOaWPw==}
-    engines: {node: ^20.19.0 || >=22.12.0}
-    cpu: [arm64]
-    os: [linux]
-    libc: [musl]
-
   '@rolldown/binding-linux-arm64-musl@1.0.0-rc.17':
     resolution: {integrity: sha512-b/CgbwAJpmrRLp02RPfhbudf5tZnN9nsPWK82znefso832etkem8H7FSZwxrOI9djcdTP7U6YfNhbRnh7djErg==}
     engines: {node: ^20.19.0 || >=22.12.0}
@@ -1612,24 +1510,10 @@ packages:
     os: [linux]
     libc: [musl]
 
-  '@rolldown/binding-linux-ppc64-gnu@1.0.0-rc.12':
-    resolution: {integrity: sha512-AP3E9BpcUYliZCxa3w5Kwj9OtEVDYK6sVoUzy4vTOJsjPOgdaJZKFmN4oOlX0Wp0RPV2ETfmIra9x1xuayFB7g==}
-    engines: {node: ^20.19.0 || >=22.12.0}
-    cpu: [ppc64]
-    os: [linux]
-    libc: [glibc]
-
   '@rolldown/binding-linux-ppc64-gnu@1.0.0-rc.17':
     resolution: {integrity: sha512-4EII1iNGRUN5WwGbF/kOh/EIkoDN9HsupgLQoXfY+D1oyJm7/F4t5PYU5n8SWZgG0FEwakyM8pGgwcBYruGTlA==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [ppc64]
-    os: [linux]
-    libc: [glibc]
-
-  '@rolldown/binding-linux-s390x-gnu@1.0.0-rc.12':
-    resolution: {integrity: sha512-nWwpvUSPkoFmZo0kQazZYOrT7J5DGOJ/+QHHzjvNlooDZED8oH82Yg67HvehPPLAg5fUff7TfWFHQS8IV1n3og==}
-    engines: {node: ^20.19.0 || >=22.12.0}
-    cpu: [s390x]
     os: [linux]
     libc: [glibc]
 
@@ -1640,26 +1524,12 @@ packages:
     os: [linux]
     libc: [glibc]
 
-  '@rolldown/binding-linux-x64-gnu@1.0.0-rc.12':
-    resolution: {integrity: sha512-RNrafz5bcwRy+O9e6P8Z/OCAJW/A+qtBczIqVYwTs14pf4iV1/+eKEjdOUta93q2TsT/FI0XYDP3TCky38LMAg==}
-    engines: {node: ^20.19.0 || >=22.12.0}
-    cpu: [x64]
-    os: [linux]
-    libc: [glibc]
-
   '@rolldown/binding-linux-x64-gnu@1.0.0-rc.17':
     resolution: {integrity: sha512-cLnjV3xfo7KslbU41Z7z8BH/E1y5mzUYzAqih1d1MDaIGZRCMqTijqLv76/P7fyHuvUcfGsIpqCdddbxLLK9rA==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [linux]
     libc: [glibc]
-
-  '@rolldown/binding-linux-x64-musl@1.0.0-rc.12':
-    resolution: {integrity: sha512-Jpw/0iwoKWx3LJ2rc1yjFrj+T7iHZn2JDg1Yny1ma0luviFS4mhAIcd1LFNxK3EYu3DHWCps0ydXQ5i/rrJ2ig==}
-    engines: {node: ^20.19.0 || >=22.12.0}
-    cpu: [x64]
-    os: [linux]
-    libc: [musl]
 
   '@rolldown/binding-linux-x64-musl@1.0.0-rc.17':
     resolution: {integrity: sha512-0phclDw1spsL7dUB37sIARuis2tAgomCJXAHZlpt8PXZ4Ba0dRP1e+66lsRqrfhISeN9bEGNjQs+T/Fbd7oYGw==}
@@ -1668,33 +1538,16 @@ packages:
     os: [linux]
     libc: [musl]
 
-  '@rolldown/binding-openharmony-arm64@1.0.0-rc.12':
-    resolution: {integrity: sha512-vRugONE4yMfVn0+7lUKdKvN4D5YusEiPilaoO2sgUWpCvrncvWgPMzK00ZFFJuiPgLwgFNP5eSiUlv2tfc+lpA==}
-    engines: {node: ^20.19.0 || >=22.12.0}
-    cpu: [arm64]
-    os: [openharmony]
-
   '@rolldown/binding-openharmony-arm64@1.0.0-rc.17':
     resolution: {integrity: sha512-0ag/hEgXOwgw4t8QyQvUCxvEg+V0KBcA6YuOx9g0r02MprutRF5dyljgm3EmR02O292UX7UeS6HzWHAl6KgyhA==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [openharmony]
 
-  '@rolldown/binding-wasm32-wasi@1.0.0-rc.12':
-    resolution: {integrity: sha512-ykGiLr/6kkiHc0XnBfmFJuCjr5ZYKKofkx+chJWDjitX+KsJuAmrzWhwyOMSHzPhzOHOy7u9HlFoa5MoAOJ/Zg==}
-    engines: {node: '>=14.0.0'}
-    cpu: [wasm32]
-
   '@rolldown/binding-wasm32-wasi@1.0.0-rc.17':
     resolution: {integrity: sha512-LEXei6vo0E5wTGwpkJ4KoT3OZJRnglwldt5ziLzOlc6qqb55z4tWNq2A+PFqCJuvWWdP53CVhG1Z9NtToDPJrA==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [wasm32]
-
-  '@rolldown/binding-win32-arm64-msvc@1.0.0-rc.12':
-    resolution: {integrity: sha512-5eOND4duWkwx1AzCxadcOrNeighiLwMInEADT0YM7xeEOOFcovWZCq8dadXgcRHSf3Ulh1kFo/qvzoFiCLOL1Q==}
-    engines: {node: ^20.19.0 || >=22.12.0}
-    cpu: [arm64]
-    os: [win32]
 
   '@rolldown/binding-win32-arm64-msvc@1.0.0-rc.17':
     resolution: {integrity: sha512-gUmyzBl3SPMa6hrqFUth9sVfcLBlYsbMzBx5PlexMroZStgzGqlZ26pYG89rBb45Mnia+oil6YAIFeEWGWhoZA==}
@@ -1702,20 +1555,11 @@ packages:
     cpu: [arm64]
     os: [win32]
 
-  '@rolldown/binding-win32-x64-msvc@1.0.0-rc.12':
-    resolution: {integrity: sha512-PyqoipaswDLAZtot351MLhrlrh6lcZPo2LSYE+VDxbVk24LVKAGOuE4hb8xZQmrPAuEtTZW8E6D2zc5EUZX4Lw==}
-    engines: {node: ^20.19.0 || >=22.12.0}
-    cpu: [x64]
-    os: [win32]
-
   '@rolldown/binding-win32-x64-msvc@1.0.0-rc.17':
     resolution: {integrity: sha512-3hkiolcUAvPB9FLb3UZdfjVVNWherN1f/skkGWJP/fgSQhYUZpSIRr0/I8ZK9TkF3F7kxvJAk0+IcKvPHk9qQg==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [win32]
-
-  '@rolldown/pluginutils@1.0.0-rc.12':
-    resolution: {integrity: sha512-HHMwmarRKvoFsJorqYlFeFRzXZqCt2ETQlEDOb9aqssrnVBB1/+xgTGtuTrIk5vzLNX1MjMtTf7W9z3tsSbrxw==}
 
   '@rolldown/pluginutils@1.0.0-rc.17':
     resolution: {integrity: sha512-n8iosDOt6Ig1UhJ2AYqoIhHWh/isz0xpicHTzpKBeotdVsTEcxsSA/i3EVM7gQAj0rU27OLAxCjzlj15IWY7bg==}
@@ -1900,21 +1744,10 @@ packages:
     peerDependencies:
       storybook: ^10.3.5
 
-  '@storybook/addon-docs@10.3.6':
-    resolution: {integrity: sha512-TvIdADVPtauxW0LzXIpIv7X6GxwetorhyNh+6+7MHC27XSBCWVxxRUwL63YeLlHTuXsIk0quG3b1xgwVRzWOJA==}
-    peerDependencies:
-      storybook: ^10.3.6
-
   '@storybook/builder-vite@10.3.5':
     resolution: {integrity: sha512-i4KwCOKbhtlbQIbhm53+Kk7bMnxa0cwTn1pxmtA/x5wm1Qu7FrrBQV0V0DNjkUqzcSKo1CjspASJV/HlY0zYlw==}
     peerDependencies:
       storybook: ^10.3.5
-      vite: ^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0
-
-  '@storybook/builder-vite@10.3.6':
-    resolution: {integrity: sha512-gpvR/sE4BcrFtmQZ+Ker7zD23oQzoVeqD9nF6cK6yzY+Q0svJXyX2EPmFG4y+EwygD5/vNzDpP84gGMut8VRwg==}
-    peerDependencies:
-      storybook: ^10.3.6
       vite: ^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0
 
   '@storybook/csf-plugin@10.3.5':
@@ -1935,24 +1768,6 @@ packages:
       webpack:
         optional: true
 
-  '@storybook/csf-plugin@10.3.6':
-    resolution: {integrity: sha512-9kBf7VRdRqTSIYo+rPtVn5yjYYyK8kP2QhEYx3oiXvfwy4RexmbJnhk/tXa/lNiTqukA1TqaWQ2+5MqF4fu6YQ==}
-    peerDependencies:
-      esbuild: '*'
-      rollup: '*'
-      storybook: ^10.3.6
-      vite: '*'
-      webpack: '*'
-    peerDependenciesMeta:
-      esbuild:
-        optional: true
-      rollup:
-        optional: true
-      vite:
-        optional: true
-      webpack:
-        optional: true
-
   '@storybook/global@5.0.0':
     resolution: {integrity: sha512-FcOqPAXACP0I3oJ/ws6/rrPT9WGhu915Cg8D02a9YxLo0DE9zI+a9A5gRGvmQ09fiWPukqI8ZAEoQEdWUKMQdQ==}
 
@@ -1961,20 +1776,10 @@ packages:
     peerDependencies:
       storybook: ^10.3.5
 
-  '@storybook/html-vite@10.3.6':
-    resolution: {integrity: sha512-yurdzG3UYQdGEjzc005jPC8cFeQCLX6hQebGwTCOGBfn9ZDwmHprQctHbKPcOZ+da96wspBUSpi1H4c+PDKH3w==}
-    peerDependencies:
-      storybook: ^10.3.6
-
   '@storybook/html@10.3.5':
     resolution: {integrity: sha512-htbHaCjCMwVTFihnnjieGWFG10ixEVTKNGY7jkgp6ztH50fX5kp8N4F06eUMaFDPW+U7gcUiLIb2fv+oNIYImA==}
     peerDependencies:
       storybook: ^10.3.5
-
-  '@storybook/html@10.3.6':
-    resolution: {integrity: sha512-Ty3RsKCy3RVYu9naFluYswmqOw+B5VYHSjQpwLl7kmTxk+Ykz14js4Rj7aV1tdyH0R8SM1g1CfL6QOizNCl96g==}
-    peerDependencies:
-      storybook: ^10.3.6
 
   '@storybook/icons@2.0.1':
     resolution: {integrity: sha512-/smVjw88yK3CKsiuR71vNgWQ9+NuY2L+e8X7IMrFjexjm6ZR8ULrV2DRkTA61aV6ryefslzHEGDInGpnNeIocg==}
@@ -1988,13 +1793,6 @@ packages:
       react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
       react-dom: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
       storybook: ^10.3.5
-
-  '@storybook/react-dom-shim@10.3.6':
-    resolution: {integrity: sha512-/Tu1gPu+Fw+zOnAGmxRmOD30FX3a04LxcTAKflEtdpmtIMVR5bA3qpjy+f5YhoyDCecbXyKmL1OeIU2FIIZHqQ==}
-    peerDependencies:
-      react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
-      react-dom: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
-      storybook: ^10.3.6
 
   '@swc/cli@0.8.1':
     resolution: {integrity: sha512-L+ACCGHCiS0VqHVep/INLVnvRvJ2XooQFLZq4L8snhxw1jsqz+XRcY313UsyPVturPPE1shW3jic7rt3qEQTSQ==}
@@ -2637,9 +2435,6 @@ packages:
   ajv@8.20.0:
     resolution: {integrity: sha512-Thbli+OlOj+iMPYFBVBfJ3OmCAnaSyNn4M1vz9T6Gka5Jt9ba/HIR56joy65tY6kx/FCF5VXNB819Y7/GUrBGA==}
 
-  animate.css@4.1.1:
-    resolution: {integrity: sha512-+mRmCTv6SbCmtYJCN4faJMNFVNN5EuCTTprDTAo7YzIGji2KADmakjVA3+8mVDkZ2Bf09vayB35lSQIex2+QaQ==}
-
   ansi-colors@4.1.3:
     resolution: {integrity: sha512-/6w/C21Pm1A7aZitlI5Ni/2J6FFQN8i1Cvz3kHABAAbw93v/NlvKdVOqz7CCWz/3iv/JplRSEEZ83XION15ovw==}
     engines: {node: '>=6'}
@@ -2732,9 +2527,6 @@ packages:
   asynckit@0.4.0:
     resolution: {integrity: sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==}
 
-  awesomplete@1.1.7:
-    resolution: {integrity: sha512-hwClzFReIIfheoMWpoJ7juLp1o6Q7YjTtEdZIGfXvhRHA9ewKM03VS4ZoK+OEFIKM066PfQt9pzRIGV1TguRBw==}
-
   axios@1.15.2:
     resolution: {integrity: sha512-wLrXxPtcrPTsNlJmKjkPnNPK2Ihe0hn0wGSaTEiHRPxwjvJwT3hKmXF4dpqxmPO9SoNb2FsYXj/xEo0gHN+D5A==}
 
@@ -2800,11 +2592,6 @@ packages:
     resolution: {integrity: sha512-lGe34o6EHj9y3Kts9R4ZYs/Gr+6N7MCaMlIFA3F1R2O5/m7K06AxfSeO5530PEERE6/WyEg3lsuyw4GHlPZHog==}
     engines: {node: ^4.5.0 || >= 5.9}
 
-  baseline-browser-mapping@2.10.24:
-    resolution: {integrity: sha512-I2NkZOOrj2XuguvWCK6OVh9GavsNjZjK908Rq3mIBK25+GD8vPX5w2WdxVqnQ7xx3SrZJiCiZFu+/Oz50oSYSA==}
-    engines: {node: '>=6.0.0'}
-    hasBin: true
-
   baseline-browser-mapping@2.9.19:
     resolution: {integrity: sha512-ipDqC8FrAl/76p2SSWKSI+H9tFwm7vYqXQrItCuiVPt26Km0jS+NzSsBWAaBusvSbQcfJG+JitdMm+wZAgTYqg==}
     hasBin: true
@@ -2858,11 +2645,6 @@ packages:
 
   browserslist@4.28.1:
     resolution: {integrity: sha512-ZC5Bd0LgJXgwGqUknZY/vkUQ04r8NXnJZ3yYi4vDmSiZmC/pdSN0NbNRPxZpbtO4uAfDUAFffO8IZoM3Gj8IkA==}
-    engines: {node: ^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7}
-    hasBin: true
-
-  browserslist@4.28.2:
-    resolution: {integrity: sha512-48xSriZYYg+8qXna9kwqjIVzuQxi+KYWp2+5nCYnYKPTr0LvD89Jqk2Or5ogxz0NUMfIjhh2lIUX/LyX9B4oIg==}
     engines: {node: ^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7}
     hasBin: true
 
@@ -2942,9 +2724,6 @@ packages:
   caniuse-lite@1.0.30001767:
     resolution: {integrity: sha512-34+zUAMhSH+r+9eKmYG+k2Rpt8XttfE4yXAjoZvkAPs15xcYQhyBYdalJ65BzivAvGRMViEjy6oKr/S91loekQ==}
 
-  caniuse-lite@1.0.30001791:
-    resolution: {integrity: sha512-yk0l/YSrOnFZk3UROpDLQD9+kC1l4meK/wed583AXrzoarMGJcbRi2Q4RaUYbKxYAsZ8sWmaSa/DsLmdBeI1vQ==}
-
   catering@2.1.1:
     resolution: {integrity: sha512-K7Qy8O9p76sL3/3m7/zLKbRkyOlSZAgzEaLhyj2mXS8PsCud2Eo4hAb8aLtZqHh0QGqLcb9dlJSu6lHRVENm1w==}
     engines: {node: '>=6'}
@@ -2993,15 +2772,9 @@ packages:
   class-validator@0.15.1:
     resolution: {integrity: sha512-LqoS80HBBSCVhz/3KloUly0ovokxpdOLR++Al3J3+dHXWt9sTKlKd4eYtoxhxyUjoe5+UcIM+5k9MIxyBWnRTw==}
 
-  class-variance-authority@0.7.1:
-    resolution: {integrity: sha512-Ka+9Trutv7G8M6WT6SeiRWz792K5qEqIGEGzXKhAE6xOWAY6pPH8U+9IY3oCMv6kqTmLsv7Xh/2w2RigkePMsg==}
-
   classic-level@1.4.1:
     resolution: {integrity: sha512-qGx/KJl3bvtOHrGau2WklEZuXhS3zme+jf+fsu6Ej7W7IP/C49v7KNlWIsT1jZu0YnfzSIYDGcEWpCa1wKGWXQ==}
     engines: {node: '>=12'}
-
-  classnames@2.5.1:
-    resolution: {integrity: sha512-saHYOzhIQs6wy2sVxTM6bUDsQO4F50V9RQ22qBpEdCW+I+/Wmke2HOl6lS6dTpdxVhb88/I6+Hs+438c3lfUow==}
 
   cli-cursor@3.1.0:
     resolution: {integrity: sha512-I/zHAwsKf9FqGoXM4WWRACob9+SNukZTd94DWF57E4toouRulbCxcUh6RKUEOQlYTHJnzkPMySvPNaaSLNfLZw==}
@@ -3038,10 +2811,6 @@ packages:
   clone@1.0.4:
     resolution: {integrity: sha512-JQHZ2QMW6l3aH/j6xCqQThY/9OH4D/9ls34cgkUBiEeocRTU04tHfKPBsUK1PqZCUQM7GiA0IIXJSuXHI64Kbg==}
     engines: {node: '>=0.8'}
-
-  clsx@2.1.1:
-    resolution: {integrity: sha512-eYm0QWBtUrBWZWG0d386OGAw16Z995PiOVo2B7bjWSbHedGl5e0ZWaq65kOGgUSNesEIDkB9ISbTg/JK9dhCZA==}
-    engines: {node: '>=6'}
 
   cluster-key-slot@1.1.2:
     resolution: {integrity: sha512-RMr0FhtfXemyinomL4hrWcYJxmX6deFdCxpJzhDttxgO1+bcCnkk+9drydLVDmAMG7NE6aN/fl4F7ucU/90gAA==}
@@ -3090,10 +2859,6 @@ packages:
   commander@6.2.1:
     resolution: {integrity: sha512-U7VdrJFnJgo4xjrHpTzu0yrHPGImdsmD95ZlgYSEajAn2JKzDhDTPG9kBTefmObL2w/ngeZnilk+OV9CG3d7UA==}
     engines: {node: '>= 6'}
-
-  commander@7.2.0:
-    resolution: {integrity: sha512-QrWXB+ZQSVPmIWIhtEO9H+gwHaMGYiF5ChvoJ+K9ZGHG/sVsa6yiesAD1GC/x46sET00Xlwo1u49RVVVzvcSkw==}
-    engines: {node: '>= 10'}
 
   commander@8.3.0:
     resolution: {integrity: sha512-OkTL9umf+He2DZkUq8f8J9of7yL6RJKI24dVITBmNfZBmri9zYZQrKkuXiKhyfPSu8tUhnVBB1iKXevvnlR4Ww==}
@@ -3218,10 +2983,6 @@ packages:
       typescript:
         optional: true
 
-  courthive-components@1.1.1:
-    resolution: {integrity: sha512-JsiR7i4ZHWudl+b8uL9vlpgzicENo36q0uqZhnFIq1ROeo9UNlEtToEBH8RVdCJA1vr2JEM9vjwTNSW+teuVCQ==}
-    engines: {node: '>=22'}
-
   create-require@1.1.1:
     resolution: {integrity: sha512-dcKFX3jn0MpIaXjisoRvexIJVEKzaq7z2rZKxf+MSr9TkdmHmsU4m2lcLojrj/FHl8mk5VxMmYA+ftRkP/3oKQ==}
 
@@ -3245,30 +3006,14 @@ packages:
   d3-array@1.2.4:
     resolution: {integrity: sha512-KHW6M86R+FUPYGb3R5XiYjXPq7VzwxZ22buHhAEVG5ztoEcZZMLov530mmccaqA1GghZArjQV46fuc8kUqhhHw==}
 
-  d3-array@3.2.4:
-    resolution: {integrity: sha512-tdQAmyA18i4J7wprpYq8ClcxZy3SC31QMeByyCFyRt7BVHdREQZ5lpzoe5mFEYZUWe+oq8HBvk9JjpibyEV4Jg==}
-    engines: {node: '>=12'}
-
   d3-axis@1.0.12:
     resolution: {integrity: sha512-ejINPfPSNdGFKEOAtnBtdkpr24c4d4jsei6Lg98mxf424ivoDP2956/5HDpIAtmHo85lqT4pruy+zEgvRUBqaQ==}
-
-  d3-axis@3.0.0:
-    resolution: {integrity: sha512-IH5tgjV4jE/GhHkRV0HiVYPDtvfjHQlQfJHs0usq7M30XcSBvOotpmH1IgkcXsO/5gEQZD43B//fc7SRT5S+xw==}
-    engines: {node: '>=12'}
 
   d3-brush@1.1.6:
     resolution: {integrity: sha512-7RW+w7HfMCPyZLifTz/UnJmI5kdkXtpCbombUSs8xniAyo0vIbrDzDwUJB6eJOgl9u5DQOt2TQlYumxzD1SvYA==}
 
-  d3-brush@3.0.0:
-    resolution: {integrity: sha512-ALnjWlVYkXsVIGlOsuWH1+3udkYFI48Ljihfnh8FZPF2QS9o+PzGLBslO0PjzVoHLZ2KCVgAM8NVkXPJB2aNnQ==}
-    engines: {node: '>=12'}
-
   d3-chord@1.0.6:
     resolution: {integrity: sha512-JXA2Dro1Fxw9rJe33Uv+Ckr5IrAa74TlfDEhE/jfLOaXegMQFQTAgAw9WnZL8+HxVBRXaRGCkrNU7pJeylRIuA==}
-
-  d3-chord@3.0.1:
-    resolution: {integrity: sha512-VE5S6TNa+j8msksl7HwjxMHDM2yNK3XCkusIlpX5kwauBfXuyLAtNg9jCp/iHH61tgI4sb6R/EIMWCqEIdjT/g==}
-    engines: {node: '>=12'}
 
   d3-collection@1.0.7:
     resolution: {integrity: sha512-ii0/r5f4sjKNTfh84Di+DpztYwqKhEyUlKoPrzUFfeSkWxjW49xU2QzO9qrPrNkpdI0XJkfzvmTu8V2Zylln6A==}
@@ -3276,178 +3021,75 @@ packages:
   d3-color@1.4.1:
     resolution: {integrity: sha512-p2sTHSLCJI2QKunbGb7ocOh7DgTAn8IrLx21QRc/BSnodXM4sv6aLQlnfpvehFMLZEfBc6g9pH9SWQccFYfJ9Q==}
 
-  d3-color@3.1.0:
-    resolution: {integrity: sha512-zg/chbXyeBtMQ1LbD/WSoW2DpC3I0mpmPdW+ynRTj/x2DAWYrIY7qeZIHidozwV24m4iavr15lNwIwLxRmOxhA==}
-    engines: {node: '>=12'}
-
   d3-contour@1.3.2:
     resolution: {integrity: sha512-hoPp4K/rJCu0ladiH6zmJUEz6+u3lgR+GSm/QdM2BBvDraU39Vr7YdDCicJcxP1z8i9B/2dJLgDC1NcvlF8WCg==}
-
-  d3-contour@4.0.2:
-    resolution: {integrity: sha512-4EzFTRIikzs47RGmdxbeUvLWtGedDUNkTcmzoeyg4sP/dvCexO47AaQL7VKy/gul85TOxw+IBgA8US2xwbToNA==}
-    engines: {node: '>=12'}
-
-  d3-delaunay@6.0.4:
-    resolution: {integrity: sha512-mdjtIZ1XLAM8bm/hx3WwjfHt6Sggek7qH043O8KEjDXN40xi3vx/6pYSVTwLjEgiXQTbvaouWKynLBiUZ6SK6A==}
-    engines: {node: '>=12'}
 
   d3-dispatch@1.0.6:
     resolution: {integrity: sha512-fVjoElzjhCEy+Hbn8KygnmMS7Or0a9sI2UzGwoB7cCtvI1XpVN9GpoYlnb3xt2YV66oXYb1fLJ8GMvP4hdU1RA==}
 
-  d3-dispatch@3.0.1:
-    resolution: {integrity: sha512-rzUyPU/S7rwUflMyLc1ETDeBj0NRuHKKAcvukozwhshr6g6c5d8zh4c2gQjY2bZ0dXeGLWc1PF174P2tVvKhfg==}
-    engines: {node: '>=12'}
-
   d3-drag@1.2.5:
     resolution: {integrity: sha512-rD1ohlkKQwMZYkQlYVCrSFxsWPzI97+W+PaEIBNTMxRuxz9RF0Hi5nJWHGVJ3Om9d2fRTe1yOBINJyy/ahV95w==}
-
-  d3-drag@3.0.0:
-    resolution: {integrity: sha512-pWbUJLdETVA8lQNJecMxoXfH6x+mO2UQo8rSmZ+QqxcbyA3hfeprFgIT//HW2nlHChWeIIMwS2Fq+gEARkhTkg==}
-    engines: {node: '>=12'}
 
   d3-dsv@1.2.0:
     resolution: {integrity: sha512-9yVlqvZcSOMhCYzniHE7EVUws7Fa1zgw+/EAV2BxJoG3ME19V6BQFBwI855XQDsxyOuG7NibqRMTtiF/Qup46g==}
     hasBin: true
 
-  d3-dsv@3.0.1:
-    resolution: {integrity: sha512-UG6OvdI5afDIFP9w4G0mNq50dSOsXHJaRE8arAS5o9ApWnIElp8GZw1Dun8vP8OyHOZ/QJUKUJwxiiCCnUwm+Q==}
-    engines: {node: '>=12'}
-    hasBin: true
-
   d3-ease@1.0.7:
     resolution: {integrity: sha512-lx14ZPYkhNx0s/2HX5sLFUI3mbasHjSSpwO/KaaNACweVwxUruKyWVcb293wMv1RqTPZyZ8kSZ2NogUZNcLOFQ==}
-
-  d3-ease@3.0.1:
-    resolution: {integrity: sha512-wR/XK3D3XcLIZwpbvQwQ5fK+8Ykds1ip7A2Txe0yxncXSdq1L9skcG7blcedkOX+ZcgxGAmLX1FrRGbADwzi0w==}
-    engines: {node: '>=12'}
 
   d3-fetch@1.2.0:
     resolution: {integrity: sha512-yC78NBVcd2zFAyR/HnUiBS7Lf6inSCoWcSxFfw8FYL7ydiqe80SazNwoffcqOfs95XaLo7yebsmQqDKSsXUtvA==}
 
-  d3-fetch@3.0.1:
-    resolution: {integrity: sha512-kpkQIM20n3oLVBKGg6oHrUchHM3xODkTzjMoj7aWQFq5QEM+R6E4WkzT5+tojDY7yjez8KgCBRoj4aEr99Fdqw==}
-    engines: {node: '>=12'}
-
   d3-force@1.2.1:
     resolution: {integrity: sha512-HHvehyaiUlVo5CxBJ0yF/xny4xoaxFxDnBXNvNcfW9adORGZfyNF1dj6DGLKyk4Yh3brP/1h3rnDzdIAwL08zg==}
-
-  d3-force@3.0.0:
-    resolution: {integrity: sha512-zxV/SsA+U4yte8051P4ECydjD/S+qeYtnaIyAs9tgHCqfguma/aAQDjo85A9Z6EKhBirHRJHXIgJUlffT4wdLg==}
-    engines: {node: '>=12'}
 
   d3-format@1.4.5:
     resolution: {integrity: sha512-J0piedu6Z8iB6TbIGfZgDzfXxUFN3qQRMofy2oPdXzQibYGqPB/9iMcxr/TGalU+2RsyDO+U4f33id8tbnSRMQ==}
 
-  d3-format@3.1.2:
-    resolution: {integrity: sha512-AJDdYOdnyRDV5b6ArilzCPPwc1ejkHcoyFarqlPqT7zRYjhavcT3uSrqcMvsgh2CgoPbK3RCwyHaVyxYcP2Arg==}
-    engines: {node: '>=12'}
-
   d3-geo@1.12.1:
     resolution: {integrity: sha512-XG4d1c/UJSEX9NfU02KwBL6BYPj8YKHxgBEw5om2ZnTRSbIcego6dhHwcxuSR3clxh0EpE38os1DVPOmnYtTPg==}
-
-  d3-geo@3.1.1:
-    resolution: {integrity: sha512-637ln3gXKXOwhalDzinUgY83KzNWZRKbYubaG+fGVuc/dxO64RRljtCTnf5ecMyE1RIdtqpkVcq0IbtU2S8j2Q==}
-    engines: {node: '>=12'}
 
   d3-hierarchy@1.1.9:
     resolution: {integrity: sha512-j8tPxlqh1srJHAtxfvOUwKNYJkQuBFdM1+JAUfq6xqH5eAqf93L7oG1NVqDa4CpFZNvnNKtCYEUC8KY9yEn9lQ==}
 
-  d3-hierarchy@3.1.2:
-    resolution: {integrity: sha512-FX/9frcub54beBdugHjDCdikxThEqjnR93Qt7PvQTOHxyiNCAlvMrHhclk3cD5VeAaq9fxmfRp+CnWw9rEMBuA==}
-    engines: {node: '>=12'}
-
   d3-interpolate@1.4.0:
     resolution: {integrity: sha512-V9znK0zc3jOPV4VD2zZn0sDhZU3WAE2bmlxdIwwQPPzPjvyLkd8B3JUVdS1IDUFDkWZ72c9qnv1GK2ZagTZ8EA==}
-
-  d3-interpolate@3.0.1:
-    resolution: {integrity: sha512-3bYs1rOD33uo8aqJfKP3JWPAibgw8Zm2+L9vBKEHJ2Rg+viTR7o5Mmv5mZcieN+FRYaAOWX5SJATX6k1PWz72g==}
-    engines: {node: '>=12'}
 
   d3-path@1.0.9:
     resolution: {integrity: sha512-VLaYcn81dtHVTjEHd8B+pbe9yHWpXKZUC87PzoFmsFrJqgFwDe/qxfp5MlfsfM1V5E/iVt0MmEbWQ7FVIXh/bg==}
 
-  d3-path@3.1.0:
-    resolution: {integrity: sha512-p3KP5HCf/bvjBSSKuXid6Zqijx7wIfNW+J/maPs+iwR35at5JCbLUT0LzF1cnjbCHWhqzQTIN2Jpe8pRebIEFQ==}
-    engines: {node: '>=12'}
-
   d3-polygon@1.0.6:
     resolution: {integrity: sha512-k+RF7WvI08PC8reEoXa/w2nSg5AUMTi+peBD9cmFc+0ixHfbs4QmxxkarVal1IkVkgxVuk9JSHhJURHiyHKAuQ==}
-
-  d3-polygon@3.0.1:
-    resolution: {integrity: sha512-3vbA7vXYwfe1SYhED++fPUQlWSYTTGmFmQiany/gdbiWgU/iEyQzyymwL9SkJjFFuCS4902BSzewVGsHHmHtXg==}
-    engines: {node: '>=12'}
 
   d3-quadtree@1.0.7:
     resolution: {integrity: sha512-RKPAeXnkC59IDGD0Wu5mANy0Q2V28L+fNe65pOCXVdVuTJS3WPKaJlFHer32Rbh9gIo9qMuJXio8ra4+YmIymA==}
 
-  d3-quadtree@3.0.1:
-    resolution: {integrity: sha512-04xDrxQTDTCFwP5H6hRhsRcb9xxv2RzkcsygFzmkSIOJy3PeRJP7sNk3VRIbKXcog561P9oU0/rVH6vDROAgUw==}
-    engines: {node: '>=12'}
-
   d3-random@1.1.2:
     resolution: {integrity: sha512-6AK5BNpIFqP+cx/sreKzNjWbwZQCSUatxq+pPRmFIQaWuoD+NrbVWw7YWpHiXpCQ/NanKdtGDuB+VQcZDaEmYQ==}
-
-  d3-random@3.0.1:
-    resolution: {integrity: sha512-FXMe9GfxTxqd5D6jFsQ+DJ8BJS4E/fT5mqqdjovykEB2oFbTMDVdg1MGFxfQW+FBOGoB++k8swBrgwSHT1cUXQ==}
-    engines: {node: '>=12'}
 
   d3-scale-chromatic@1.5.0:
     resolution: {integrity: sha512-ACcL46DYImpRFMBcpk9HhtIyC7bTBR4fNOPxwVSl0LfulDAwyiHyPOTqcDG1+t5d4P9W7t/2NAuWu59aKko/cg==}
 
-  d3-scale-chromatic@3.1.0:
-    resolution: {integrity: sha512-A3s5PWiZ9YCXFye1o246KoscMWqf8BsD9eRiJ3He7C9OBaxKhAd5TFCdEx/7VbKtxxTsu//1mMJFrEt572cEyQ==}
-    engines: {node: '>=12'}
-
   d3-scale@2.2.2:
     resolution: {integrity: sha512-LbeEvGgIb8UMcAa0EATLNX0lelKWGYDQiPdHj+gLblGVhGLyNbaCn3EvrJf0A3Y/uOOU5aD6MTh5ZFCdEwGiCw==}
-
-  d3-scale@4.0.2:
-    resolution: {integrity: sha512-GZW464g1SH7ag3Y7hXjf8RoUuAFIqklOAq3MRl4OaWabTFJY9PN/E1YklhXLh+OQ3fM9yS2nOkCoS+WLZ6kvxQ==}
-    engines: {node: '>=12'}
 
   d3-selection@1.4.2:
     resolution: {integrity: sha512-SJ0BqYihzOjDnnlfyeHT0e30k0K1+5sR3d5fNueCNeuhZTnGw4M4o8mqJchSwgKMXCNFo+e2VTChiSJ0vYtXkg==}
 
-  d3-selection@3.0.0:
-    resolution: {integrity: sha512-fmTRWbNMmsmWq6xJV8D19U/gw/bwrHfNXxrIN+HfZgnzqTHp9jOmKMhsTUjXOJnZOdZY9Q28y4yebKzqDKlxlQ==}
-    engines: {node: '>=12'}
-
   d3-shape@1.3.7:
     resolution: {integrity: sha512-EUkvKjqPFUAZyOlhY5gzCxCeI0Aep04LwIRpsZ/mLFelJiUfnK56jo5JMDSE7yyP2kLSb6LtF+S5chMk7uqPqw==}
-
-  d3-shape@3.2.0:
-    resolution: {integrity: sha512-SaLBuwGm3MOViRq2ABk3eLoxwZELpH6zhl3FbAoJ7Vm1gofKx6El1Ib5z23NUEhF9AsGl7y+dzLe5Cw2AArGTA==}
-    engines: {node: '>=12'}
 
   d3-time-format@2.3.0:
     resolution: {integrity: sha512-guv6b2H37s2Uq/GefleCDtbe0XZAuy7Wa49VGkPVPMfLL9qObgBST3lEHJBMUp8S7NdLQAGIvr2KXk8Hc98iKQ==}
 
-  d3-time-format@4.1.0:
-    resolution: {integrity: sha512-dJxPBlzC7NugB2PDLwo9Q8JiTR3M3e4/XANkreKSUxF8vvXKqm1Yfq4Q5dl8budlunRVlUUaDUgFt7eA8D6NLg==}
-    engines: {node: '>=12'}
-
   d3-time@1.1.0:
     resolution: {integrity: sha512-Xh0isrZ5rPYYdqhAVk8VLnMEidhz5aP7htAADH6MfzgmmicPkTo8LhkLxci61/lCB7n7UmE3bN0leRt+qvkLxA==}
-
-  d3-time@3.1.0:
-    resolution: {integrity: sha512-VqKjzBLejbSMT4IgbmVgDjpkYrNWUYJnbCGo874u7MMKIWsILRX+OpX/gTk8MqjpT1A/c6HY2dCA77ZN0lkQ2Q==}
-    engines: {node: '>=12'}
 
   d3-timer@1.0.10:
     resolution: {integrity: sha512-B1JDm0XDaQC+uvo4DT79H0XmBskgS3l6Ve+1SBCfxgmtIb1AVrPIoqd+nPSv+loMX8szQ0sVUhGngL7D5QPiXw==}
 
-  d3-timer@3.0.1:
-    resolution: {integrity: sha512-ndfJ/JxxMd3nw31uyKoY2naivF+r29V+Lc0svZxe1JvvIRmi8hUsrMvdOwgS1o6uBHmiz91geQ0ylPP0aj1VUA==}
-    engines: {node: '>=12'}
-
   d3-transition@1.3.2:
     resolution: {integrity: sha512-sc0gRU4PFqZ47lPVHloMn9tlPcv8jxgOQg+0zjhfZXMQuvppjG6YuwdMBE0TuqCZjeJkLecku/l9R0JPcRhaDA==}
-
-  d3-transition@3.0.1:
-    resolution: {integrity: sha512-ApKvfjsSR6tg06xrL434C0WydLr7JewBB3V+/39RMHsaXTOG0zmt/OAXeng5M5LBm0ojmxJrpomQVZ1aPvBL4w==}
-    engines: {node: '>=12'}
-    peerDependencies:
-      d3-selection: 2 - 3
 
   d3-voronoi@1.1.4:
     resolution: {integrity: sha512-dArJ32hchFsrQ8uMiTBLq256MpnZjeuBtdHpaDlYuQyjU0CVzCJl/BVW+SkszaAeH95D/8gxqAhgx0ouAWAfRg==}
@@ -3455,16 +3097,8 @@ packages:
   d3-zoom@1.8.3:
     resolution: {integrity: sha512-VoLXTK4wvy1a0JpH2Il+F2CiOhVu7VRXWF5M/LroMIh3/zBAC3WAt7QoIvPibOavVo20hN6/37vwAsdBejLyKQ==}
 
-  d3-zoom@3.0.0:
-    resolution: {integrity: sha512-b8AmV3kfQaqWAuacbPuNbL6vahnOJflOhexLzMMNLga62+/nh0JzvJ0aO/5a5MVgUFGS7Hu1P9P03o3fJkDCyw==}
-    engines: {node: '>=12'}
-
   d3@5.16.0:
     resolution: {integrity: sha512-4PL5hHaHwX4m7Zr1UapXW23apo6pexCgdetdJ5kTmADpG/7T9Gkxw0M0tf/pjoB63ezCCm0u5UaFYy2aMt0Mcw==}
-
-  d3@7.9.0:
-    resolution: {integrity: sha512-e1U46jVP+w7Iut8Jt8ri1YsPOvFpg46k+K8TpCb0P+zjCkjkPnV7WzfDJzMHy1LnA+wj5pLT1wjO901gLXeEhA==}
-    engines: {node: '>=12'}
 
   date-fns@2.30.0:
     resolution: {integrity: sha512-fnULvOpxnC5/Vg3NCiWelDsLiUc9bRwAPs/+LfTLNvetFCtCTN+yQz15C/fs4AwX1R9K5GLtLfn8QW+dWisaAw==}
@@ -3472,9 +3106,6 @@ packages:
 
   dayjs@1.11.10:
     resolution: {integrity: sha512-vjAczensTgRcqDERK0SR2XMwsF/tSvnvlv6VcF2GIhg6Sx4yOIt/irsr1RDJsKiIyBzJDpCoXiWWq28MqH2cnQ==}
-
-  dayjs@1.11.20:
-    resolution: {integrity: sha512-YbwwqR/uYpeoP4pu043q+LTDLFBLApUP6VxRihdfNTqu4ubqMlGDLd6ErXhEgsyvY0K6nCs7nggYumAN+9uEuQ==}
 
   debug@2.6.9:
     resolution: {integrity: sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==}
@@ -3543,9 +3174,6 @@ packages:
   define-lazy-prop@3.0.0:
     resolution: {integrity: sha512-N+MeXYoqr3pOgn8xfyRPREN7gHakLYjhsHhWGT3fWAiL4IkAt0iDw14QiiEm2bE30c5XX5q0FtAA3CK5f9/BUg==}
     engines: {node: '>=12'}
-
-  delaunator@5.1.0:
-    resolution: {integrity: sha512-AGrQ4QSgssa1NGmWmLPqN5NY2KajF5MqxetNEO+o0n3ZwZZeTmt7bBnvzHWrmkZFxGgr4HdyFgelzgi06otLuQ==}
 
   delayed-stream@1.0.0:
     resolution: {integrity: sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==}
@@ -3646,9 +3274,6 @@ packages:
   electron-to-chromium@1.5.286:
     resolution: {integrity: sha512-9tfDXhJ4RKFNerfjdCcZfufu49vg620741MNs26a9+bhLThdB+plgMeou98CAaHu/WATj2iHOOHTp1hWtABj2A==}
 
-  electron-to-chromium@1.5.348:
-    resolution: {integrity: sha512-QC2X59nRlycQQMc4ZXjSVBX+tSgJfgRtcrYHbIZLgOV2dCvefoQGegLR7lLXKgpPpSuVmJU19LMzGrSa2C7k3Q==}
-
   email-addresses@5.0.0:
     resolution: {integrity: sha512-4OIPYlA6JXqtVn8zpHpGiI7vE6EQOAg16aGnDMIAlZVinnoZ8208tW1hAbjWydgN/4PLTT9q+O1K6AH/vALJGw==}
 
@@ -3692,10 +3317,6 @@ packages:
     resolution: {integrity: sha512-Qohcme7V1inbAfvjItgw0EaxVX5q2rdVEZHRBrEQdRZTssLDGsL8Lwrznl8oQ/6kuTJONLaDcGjkNP247XEhcA==}
     engines: {node: '>=10.13.0'}
 
-  enhanced-resolve@5.21.0:
-    resolution: {integrity: sha512-otxSQPw4lkOZWkHpB3zaEQs6gWYEsmX4xQF68ElXC/TWvGxGMSGOvoNbaLXm6/cS/fSfHtsEdw90y20PCd+sCA==}
-    engines: {node: '>=10.13.0'}
-
   entities@4.5.0:
     resolution: {integrity: sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw==}
     engines: {node: '>=0.12'}
@@ -3725,9 +3346,6 @@ packages:
 
   es-module-lexer@2.0.0:
     resolution: {integrity: sha512-5POEcUuZybH7IdmGsD8wlf0AI55wMecM9rVBTI/qEAy2c1kTOm3DjFYjrBdI2K3BaJjJYfYFeRtM0t9ssnRuxw==}
-
-  es-module-lexer@2.1.0:
-    resolution: {integrity: sha512-n27zTYMjYu1aj4MjCWzSP7G9r75utsaoc8m61weK+W8JMBGGQybd43GstCXZ3WNmSFtGT9wi59qQTW6mhTR5LQ==}
 
   es-object-atoms@1.1.1:
     resolution: {integrity: sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA==}
@@ -4010,9 +3628,6 @@ packages:
   flatted@3.3.3:
     resolution: {integrity: sha512-GX+ysw4PBCz0PzosHDepZGANEuFCMLrnRTiEy9McGjmkCQYwRq4A/X786G/fjM/+OjsWSU1ZrY5qyARZmO/uwg==}
 
-  focus-trap@8.1.0:
-    resolution: {integrity: sha512-T65crff26CKV2CZ3csg5y05r+560srp0b8EbAif35euW58hzklVf/Gb4Q+/HCtB8e9III3QFEyk5BWV5XJuOyw==}
-
   follow-redirects@1.16.0:
     resolution: {integrity: sha512-y5rN/uOsadFT/JfYwhxRS5R7Qce+g3zG97+JrtFZlC9klX/W5hD7iiLzScI4nZqUS7DNUdhPgw4xI8W2LuXlUw==}
     engines: {node: '>=4.0'}
@@ -4262,20 +3877,8 @@ packages:
     engines: {node: '>=18'}
     hasBin: true
 
-  i18next@26.0.8:
-    resolution: {integrity: sha512-BRzLom0mhDhV9v0QhgUUHWQJuwFmnr1194xEcNLYD6ym8y8s542n4jXUvRLnhNTbh9PmpU6kGZamyuGHQMsGjw==}
-    peerDependencies:
-      typescript: ^5 || ^6
-    peerDependenciesMeta:
-      typescript:
-        optional: true
-
   iconv-lite@0.4.24:
     resolution: {integrity: sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==}
-    engines: {node: '>=0.10.0'}
-
-  iconv-lite@0.6.3:
-    resolution: {integrity: sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==}
     engines: {node: '>=0.10.0'}
 
   iconv-lite@0.7.0:
@@ -4326,10 +3929,6 @@ packages:
 
   inspect-with-kind@1.0.5:
     resolution: {integrity: sha512-MAQUJuIo7Xqk8EVNP+6d3CKq9c80hi4tjIbIAT6lmGW9W6WzlHiu9PS8uSuUYU+Do+j1baiFp3H25XEVxDIG2g==}
-
-  internmap@2.0.3:
-    resolution: {integrity: sha512-5Hh7Y1wQbvY5ooGgPbDaL5iYLAPzMTUrjMulskHLH6wnv/A+1q5rgEaiuqEjB+oxGXIVZs1FF+R/KPN3ZSQYYg==}
-    engines: {node: '>=12'}
 
   ipaddr.js@1.9.1:
     resolution: {integrity: sha512-0KI/607xoxSToH7GjN1FfSbLoU0+btTicjsQSWQlh/hZykN8KpmMf7uYwPW3R+akZ6R/w18ZlXSHBYXiYUPO3g==}
@@ -4665,10 +4264,6 @@ packages:
   jws@4.0.1:
     resolution: {integrity: sha512-EKI/M/yqPncGUUh44xz0PxSidXFr/+r0pA70+gIYhjv+et7yxM+s29Y+VGDkovRofQem0fs7Uvf4+YmAdyRduA==}
 
-  jwt-decode@4.0.0:
-    resolution: {integrity: sha512-+KJGIyHgkGuIq3IEBNftfhW/LfWhXUIY6OmyVWjliu5KH1y0fw7VQ8YndE2O4qZdMSd9SqbnC8GOcZEy0Om7sA==}
-    engines: {node: '>=18'}
-
   keyv@4.5.4:
     resolution: {integrity: sha512-oxVHkHR/EJf2CNXnWxRLW6mg7JyCCUcG0DtEGmL2ctUo1PNTin1PUil+r/+4r5MpVgC/fn1kjsx7mjSujKqIpw==}
 
@@ -4794,10 +4389,6 @@ packages:
 
   loader-runner@4.3.1:
     resolution: {integrity: sha512-IWqP2SCPhyVFTBtRcgMHdzlf9ul25NwaFx4wCEH/KjAXuuHY4yNjvPXsBokp8jCB936PyWRaPKUNh8NvylLp2Q==}
-    engines: {node: '>=6.11.5'}
-
-  loader-runner@4.3.2:
-    resolution: {integrity: sha512-DFEqQ3ihfS9blba08cLfYf1NRAIEm+dDjic073DRDc3/JspI/8wYmtDsHwd3+4hwvdxSK7PGaElfTmm0awWJ4w==}
     engines: {node: '>=6.11.5'}
 
   locate-path@5.0.0:
@@ -5045,11 +4636,6 @@ packages:
     resolution: {integrity: sha512-WWdIxpyjEn+FhQJQQv9aQAYlHoNVdzIzUySNV1gHUPDSdZJ3yZn7pAAbQcV7B56Mvu881q9FZV+0Vx2xC44VWA==}
     engines: {node: ^18.17.0 || >=20.5.0}
 
-  nanoid@3.3.11:
-    resolution: {integrity: sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==}
-    engines: {node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1}
-    hasBin: true
-
   nanoid@3.3.12:
     resolution: {integrity: sha512-ZB9RH/39qpq5Vu6Y+NmUaFhQR6pp+M2Xt76XBnEwDaGcVAqhlvxrl3B2bKS5D3NH3QR76v3aSrKaF/Kiy7lEtQ==}
     engines: {node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1}
@@ -5065,9 +4651,6 @@ packages:
 
   natural-compare@1.4.0:
     resolution: {integrity: sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==}
-
-  navigo@8.11.1:
-    resolution: {integrity: sha512-e3sc1UzakF+bWquC8/dbPCgo7LgPEW1ekgwb4pmEcl8tOc/I7lML8r7HBql+b0VRk7tJWTZqtkeObwJAVR1pxg==}
 
   negotiator@0.6.3:
     resolution: {integrity: sha512-+EUsqGPLsM+j/zdChZjsnX51g4XrHFOIXwfnCVPGlQk/k5giakcKsuxCObBRu6DSm9opw/O6slWbJdghQM4bBg==}
@@ -5102,9 +4685,6 @@ packages:
 
   node-releases@2.0.27:
     resolution: {integrity: sha512-nmh3lCkYZ3grZvqcCH+fjmQ7X+H0OeZgP40OierEaAptX4XofMh5kwNbWh7lBduUzCcV/8kZ+NDLCwm2iorIlA==}
-
-  node-releases@2.0.38:
-    resolution: {integrity: sha512-3qT/88Y3FbH/Kx4szpQQ4HzUbVrHPKTLVpVocKiLfoYvw9XSGOX2FmD2d6DrXbVYyAQTF2HeF6My8jmzx7/CRw==}
 
   normalize-path@3.0.0:
     resolution: {integrity: sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==}
@@ -5356,10 +4936,6 @@ packages:
     resolution: {integrity: sha512-Nc3IT5yHzflTfbjgqWcCPpo7DaKy4FnpB0l/zCAW0Tc7jxAiuqSxHasntB3D7887LSrA93kDJ9IXovxJYxyLCA==}
     engines: {node: '>=4'}
 
-  postcss@8.5.10:
-    resolution: {integrity: sha512-pMMHxBOZKFU6HgAZ4eyGnwXF/EvPGGqUr0MnZ5+99485wwW41kW91A4LOGxSHhgugZmSChL5AlElNdwlNgcnLQ==}
-    engines: {node: ^10 || ^12 || >=14}
-
   postcss@8.5.13:
     resolution: {integrity: sha512-qif0+jGGZoLWdHey3UFHHWP0H7Gbmsk8T5VEqyYFbWqPr1XqvLGBbk/sl8V5exGmcYJklJOhOQq1pV9IcsiFag==}
     engines: {node: ^10 || ^12 || >=14}
@@ -5558,14 +5134,6 @@ packages:
   rimraf@6.1.3:
     resolution: {integrity: sha512-LKg+Cr2ZF61fkcaK1UdkH2yEBBKnYjTyWzTJT6KNPcSPaiT7HSdhtMXQuN5wkTX0Xu72KQ1l8S42rlmexS2hSA==}
     engines: {node: 20 || >=22}
-    hasBin: true
-
-  robust-predicates@3.0.3:
-    resolution: {integrity: sha512-NS3levdsRIUOmiJ8FZWCP7LG3QpJyrs/TE0Zpf1yvZu8cAJJ6QMW92H1c7kWpdIHo8RvmLxN/o2JXTKHp74lUA==}
-
-  rolldown@1.0.0-rc.12:
-    resolution: {integrity: sha512-yP4USLIMYrwpPHEFB5JGH1uxhcslv6/hL0OyvTuY+3qlOSJvZ7ntYnoWpehBxufkgN0cvXxppuTu5hHa/zPh+A==}
-    engines: {node: ^20.19.0 || >=22.12.0}
     hasBin: true
 
   rolldown@1.0.0-rc.17:
@@ -5779,18 +5347,6 @@ packages:
       prettier:
         optional: true
 
-  storybook@10.3.6:
-    resolution: {integrity: sha512-vbSz7g/1rGMC1uAULqMZjALkIuLu2QABqfhRYhyr/11kzyesi+vAmwyJLukZP1FfecxGOgMwOh6GS0YsGpHAvQ==}
-    hasBin: true
-    peerDependencies:
-      prettier: ^2 || ^3
-      vite-plus: ^0.1.15
-    peerDependenciesMeta:
-      prettier:
-        optional: true
-      vite-plus:
-        optional: true
-
   streamsearch@1.1.0:
     resolution: {integrity: sha512-Mcc5wHehp9aXz1ax6bZUyY5afg9u2rv5cqQI3mRrYkGC8rW2hM02jWuwjtL++LS5qinSyhj2QfLyNsuc+VsExg==}
     engines: {node: '>=10.0.0'}
@@ -5903,18 +5459,8 @@ packages:
     resolution: {integrity: sha512-Bh7QjT8/SuKUIfObSXNHNSK6WHo6J1tHCqJsuaFDP7gP0fkzSfTxI8y85JrppZ0h8l0maIgc2tfuZQ6/t3GtnQ==}
     engines: {node: ^14.18.0 || >=16.0.0}
 
-  tabbable@6.4.0:
-    resolution: {integrity: sha512-05PUHKSNE8ou2dwIxTngl4EzcnsCDZGJ/iCLtDflR/SHB/ny14rXc+qU5P4mG9JkusiV7EivzY9Mhm55AzAvCg==}
-
-  tabulator-tables@6.4.0:
-    resolution: {integrity: sha512-Lxh+leFNoBo/Yyr4USs6gxqbfo8anYUaUMmoT91pfVLtoUgl/dE+qV7ahnFrKVMCYYqGG33aIMPR7FzpPBaNYA==}
-
   tapable@2.3.0:
     resolution: {integrity: sha512-g9ljZiwki/LfxmQADO3dEY1CbpmXT5Hm2fJ+QaGKwSXUylMybePR7/67YW7jOrrvjEgL1Fmz5kzyAjWVWLlucg==}
-    engines: {node: '>=6'}
-
-  tapable@2.3.3:
-    resolution: {integrity: sha512-uxc/zpqFg6x7C8vOE7lh6Lbda8eEL9zmVm/PLeTPBRhh1xCgdWaQ+J1CUieGpIfm2HdtsUpRv+HshiasBMcc6A==}
     engines: {node: '>=6'}
 
   tar-stream@3.1.7:
@@ -5922,22 +5468,6 @@ packages:
 
   terser-webpack-plugin@5.4.0:
     resolution: {integrity: sha512-Bn5vxm48flOIfkdl5CaD2+1CiUVbonWQ3KQPyP7/EuIl9Gbzq/gQFOzaMFUEgVjB1396tcK0SG8XcNJ/2kDH8g==}
-    engines: {node: '>= 10.13.0'}
-    peerDependencies:
-      '@swc/core': '*'
-      esbuild: '*'
-      uglify-js: '*'
-      webpack: ^5.1.0
-    peerDependenciesMeta:
-      '@swc/core':
-        optional: true
-      esbuild:
-        optional: true
-      uglify-js:
-        optional: true
-
-  terser-webpack-plugin@5.5.0:
-    resolution: {integrity: sha512-UYhptBwhWvfIjKd/UuFo6D8uq9xpGLDK+z8EDsj/zWhrTaH34cKEbrkMKfV5YWqGBvAYA3tlzZbs2R+qYrbQJA==}
     engines: {node: '>= 10.13.0'}
     peerDependencies:
       '@swc/core': '*'
@@ -5971,9 +5501,6 @@ packages:
     resolution: {integrity: sha512-75voc/9G4rDIJleOo4jPvN4/YC4GRZrY8yy1uU4lwrB3XEQbWve8zXoO5No4eFrGcTAMYyoY67p8jRQdtA1HbA==}
     engines: {node: '>=12'}
 
-  timepicker-ui@4.3.0:
-    resolution: {integrity: sha512-Gw6QFGKvgrs9OOqFGT84/5g27t/YHMzTY1n0BOSZitnBLWH+ZKBxT73Nn/J7qMKGwZ70eqX+Jn99NzGAvwrwEA==}
-
   tiny-invariant@1.3.3:
     resolution: {integrity: sha512-+FbBPE1o9QAYvviau/qC5SE3caw21q3xkvWKBtja5vgqOWIHHJ3ioaq1VPfn/Szqctz2bU/oYeKd9/z5BL+PVg==}
 
@@ -5986,10 +5513,6 @@ packages:
 
   tinyexec@1.1.1:
     resolution: {integrity: sha512-VKS/ZaQhhkKFMANmAOhhXVoIfBXblQxGX1myCQ2faQrfmobMftXeJPcZGp0gS07ocvGJWDLZGyOZDadDBqYIJg==}
-    engines: {node: '>=18'}
-
-  tinyexec@1.1.2:
-    resolution: {integrity: sha512-dAqSqE/RabpBKI8+h26GfLq6Vb3JVXs30XYQjdMjaj/c2tS8IYYMbIzP599KtRj7c57/wYApb3QjgRgXmrCukA==}
     engines: {node: '>=18'}
 
   tinyglobby@0.2.15:
@@ -6011,9 +5534,6 @@ packages:
   tinyspy@4.0.4:
     resolution: {integrity: sha512-azl+t0z7pw/z958Gy9svOTuzqIk6xq+NSheJzn5MMWtWTFywIacg2wUlzKFGtt3cthx0r2SxMK0yzJOR0IES7Q==}
     engines: {node: '>=14.0.0'}
-
-  tippy.js@6.3.7:
-    resolution: {integrity: sha512-E1d3oP2emgJ9dRQZdf3Kkn0qJgI6ZLpyS5z6ZkY1DF3kaQaBsGZsndEpHwx+eC+tYM41HaSNvNtLx8tU57FzTQ==}
 
   tmpl@1.0.5:
     resolution: {integrity: sha512-3f0uOEAQwIqGuWW2MVzYg8fV/QNnc/IpuJNG837rLuczAaLVHslWHZQj4IGiEl5Hs3kkbhwL9Ab7Hrsmuj+Smw==}
@@ -6222,9 +5742,6 @@ packages:
     resolution: {integrity: sha512-spH26xU080ydGggxRyR1Yhcbgx+j3y5jbNXk/8L+iRvdIEQ4uTRH2Sgf2dokud6Q4oAtsbNvJ1Ft+9xmm6IZcA==}
     engines: {node: '>= 0.10'}
 
-  vanillajs-datepicker@1.3.4:
-    resolution: {integrity: sha512-waOyp2Ay+K1VA/B5cNlFgSNzFR9efCVKaoyMyNEAhAwmKLzMB9nCJs6Vqmo6HuHWA98VEHXbgz5thZ7hH/uohA==}
-
   vary@1.1.2:
     resolution: {integrity: sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg==}
     engines: {node: '>= 0.8'}
@@ -6237,49 +5754,6 @@ packages:
       '@types/node': ^20.19.0 || >=22.12.0
       '@vitejs/devtools': ^0.1.0
       esbuild: ^0.27.0 || ^0.28.0
-      jiti: '>=1.21.0'
-      less: ^4.0.0
-      sass: ^1.70.0
-      sass-embedded: ^1.70.0
-      stylus: '>=0.54.8'
-      sugarss: ^5.0.0
-      terser: ^5.16.0
-      tsx: ^4.8.1
-      yaml: ^2.4.2
-    peerDependenciesMeta:
-      '@types/node':
-        optional: true
-      '@vitejs/devtools':
-        optional: true
-      esbuild:
-        optional: true
-      jiti:
-        optional: true
-      less:
-        optional: true
-      sass:
-        optional: true
-      sass-embedded:
-        optional: true
-      stylus:
-        optional: true
-      sugarss:
-        optional: true
-      terser:
-        optional: true
-      tsx:
-        optional: true
-      yaml:
-        optional: true
-
-  vite@8.0.3:
-    resolution: {integrity: sha512-B9ifbFudT1TFhfltfaIPgjo9Z3mDynBTJSUYxTjOQruf/zHH+ezCQKcoqO+h7a9Pw9Nm/OtlXAiGT1axBgwqrQ==}
-    engines: {node: ^20.19.0 || >=22.12.0}
-    hasBin: true
-    peerDependencies:
-      '@types/node': ^20.19.0 || >=22.12.0
-      '@vitejs/devtools': ^0.1.0
-      esbuild: ^0.27.0
       jiti: '>=1.21.0'
       less: ^4.0.0
       sass: ^1.70.0
@@ -6375,10 +5849,6 @@ packages:
 
   webpack-sources@3.3.4:
     resolution: {integrity: sha512-7tP1PdV4vF+lYPnkMR0jMY5/la2ub5Fc/8VQrrU+lXkiM6C4TjVfGw7iKfyhnTQOsD+6Q/iKw0eFciziRgD58Q==}
-    engines: {node: '>=10.13.0'}
-
-  webpack-sources@3.4.1:
-    resolution: {integrity: sha512-eACpxRN02yaawnt+uUNIF7Qje6A9zArxBbcAJjK1PK3S9Ycg5jIuJ8pW4q8EMnwNZCEGltcjkRx1QzOxOkKD8A==}
     engines: {node: '>=10.13.0'}
 
   webpack-virtual-modules@0.6.2:
@@ -7474,12 +6944,6 @@ snapshots:
       '@types/react': 19.2.14
       react: 19.2.4
 
-  '@mdx-js/react@3.1.1(@types/react@19.2.14)(react@19.2.5)':
-    dependencies:
-      '@types/mdx': 2.0.13
-      '@types/react': 19.2.14
-      react: 19.2.5
-
   '@microsoft/tsdoc@0.16.0': {}
 
   '@napi-rs/nice-android-arm-eabi@1.1.1':
@@ -7565,13 +7029,6 @@ snapshots:
     dependencies:
       '@emnapi/core': 1.10.0
       '@emnapi/runtime': 1.10.0
-      '@tybys/wasm-util': 0.10.1
-    optional: true
-
-  '@napi-rs/wasm-runtime@1.1.4(@emnapi/core@1.7.0)(@emnapi/runtime@1.7.0)':
-    dependencies:
-      '@emnapi/core': 1.7.0
-      '@emnapi/runtime': 1.7.0
       '@tybys/wasm-util': 0.10.1
     optional: true
 
@@ -7778,8 +7235,6 @@ snapshots:
     dependencies:
       consola: 3.4.2
 
-  '@oxc-project/types@0.122.0': {}
-
   '@oxc-project/types@0.127.0': {}
 
   '@paralleldrive/cuid2@2.3.1':
@@ -7794,8 +7249,6 @@ snapshots:
   '@playwright/test@1.59.1':
     dependencies:
       playwright: 1.59.1
-
-  '@popperjs/core@2.11.8': {}
 
   '@redis/bloom@5.12.1(@redis/client@5.12.1)':
     dependencies:
@@ -7821,84 +7274,40 @@ snapshots:
     dependencies:
       '@redis/client': 5.12.1
 
-  '@rolldown/binding-android-arm64@1.0.0-rc.12':
-    optional: true
-
   '@rolldown/binding-android-arm64@1.0.0-rc.17':
-    optional: true
-
-  '@rolldown/binding-darwin-arm64@1.0.0-rc.12':
     optional: true
 
   '@rolldown/binding-darwin-arm64@1.0.0-rc.17':
     optional: true
 
-  '@rolldown/binding-darwin-x64@1.0.0-rc.12':
-    optional: true
-
   '@rolldown/binding-darwin-x64@1.0.0-rc.17':
-    optional: true
-
-  '@rolldown/binding-freebsd-x64@1.0.0-rc.12':
     optional: true
 
   '@rolldown/binding-freebsd-x64@1.0.0-rc.17':
     optional: true
 
-  '@rolldown/binding-linux-arm-gnueabihf@1.0.0-rc.12':
-    optional: true
-
   '@rolldown/binding-linux-arm-gnueabihf@1.0.0-rc.17':
-    optional: true
-
-  '@rolldown/binding-linux-arm64-gnu@1.0.0-rc.12':
     optional: true
 
   '@rolldown/binding-linux-arm64-gnu@1.0.0-rc.17':
     optional: true
 
-  '@rolldown/binding-linux-arm64-musl@1.0.0-rc.12':
-    optional: true
-
   '@rolldown/binding-linux-arm64-musl@1.0.0-rc.17':
-    optional: true
-
-  '@rolldown/binding-linux-ppc64-gnu@1.0.0-rc.12':
     optional: true
 
   '@rolldown/binding-linux-ppc64-gnu@1.0.0-rc.17':
     optional: true
 
-  '@rolldown/binding-linux-s390x-gnu@1.0.0-rc.12':
-    optional: true
-
   '@rolldown/binding-linux-s390x-gnu@1.0.0-rc.17':
-    optional: true
-
-  '@rolldown/binding-linux-x64-gnu@1.0.0-rc.12':
     optional: true
 
   '@rolldown/binding-linux-x64-gnu@1.0.0-rc.17':
     optional: true
 
-  '@rolldown/binding-linux-x64-musl@1.0.0-rc.12':
-    optional: true
-
   '@rolldown/binding-linux-x64-musl@1.0.0-rc.17':
     optional: true
 
-  '@rolldown/binding-openharmony-arm64@1.0.0-rc.12':
-    optional: true
-
   '@rolldown/binding-openharmony-arm64@1.0.0-rc.17':
-    optional: true
-
-  '@rolldown/binding-wasm32-wasi@1.0.0-rc.12(@emnapi/core@1.7.0)(@emnapi/runtime@1.7.0)':
-    dependencies:
-      '@napi-rs/wasm-runtime': 1.1.4(@emnapi/core@1.7.0)(@emnapi/runtime@1.7.0)
-    transitivePeerDependencies:
-      - '@emnapi/core'
-      - '@emnapi/runtime'
     optional: true
 
   '@rolldown/binding-wasm32-wasi@1.0.0-rc.17':
@@ -7908,19 +7317,11 @@ snapshots:
       '@napi-rs/wasm-runtime': 1.1.4(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)
     optional: true
 
-  '@rolldown/binding-win32-arm64-msvc@1.0.0-rc.12':
-    optional: true
-
   '@rolldown/binding-win32-arm64-msvc@1.0.0-rc.17':
-    optional: true
-
-  '@rolldown/binding-win32-x64-msvc@1.0.0-rc.12':
     optional: true
 
   '@rolldown/binding-win32-x64-msvc@1.0.0-rc.17':
     optional: true
-
-  '@rolldown/pluginutils@1.0.0-rc.12': {}
 
   '@rolldown/pluginutils@1.0.0-rc.17': {}
 
@@ -8027,15 +7428,15 @@ snapshots:
 
   '@standard-schema/spec@1.1.0': {}
 
-  '@storybook/addon-docs@10.3.5(@types/react@19.2.14)(esbuild@0.27.7)(rollup@4.60.0)(storybook@10.3.5(@testing-library/dom@10.4.1)(prettier@3.8.3)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(vite@8.0.3(@emnapi/core@1.7.0)(@emnapi/runtime@1.7.0)(@types/node@25.6.0)(esbuild@0.27.7)(jiti@2.6.1)(terser@5.44.0)(tsx@4.21.0)(yaml@2.8.2))(webpack@5.106.0(@swc/core@1.15.32)(esbuild@0.27.7))':
+  '@storybook/addon-docs@10.3.5(@types/react@19.2.14)(esbuild@0.27.7)(rollup@4.60.0)(storybook@10.3.5(@testing-library/dom@10.4.1)(prettier@3.8.3)(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(vite@8.0.10(@types/node@25.6.0)(esbuild@0.27.7)(jiti@2.6.1)(terser@5.44.0)(tsx@4.21.0)(yaml@2.8.2))(webpack@5.106.0(@swc/core@1.15.32)(esbuild@0.27.7))':
     dependencies:
       '@mdx-js/react': 3.1.1(@types/react@19.2.14)(react@19.2.4)
-      '@storybook/csf-plugin': 10.3.5(esbuild@0.27.7)(rollup@4.60.0)(storybook@10.3.5(@testing-library/dom@10.4.1)(prettier@3.8.3)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(vite@8.0.3(@emnapi/core@1.7.0)(@emnapi/runtime@1.7.0)(@types/node@25.6.0)(esbuild@0.27.7)(jiti@2.6.1)(terser@5.44.0)(tsx@4.21.0)(yaml@2.8.2))(webpack@5.106.0(@swc/core@1.15.32)(esbuild@0.27.7))
+      '@storybook/csf-plugin': 10.3.5(esbuild@0.27.7)(rollup@4.60.0)(storybook@10.3.5(@testing-library/dom@10.4.1)(prettier@3.8.3)(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(vite@8.0.10(@types/node@25.6.0)(esbuild@0.27.7)(jiti@2.6.1)(terser@5.44.0)(tsx@4.21.0)(yaml@2.8.2))(webpack@5.106.0(@swc/core@1.15.32)(esbuild@0.27.7))
       '@storybook/icons': 2.0.1(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
-      '@storybook/react-dom-shim': 10.3.5(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(storybook@10.3.5(@testing-library/dom@10.4.1)(prettier@3.8.3)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))
+      '@storybook/react-dom-shim': 10.3.5(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(storybook@10.3.5(@testing-library/dom@10.4.1)(prettier@3.8.3)(react-dom@19.2.5(react@19.2.5))(react@19.2.5))
       react: 19.2.4
       react-dom: 19.2.4(react@19.2.4)
-      storybook: 10.3.5(@testing-library/dom@10.4.1)(prettier@3.8.3)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      storybook: 10.3.5(@testing-library/dom@10.4.1)(prettier@3.8.3)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
       ts-dedent: 2.2.0
     transitivePeerDependencies:
       - '@types/react'
@@ -8044,38 +7445,10 @@ snapshots:
       - vite
       - webpack
 
-  '@storybook/addon-docs@10.3.6(@types/react@19.2.14)(esbuild@0.27.7)(rollup@4.60.0)(storybook@10.3.6(@testing-library/dom@10.4.1)(prettier@3.8.3)(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(vite@8.0.10(@types/node@25.6.0)(esbuild@0.27.7)(jiti@2.6.1)(terser@5.44.0)(tsx@4.21.0)(yaml@2.8.2))(webpack@5.106.0(esbuild@0.27.7))':
+  '@storybook/builder-vite@10.3.5(esbuild@0.27.7)(rollup@4.60.0)(storybook@10.3.5(@testing-library/dom@10.4.1)(prettier@3.8.3)(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(vite@8.0.10(@types/node@25.6.0)(esbuild@0.27.7)(jiti@2.6.1)(terser@5.44.0)(tsx@4.21.0)(yaml@2.8.2))(webpack@5.106.0(@swc/core@1.15.32)(esbuild@0.27.7))':
     dependencies:
-      '@mdx-js/react': 3.1.1(@types/react@19.2.14)(react@19.2.5)
-      '@storybook/csf-plugin': 10.3.6(esbuild@0.27.7)(rollup@4.60.0)(storybook@10.3.6(@testing-library/dom@10.4.1)(prettier@3.8.3)(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(vite@8.0.10(@types/node@25.6.0)(esbuild@0.27.7)(jiti@2.6.1)(terser@5.44.0)(tsx@4.21.0)(yaml@2.8.2))(webpack@5.106.0(esbuild@0.27.7))
-      '@storybook/icons': 2.0.1(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
-      '@storybook/react-dom-shim': 10.3.6(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(storybook@10.3.6(@testing-library/dom@10.4.1)(prettier@3.8.3)(react-dom@19.2.5(react@19.2.5))(react@19.2.5))
-      react: 19.2.5
-      react-dom: 19.2.5(react@19.2.5)
-      storybook: 10.3.6(@testing-library/dom@10.4.1)(prettier@3.8.3)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
-      ts-dedent: 2.2.0
-    transitivePeerDependencies:
-      - '@types/react'
-      - esbuild
-      - rollup
-      - vite
-      - webpack
-
-  '@storybook/builder-vite@10.3.5(esbuild@0.27.7)(rollup@4.60.0)(storybook@10.3.5(@testing-library/dom@10.4.1)(prettier@3.8.3)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(vite@8.0.3(@emnapi/core@1.7.0)(@emnapi/runtime@1.7.0)(@types/node@25.6.0)(esbuild@0.27.7)(jiti@2.6.1)(terser@5.44.0)(tsx@4.21.0)(yaml@2.8.2))(webpack@5.106.0(@swc/core@1.15.32)(esbuild@0.27.7))':
-    dependencies:
-      '@storybook/csf-plugin': 10.3.5(esbuild@0.27.7)(rollup@4.60.0)(storybook@10.3.5(@testing-library/dom@10.4.1)(prettier@3.8.3)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(vite@8.0.3(@emnapi/core@1.7.0)(@emnapi/runtime@1.7.0)(@types/node@25.6.0)(esbuild@0.27.7)(jiti@2.6.1)(terser@5.44.0)(tsx@4.21.0)(yaml@2.8.2))(webpack@5.106.0(@swc/core@1.15.32)(esbuild@0.27.7))
-      storybook: 10.3.5(@testing-library/dom@10.4.1)(prettier@3.8.3)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
-      ts-dedent: 2.2.0
-      vite: 8.0.3(@emnapi/core@1.7.0)(@emnapi/runtime@1.7.0)(@types/node@25.6.0)(esbuild@0.27.7)(jiti@2.6.1)(terser@5.44.0)(tsx@4.21.0)(yaml@2.8.2)
-    transitivePeerDependencies:
-      - esbuild
-      - rollup
-      - webpack
-
-  '@storybook/builder-vite@10.3.6(esbuild@0.27.7)(rollup@4.60.0)(storybook@10.3.6(@testing-library/dom@10.4.1)(prettier@3.8.3)(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(vite@8.0.10(@types/node@25.6.0)(esbuild@0.27.7)(jiti@2.6.1)(terser@5.44.0)(tsx@4.21.0)(yaml@2.8.2))(webpack@5.106.0(esbuild@0.27.7))':
-    dependencies:
-      '@storybook/csf-plugin': 10.3.6(esbuild@0.27.7)(rollup@4.60.0)(storybook@10.3.6(@testing-library/dom@10.4.1)(prettier@3.8.3)(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(vite@8.0.10(@types/node@25.6.0)(esbuild@0.27.7)(jiti@2.6.1)(terser@5.44.0)(tsx@4.21.0)(yaml@2.8.2))(webpack@5.106.0(esbuild@0.27.7))
-      storybook: 10.3.6(@testing-library/dom@10.4.1)(prettier@3.8.3)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
+      '@storybook/csf-plugin': 10.3.5(esbuild@0.27.7)(rollup@4.60.0)(storybook@10.3.5(@testing-library/dom@10.4.1)(prettier@3.8.3)(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(vite@8.0.10(@types/node@25.6.0)(esbuild@0.27.7)(jiti@2.6.1)(terser@5.44.0)(tsx@4.21.0)(yaml@2.8.2))(webpack@5.106.0(@swc/core@1.15.32)(esbuild@0.27.7))
+      storybook: 10.3.5(@testing-library/dom@10.4.1)(prettier@3.8.3)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
       ts-dedent: 2.2.0
       vite: 8.0.10(@types/node@25.6.0)(esbuild@0.27.7)(jiti@2.6.1)(terser@5.44.0)(tsx@4.21.0)(yaml@2.8.2)
     transitivePeerDependencies:
@@ -8083,60 +7456,33 @@ snapshots:
       - rollup
       - webpack
 
-  '@storybook/csf-plugin@10.3.5(esbuild@0.27.7)(rollup@4.60.0)(storybook@10.3.5(@testing-library/dom@10.4.1)(prettier@3.8.3)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(vite@8.0.3(@emnapi/core@1.7.0)(@emnapi/runtime@1.7.0)(@types/node@25.6.0)(esbuild@0.27.7)(jiti@2.6.1)(terser@5.44.0)(tsx@4.21.0)(yaml@2.8.2))(webpack@5.106.0(@swc/core@1.15.32)(esbuild@0.27.7))':
+  '@storybook/csf-plugin@10.3.5(esbuild@0.27.7)(rollup@4.60.0)(storybook@10.3.5(@testing-library/dom@10.4.1)(prettier@3.8.3)(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(vite@8.0.10(@types/node@25.6.0)(esbuild@0.27.7)(jiti@2.6.1)(terser@5.44.0)(tsx@4.21.0)(yaml@2.8.2))(webpack@5.106.0(@swc/core@1.15.32)(esbuild@0.27.7))':
     dependencies:
-      storybook: 10.3.5(@testing-library/dom@10.4.1)(prettier@3.8.3)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      storybook: 10.3.5(@testing-library/dom@10.4.1)(prettier@3.8.3)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
       unplugin: 2.3.11
     optionalDependencies:
       esbuild: 0.27.7
       rollup: 4.60.0
-      vite: 8.0.3(@emnapi/core@1.7.0)(@emnapi/runtime@1.7.0)(@types/node@25.6.0)(esbuild@0.27.7)(jiti@2.6.1)(terser@5.44.0)(tsx@4.21.0)(yaml@2.8.2)
+      vite: 8.0.10(@types/node@25.6.0)(esbuild@0.27.7)(jiti@2.6.1)(terser@5.44.0)(tsx@4.21.0)(yaml@2.8.2)
       webpack: 5.106.0(@swc/core@1.15.32)(esbuild@0.27.7)
-
-  '@storybook/csf-plugin@10.3.6(esbuild@0.27.7)(rollup@4.60.0)(storybook@10.3.6(@testing-library/dom@10.4.1)(prettier@3.8.3)(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(vite@8.0.10(@types/node@25.6.0)(esbuild@0.27.7)(jiti@2.6.1)(terser@5.44.0)(tsx@4.21.0)(yaml@2.8.2))(webpack@5.106.0(esbuild@0.27.7))':
-    dependencies:
-      storybook: 10.3.6(@testing-library/dom@10.4.1)(prettier@3.8.3)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
-      unplugin: 2.3.11
-    optionalDependencies:
-      esbuild: 0.27.7
-      rollup: 4.60.0
-      vite: 8.0.10(@types/node@25.6.0)(esbuild@0.27.7)(jiti@2.6.1)(terser@5.44.0)(tsx@4.21.0)(yaml@2.8.2)
-      webpack: 5.106.0(esbuild@0.27.7)
 
   '@storybook/global@5.0.0': {}
 
-  '@storybook/html-vite@10.3.5(esbuild@0.27.7)(rollup@4.60.0)(storybook@10.3.5(@testing-library/dom@10.4.1)(prettier@3.8.3)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(vite@8.0.3(@emnapi/core@1.7.0)(@emnapi/runtime@1.7.0)(@types/node@25.6.0)(esbuild@0.27.7)(jiti@2.6.1)(terser@5.44.0)(tsx@4.21.0)(yaml@2.8.2))(webpack@5.106.0(@swc/core@1.15.32)(esbuild@0.27.7))':
+  '@storybook/html-vite@10.3.5(esbuild@0.27.7)(rollup@4.60.0)(storybook@10.3.5(@testing-library/dom@10.4.1)(prettier@3.8.3)(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(vite@8.0.10(@types/node@25.6.0)(esbuild@0.27.7)(jiti@2.6.1)(terser@5.44.0)(tsx@4.21.0)(yaml@2.8.2))(webpack@5.106.0(@swc/core@1.15.32)(esbuild@0.27.7))':
     dependencies:
-      '@storybook/builder-vite': 10.3.5(esbuild@0.27.7)(rollup@4.60.0)(storybook@10.3.5(@testing-library/dom@10.4.1)(prettier@3.8.3)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(vite@8.0.3(@emnapi/core@1.7.0)(@emnapi/runtime@1.7.0)(@types/node@25.6.0)(esbuild@0.27.7)(jiti@2.6.1)(terser@5.44.0)(tsx@4.21.0)(yaml@2.8.2))(webpack@5.106.0(@swc/core@1.15.32)(esbuild@0.27.7))
-      '@storybook/html': 10.3.5(storybook@10.3.5(@testing-library/dom@10.4.1)(prettier@3.8.3)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))
-      storybook: 10.3.5(@testing-library/dom@10.4.1)(prettier@3.8.3)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@storybook/builder-vite': 10.3.5(esbuild@0.27.7)(rollup@4.60.0)(storybook@10.3.5(@testing-library/dom@10.4.1)(prettier@3.8.3)(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(vite@8.0.10(@types/node@25.6.0)(esbuild@0.27.7)(jiti@2.6.1)(terser@5.44.0)(tsx@4.21.0)(yaml@2.8.2))(webpack@5.106.0(@swc/core@1.15.32)(esbuild@0.27.7))
+      '@storybook/html': 10.3.5(storybook@10.3.5(@testing-library/dom@10.4.1)(prettier@3.8.3)(react-dom@19.2.5(react@19.2.5))(react@19.2.5))
+      storybook: 10.3.5(@testing-library/dom@10.4.1)(prettier@3.8.3)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
     transitivePeerDependencies:
       - esbuild
       - rollup
       - vite
       - webpack
 
-  '@storybook/html-vite@10.3.6(esbuild@0.27.7)(rollup@4.60.0)(storybook@10.3.6(@testing-library/dom@10.4.1)(prettier@3.8.3)(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(vite@8.0.10(@types/node@25.6.0)(esbuild@0.27.7)(jiti@2.6.1)(terser@5.44.0)(tsx@4.21.0)(yaml@2.8.2))(webpack@5.106.0(esbuild@0.27.7))':
-    dependencies:
-      '@storybook/builder-vite': 10.3.6(esbuild@0.27.7)(rollup@4.60.0)(storybook@10.3.6(@testing-library/dom@10.4.1)(prettier@3.8.3)(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(vite@8.0.10(@types/node@25.6.0)(esbuild@0.27.7)(jiti@2.6.1)(terser@5.44.0)(tsx@4.21.0)(yaml@2.8.2))(webpack@5.106.0(esbuild@0.27.7))
-      '@storybook/html': 10.3.6(storybook@10.3.6(@testing-library/dom@10.4.1)(prettier@3.8.3)(react-dom@19.2.5(react@19.2.5))(react@19.2.5))
-      storybook: 10.3.6(@testing-library/dom@10.4.1)(prettier@3.8.3)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
-    transitivePeerDependencies:
-      - esbuild
-      - rollup
-      - vite
-      - webpack
-
-  '@storybook/html@10.3.5(storybook@10.3.5(@testing-library/dom@10.4.1)(prettier@3.8.3)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))':
+  '@storybook/html@10.3.5(storybook@10.3.5(@testing-library/dom@10.4.1)(prettier@3.8.3)(react-dom@19.2.5(react@19.2.5))(react@19.2.5))':
     dependencies:
       '@storybook/global': 5.0.0
-      storybook: 10.3.5(@testing-library/dom@10.4.1)(prettier@3.8.3)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
-      ts-dedent: 2.2.0
-
-  '@storybook/html@10.3.6(storybook@10.3.6(@testing-library/dom@10.4.1)(prettier@3.8.3)(react-dom@19.2.5(react@19.2.5))(react@19.2.5))':
-    dependencies:
-      '@storybook/global': 5.0.0
-      storybook: 10.3.6(@testing-library/dom@10.4.1)(prettier@3.8.3)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
+      storybook: 10.3.5(@testing-library/dom@10.4.1)(prettier@3.8.3)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
       ts-dedent: 2.2.0
 
   '@storybook/icons@2.0.1(react-dom@19.2.4(react@19.2.4))(react@19.2.4)':
@@ -8149,17 +7495,11 @@ snapshots:
       react: 19.2.5
       react-dom: 19.2.5(react@19.2.5)
 
-  '@storybook/react-dom-shim@10.3.5(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(storybook@10.3.5(@testing-library/dom@10.4.1)(prettier@3.8.3)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))':
+  '@storybook/react-dom-shim@10.3.5(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(storybook@10.3.5(@testing-library/dom@10.4.1)(prettier@3.8.3)(react-dom@19.2.5(react@19.2.5))(react@19.2.5))':
     dependencies:
       react: 19.2.4
       react-dom: 19.2.4(react@19.2.4)
-      storybook: 10.3.5(@testing-library/dom@10.4.1)(prettier@3.8.3)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
-
-  '@storybook/react-dom-shim@10.3.6(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(storybook@10.3.6(@testing-library/dom@10.4.1)(prettier@3.8.3)(react-dom@19.2.5(react@19.2.5))(react@19.2.5))':
-    dependencies:
-      react: 19.2.5
-      react-dom: 19.2.5(react@19.2.5)
-      storybook: 10.3.6(@testing-library/dom@10.4.1)(prettier@3.8.3)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
+      storybook: 10.3.5(@testing-library/dom@10.4.1)(prettier@3.8.3)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
 
   '@swc/cli@0.8.1(@swc/core@1.15.32)(chokidar@4.0.3)':
     dependencies:
@@ -8433,11 +7773,13 @@ snapshots:
 
   '@types/validator@13.15.10': {}
 
-  '@types/whatwg-mimetype@3.0.2': {}
+  '@types/whatwg-mimetype@3.0.2':
+    optional: true
 
   '@types/ws@8.18.1':
     dependencies:
       '@types/node': 25.6.0
+    optional: true
 
   '@types/yargs-parser@21.0.3': {}
 
@@ -8621,14 +7963,6 @@ snapshots:
       magic-string: 0.30.21
     optionalDependencies:
       vite: 8.0.10(@types/node@25.6.0)(esbuild@0.27.7)(jiti@2.6.1)(terser@5.44.0)(tsx@4.21.0)(yaml@2.8.2)
-
-  '@vitest/mocker@4.1.5(vite@8.0.3(@emnapi/core@1.7.0)(@emnapi/runtime@1.7.0)(@types/node@25.6.0)(esbuild@0.27.7)(jiti@2.6.1)(terser@5.44.0)(tsx@4.21.0)(yaml@2.8.2))':
-    dependencies:
-      '@vitest/spy': 4.1.5
-      estree-walker: 3.0.3
-      magic-string: 0.30.21
-    optionalDependencies:
-      vite: 8.0.3(@emnapi/core@1.7.0)(@emnapi/runtime@1.7.0)(@types/node@25.6.0)(esbuild@0.27.7)(jiti@2.6.1)(terser@5.44.0)(tsx@4.21.0)(yaml@2.8.2)
 
   '@vitest/pretty-format@3.2.4':
     dependencies:
@@ -8919,8 +8253,6 @@ snapshots:
       json-schema-traverse: 1.0.0
       require-from-string: 2.0.2
 
-  animate.css@4.1.1: {}
-
   ansi-colors@4.1.3: {}
 
   ansi-escapes@4.3.2:
@@ -8987,8 +8319,6 @@ snapshots:
   async@3.2.6: {}
 
   asynckit@0.4.0: {}
-
-  awesomplete@1.1.7: {}
 
   axios@1.15.2:
     dependencies:
@@ -9065,9 +8395,6 @@ snapshots:
   base64-js@1.5.1: {}
 
   base64id@2.0.0: {}
-
-  baseline-browser-mapping@2.10.24:
-    optional: true
 
   baseline-browser-mapping@2.9.19: {}
 
@@ -9159,15 +8486,6 @@ snapshots:
       node-releases: 2.0.27
       update-browserslist-db: 1.2.3(browserslist@4.28.1)
 
-  browserslist@4.28.2:
-    dependencies:
-      baseline-browser-mapping: 2.10.24
-      caniuse-lite: 1.0.30001791
-      electron-to-chromium: 1.5.348
-      node-releases: 2.0.38
-      update-browserslist-db: 1.2.3(browserslist@4.28.2)
-    optional: true
-
   bs-logger@0.2.6:
     dependencies:
       fast-json-stable-stringify: 2.1.0
@@ -9241,9 +8559,6 @@ snapshots:
 
   caniuse-lite@1.0.30001767: {}
 
-  caniuse-lite@1.0.30001791:
-    optional: true
-
   catering@2.1.1: {}
 
   chai@5.3.3:
@@ -9285,10 +8600,6 @@ snapshots:
       libphonenumber-js: 1.12.37
       validator: 13.15.26
 
-  class-variance-authority@0.7.1:
-    dependencies:
-      clsx: 2.1.1
-
   classic-level@1.4.1:
     dependencies:
       abstract-level: 1.0.4
@@ -9296,8 +8607,6 @@ snapshots:
       module-error: 1.0.2
       napi-macros: 2.2.2
       node-gyp-build: 4.8.4
-
-  classnames@2.5.1: {}
 
   cli-cursor@3.1.0:
     dependencies:
@@ -9334,8 +8643,6 @@ snapshots:
 
   clone@1.0.4: {}
 
-  clsx@2.1.1: {}
-
   cluster-key-slot@1.1.2: {}
 
   co@4.6.0: {}
@@ -9365,8 +8672,6 @@ snapshots:
   commander@4.1.1: {}
 
   commander@6.2.1: {}
-
-  commander@7.2.0: {}
 
   commander@8.3.0: {}
 
@@ -9483,19 +8788,6 @@ snapshots:
     optionalDependencies:
       typescript: 6.0.3
 
-  courthive-components@1.1.1:
-    dependencies:
-      awesomplete: 1.1.7
-      class-variance-authority: 0.7.1
-      classnames: 2.5.1
-      d3: 7.9.0
-      dayjs: 1.11.20
-      focus-trap: 8.1.0
-      timepicker-ui: 4.3.0
-      tippy.js: 6.3.7
-      tods-competition-factory: link:../factory
-      vanillajs-datepicker: 1.3.4
-
   create-require@1.1.1: {}
 
   cross-spawn@7.0.6:
@@ -9520,13 +8812,7 @@ snapshots:
 
   d3-array@1.2.4: {}
 
-  d3-array@3.2.4:
-    dependencies:
-      internmap: 2.0.3
-
   d3-axis@1.0.12: {}
-
-  d3-axis@3.0.0: {}
 
   d3-brush@1.1.6:
     dependencies:
@@ -9536,54 +8822,25 @@ snapshots:
       d3-selection: 1.4.2
       d3-transition: 1.3.2
 
-  d3-brush@3.0.0:
-    dependencies:
-      d3-dispatch: 3.0.1
-      d3-drag: 3.0.0
-      d3-interpolate: 3.0.1
-      d3-selection: 3.0.0
-      d3-transition: 3.0.1(d3-selection@3.0.0)
-
   d3-chord@1.0.6:
     dependencies:
       d3-array: 1.2.4
       d3-path: 1.0.9
 
-  d3-chord@3.0.1:
-    dependencies:
-      d3-path: 3.1.0
-
   d3-collection@1.0.7: {}
 
   d3-color@1.4.1: {}
-
-  d3-color@3.1.0: {}
 
   d3-contour@1.3.2:
     dependencies:
       d3-array: 1.2.4
 
-  d3-contour@4.0.2:
-    dependencies:
-      d3-array: 3.2.4
-
-  d3-delaunay@6.0.4:
-    dependencies:
-      delaunator: 5.1.0
-
   d3-dispatch@1.0.6: {}
-
-  d3-dispatch@3.0.1: {}
 
   d3-drag@1.2.5:
     dependencies:
       d3-dispatch: 1.0.6
       d3-selection: 1.4.2
-
-  d3-drag@3.0.0:
-    dependencies:
-      d3-dispatch: 3.0.1
-      d3-selection: 3.0.0
 
   d3-dsv@1.2.0:
     dependencies:
@@ -9591,23 +8848,11 @@ snapshots:
       iconv-lite: 0.4.24
       rw: 1.3.3
 
-  d3-dsv@3.0.1:
-    dependencies:
-      commander: 7.2.0
-      iconv-lite: 0.6.3
-      rw: 1.3.3
-
   d3-ease@1.0.7: {}
-
-  d3-ease@3.0.1: {}
 
   d3-fetch@1.2.0:
     dependencies:
       d3-dsv: 1.2.0
-
-  d3-fetch@3.0.1:
-    dependencies:
-      d3-dsv: 3.0.1
 
   d3-force@1.2.1:
     dependencies:
@@ -9616,61 +8861,30 @@ snapshots:
       d3-quadtree: 1.0.7
       d3-timer: 1.0.10
 
-  d3-force@3.0.0:
-    dependencies:
-      d3-dispatch: 3.0.1
-      d3-quadtree: 3.0.1
-      d3-timer: 3.0.1
-
   d3-format@1.4.5: {}
-
-  d3-format@3.1.2: {}
 
   d3-geo@1.12.1:
     dependencies:
       d3-array: 1.2.4
 
-  d3-geo@3.1.1:
-    dependencies:
-      d3-array: 3.2.4
-
   d3-hierarchy@1.1.9: {}
-
-  d3-hierarchy@3.1.2: {}
 
   d3-interpolate@1.4.0:
     dependencies:
       d3-color: 1.4.1
 
-  d3-interpolate@3.0.1:
-    dependencies:
-      d3-color: 3.1.0
-
   d3-path@1.0.9: {}
-
-  d3-path@3.1.0: {}
 
   d3-polygon@1.0.6: {}
 
-  d3-polygon@3.0.1: {}
-
   d3-quadtree@1.0.7: {}
 
-  d3-quadtree@3.0.1: {}
-
   d3-random@1.1.2: {}
-
-  d3-random@3.0.1: {}
 
   d3-scale-chromatic@1.5.0:
     dependencies:
       d3-color: 1.4.1
       d3-interpolate: 1.4.0
-
-  d3-scale-chromatic@3.1.0:
-    dependencies:
-      d3-color: 3.1.0
-      d3-interpolate: 3.0.1
 
   d3-scale@2.2.2:
     dependencies:
@@ -9681,43 +8895,19 @@ snapshots:
       d3-time: 1.1.0
       d3-time-format: 2.3.0
 
-  d3-scale@4.0.2:
-    dependencies:
-      d3-array: 3.2.4
-      d3-format: 3.1.2
-      d3-interpolate: 3.0.1
-      d3-time: 3.1.0
-      d3-time-format: 4.1.0
-
   d3-selection@1.4.2: {}
-
-  d3-selection@3.0.0: {}
 
   d3-shape@1.3.7:
     dependencies:
       d3-path: 1.0.9
 
-  d3-shape@3.2.0:
-    dependencies:
-      d3-path: 3.1.0
-
   d3-time-format@2.3.0:
     dependencies:
       d3-time: 1.1.0
 
-  d3-time-format@4.1.0:
-    dependencies:
-      d3-time: 3.1.0
-
   d3-time@1.1.0: {}
 
-  d3-time@3.1.0:
-    dependencies:
-      d3-array: 3.2.4
-
   d3-timer@1.0.10: {}
-
-  d3-timer@3.0.1: {}
 
   d3-transition@1.3.2:
     dependencies:
@@ -9728,15 +8918,6 @@ snapshots:
       d3-selection: 1.4.2
       d3-timer: 1.0.10
 
-  d3-transition@3.0.1(d3-selection@3.0.0):
-    dependencies:
-      d3-color: 3.1.0
-      d3-dispatch: 3.0.1
-      d3-ease: 3.0.1
-      d3-interpolate: 3.0.1
-      d3-selection: 3.0.0
-      d3-timer: 3.0.1
-
   d3-voronoi@1.1.4: {}
 
   d3-zoom@1.8.3:
@@ -9746,14 +8927,6 @@ snapshots:
       d3-interpolate: 1.4.0
       d3-selection: 1.4.2
       d3-transition: 1.3.2
-
-  d3-zoom@3.0.0:
-    dependencies:
-      d3-dispatch: 3.0.1
-      d3-drag: 3.0.0
-      d3-interpolate: 3.0.1
-      d3-selection: 3.0.0
-      d3-transition: 3.0.1(d3-selection@3.0.0)
 
   d3@5.16.0:
     dependencies:
@@ -9789,46 +8962,11 @@ snapshots:
       d3-voronoi: 1.1.4
       d3-zoom: 1.8.3
 
-  d3@7.9.0:
-    dependencies:
-      d3-array: 3.2.4
-      d3-axis: 3.0.0
-      d3-brush: 3.0.0
-      d3-chord: 3.0.1
-      d3-color: 3.1.0
-      d3-contour: 4.0.2
-      d3-delaunay: 6.0.4
-      d3-dispatch: 3.0.1
-      d3-drag: 3.0.0
-      d3-dsv: 3.0.1
-      d3-ease: 3.0.1
-      d3-fetch: 3.0.1
-      d3-force: 3.0.0
-      d3-format: 3.1.2
-      d3-geo: 3.1.1
-      d3-hierarchy: 3.1.2
-      d3-interpolate: 3.0.1
-      d3-path: 3.1.0
-      d3-polygon: 3.0.1
-      d3-quadtree: 3.0.1
-      d3-random: 3.0.1
-      d3-scale: 4.0.2
-      d3-scale-chromatic: 3.1.0
-      d3-selection: 3.0.0
-      d3-shape: 3.2.0
-      d3-time: 3.1.0
-      d3-time-format: 4.1.0
-      d3-timer: 3.0.1
-      d3-transition: 3.0.1(d3-selection@3.0.0)
-      d3-zoom: 3.0.0
-
   date-fns@2.30.0:
     dependencies:
       '@babel/runtime': 7.28.4
 
   dayjs@1.11.10: {}
-
-  dayjs@1.11.20: {}
 
   debug@2.6.9:
     dependencies:
@@ -9868,10 +9006,6 @@ snapshots:
   defaults@2.0.2: {}
 
   define-lazy-prop@3.0.0: {}
-
-  delaunator@5.1.0:
-    dependencies:
-      robust-predicates: 3.0.3
 
   delayed-stream@1.0.0: {}
 
@@ -9952,9 +9086,6 @@ snapshots:
 
   electron-to-chromium@1.5.286: {}
 
-  electron-to-chromium@1.5.348:
-    optional: true
-
   email-addresses@5.0.0: {}
 
   emittery@0.13.1: {}
@@ -10009,15 +9140,10 @@ snapshots:
       graceful-fs: 4.2.11
       tapable: 2.3.0
 
-  enhanced-resolve@5.21.0:
-    dependencies:
-      graceful-fs: 4.2.11
-      tapable: 2.3.3
-    optional: true
-
   entities@4.5.0: {}
 
-  entities@7.0.1: {}
+  entities@7.0.1:
+    optional: true
 
   env-paths@2.2.1: {}
 
@@ -10032,8 +9158,6 @@ snapshots:
   es-errors@1.3.0: {}
 
   es-module-lexer@2.0.0: {}
-
-  es-module-lexer@2.1.0: {}
 
   es-object-atoms@1.1.1:
     dependencies:
@@ -10473,10 +9597,6 @@ snapshots:
 
   flatted@3.3.3: {}
 
-  focus-trap@8.1.0:
-    dependencies:
-      tabbable: 6.4.0
-
   follow-redirects@1.16.0: {}
 
   foreground-child@3.3.1:
@@ -10702,6 +9822,7 @@ snapshots:
     transitivePeerDependencies:
       - bufferutil
       - utf-8-validate
+    optional: true
 
   has-flag@4.0.0: {}
 
@@ -10756,15 +9877,7 @@ snapshots:
 
   husky@9.1.7: {}
 
-  i18next@26.0.8(typescript@6.0.3):
-    optionalDependencies:
-      typescript: 6.0.3
-
   iconv-lite@0.4.24:
-    dependencies:
-      safer-buffer: 2.1.2
-
-  iconv-lite@0.6.3:
     dependencies:
       safer-buffer: 2.1.2
 
@@ -10806,8 +9919,6 @@ snapshots:
   inspect-with-kind@1.0.5:
     dependencies:
       kind-of: 6.0.3
-
-  internmap@2.0.3: {}
 
   ipaddr.js@1.9.1: {}
 
@@ -11324,8 +10435,6 @@ snapshots:
       jwa: 2.0.1
       safe-buffer: 5.2.1
 
-  jwt-decode@4.0.0: {}
-
   keyv@4.5.4:
     dependencies:
       json-buffer: 3.0.1
@@ -11430,9 +10539,6 @@ snapshots:
   load-esm@1.0.3: {}
 
   loader-runner@4.3.1: {}
-
-  loader-runner@4.3.2:
-    optional: true
 
   locate-path@5.0.0:
     dependencies:
@@ -11627,8 +10733,6 @@ snapshots:
 
   mute-stream@2.0.0: {}
 
-  nanoid@3.3.11: {}
-
   nanoid@3.3.12: {}
 
   napi-macros@2.2.2: {}
@@ -11636,8 +10740,6 @@ snapshots:
   napi-postinstall@0.3.4: {}
 
   natural-compare@1.4.0: {}
-
-  navigo@8.11.1: {}
 
   negotiator@0.6.3: {}
 
@@ -11663,9 +10765,6 @@ snapshots:
   node-int64@0.4.0: {}
 
   node-releases@2.0.27: {}
-
-  node-releases@2.0.38:
-    optional: true
 
   normalize-path@3.0.0: {}
 
@@ -11889,12 +10988,6 @@ snapshots:
 
   pluralize@8.0.0: {}
 
-  postcss@8.5.10:
-    dependencies:
-      nanoid: 3.3.11
-      picocolors: 1.1.1
-      source-map-js: 1.2.1
-
   postcss@8.5.13:
     dependencies:
       nanoid: 3.3.12
@@ -12083,32 +11176,6 @@ snapshots:
     dependencies:
       glob: 13.0.5
       package-json-from-dist: 1.0.1
-
-  robust-predicates@3.0.3: {}
-
-  rolldown@1.0.0-rc.12(@emnapi/core@1.7.0)(@emnapi/runtime@1.7.0):
-    dependencies:
-      '@oxc-project/types': 0.122.0
-      '@rolldown/pluginutils': 1.0.0-rc.12
-    optionalDependencies:
-      '@rolldown/binding-android-arm64': 1.0.0-rc.12
-      '@rolldown/binding-darwin-arm64': 1.0.0-rc.12
-      '@rolldown/binding-darwin-x64': 1.0.0-rc.12
-      '@rolldown/binding-freebsd-x64': 1.0.0-rc.12
-      '@rolldown/binding-linux-arm-gnueabihf': 1.0.0-rc.12
-      '@rolldown/binding-linux-arm64-gnu': 1.0.0-rc.12
-      '@rolldown/binding-linux-arm64-musl': 1.0.0-rc.12
-      '@rolldown/binding-linux-ppc64-gnu': 1.0.0-rc.12
-      '@rolldown/binding-linux-s390x-gnu': 1.0.0-rc.12
-      '@rolldown/binding-linux-x64-gnu': 1.0.0-rc.12
-      '@rolldown/binding-linux-x64-musl': 1.0.0-rc.12
-      '@rolldown/binding-openharmony-arm64': 1.0.0-rc.12
-      '@rolldown/binding-wasm32-wasi': 1.0.0-rc.12(@emnapi/core@1.7.0)(@emnapi/runtime@1.7.0)
-      '@rolldown/binding-win32-arm64-msvc': 1.0.0-rc.12
-      '@rolldown/binding-win32-x64-msvc': 1.0.0-rc.12
-    transitivePeerDependencies:
-      - '@emnapi/core'
-      - '@emnapi/runtime'
 
   rolldown@1.0.0-rc.17:
     dependencies:
@@ -12407,31 +11474,7 @@ snapshots:
 
   std-env@4.1.0: {}
 
-  storybook@10.3.5(@testing-library/dom@10.4.1)(prettier@3.8.3)(react-dom@19.2.4(react@19.2.4))(react@19.2.4):
-    dependencies:
-      '@storybook/global': 5.0.0
-      '@storybook/icons': 2.0.1(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
-      '@testing-library/jest-dom': 6.9.1
-      '@testing-library/user-event': 14.6.1(@testing-library/dom@10.4.1)
-      '@vitest/expect': 3.2.4
-      '@vitest/spy': 3.2.4
-      '@webcontainer/env': 1.1.1
-      esbuild: 0.27.7
-      open: 10.2.0
-      recast: 0.23.11
-      semver: 7.7.4
-      use-sync-external-store: 1.6.0(react@19.2.4)
-      ws: 8.20.0
-    optionalDependencies:
-      prettier: 3.8.3
-    transitivePeerDependencies:
-      - '@testing-library/dom'
-      - bufferutil
-      - react
-      - react-dom
-      - utf-8-validate
-
-  storybook@10.3.6(@testing-library/dom@10.4.1)(prettier@3.8.3)(react-dom@19.2.5(react@19.2.5))(react@19.2.5):
+  storybook@10.3.5(@testing-library/dom@10.4.1)(prettier@3.8.3)(react-dom@19.2.5(react@19.2.5))(react@19.2.5):
     dependencies:
       '@storybook/global': 5.0.0
       '@storybook/icons': 2.0.1(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
@@ -12583,14 +11626,7 @@ snapshots:
     dependencies:
       '@pkgr/core': 0.2.9
 
-  tabbable@6.4.0: {}
-
-  tabulator-tables@6.4.0: {}
-
   tapable@2.3.0: {}
-
-  tapable@2.3.3:
-    optional: true
 
   tar-stream@3.1.7:
     dependencies:
@@ -12611,17 +11647,6 @@ snapshots:
     optionalDependencies:
       '@swc/core': 1.15.32
       esbuild: 0.27.7
-
-  terser-webpack-plugin@5.5.0(esbuild@0.27.7)(webpack@5.106.0(esbuild@0.27.7)):
-    dependencies:
-      '@jridgewell/trace-mapping': 0.3.31
-      jest-worker: 27.5.1
-      schema-utils: 4.3.3
-      terser: 5.44.0
-      webpack: 5.106.0(esbuild@0.27.7)
-    optionalDependencies:
-      esbuild: 0.27.7
-    optional: true
 
   terser@5.44.0:
     dependencies:
@@ -12648,8 +11673,6 @@ snapshots:
     dependencies:
       convert-hrtime: 5.0.0
 
-  timepicker-ui@4.3.0: {}
-
   tiny-invariant@1.3.3: {}
 
   tinybench@2.9.0: {}
@@ -12657,8 +11680,6 @@ snapshots:
   tinyexec@1.0.4: {}
 
   tinyexec@1.1.1: {}
-
-  tinyexec@1.1.2: {}
 
   tinyglobby@0.2.15:
     dependencies:
@@ -12675,10 +11696,6 @@ snapshots:
   tinyrainbow@3.1.0: {}
 
   tinyspy@4.0.4: {}
-
-  tippy.js@6.3.7:
-    dependencies:
-      '@popperjs/core': 2.11.8
 
   tmpl@1.0.5: {}
 
@@ -12871,22 +11888,11 @@ snapshots:
       escalade: 3.2.0
       picocolors: 1.1.1
 
-  update-browserslist-db@1.2.3(browserslist@4.28.2):
-    dependencies:
-      browserslist: 4.28.2
-      escalade: 3.2.0
-      picocolors: 1.1.1
-    optional: true
-
   uri-js@4.4.1:
     dependencies:
       punycode: 2.3.1
 
   url-join@4.0.1: {}
-
-  use-sync-external-store@1.6.0(react@19.2.4):
-    dependencies:
-      react: 19.2.4
 
   use-sync-external-store@1.6.0(react@19.2.5):
     dependencies:
@@ -12906,8 +11912,6 @@ snapshots:
 
   validator@13.15.26: {}
 
-  vanillajs-datepicker@1.3.4: {}
-
   vary@1.1.2: {}
 
   vite@8.0.10(@types/node@25.6.0)(esbuild@0.27.7)(jiti@2.6.1)(terser@5.44.0)(tsx@4.21.0)(yaml@2.8.2):
@@ -12926,57 +11930,10 @@ snapshots:
       tsx: 4.21.0
       yaml: 2.8.2
 
-  vite@8.0.3(@emnapi/core@1.7.0)(@emnapi/runtime@1.7.0)(@types/node@25.6.0)(esbuild@0.27.7)(jiti@2.6.1)(terser@5.44.0)(tsx@4.21.0)(yaml@2.8.2):
-    dependencies:
-      lightningcss: 1.32.0
-      picomatch: 4.0.4
-      postcss: 8.5.10
-      rolldown: 1.0.0-rc.12(@emnapi/core@1.7.0)(@emnapi/runtime@1.7.0)
-      tinyglobby: 0.2.16
-    optionalDependencies:
-      '@types/node': 25.6.0
-      esbuild: 0.27.7
-      fsevents: 2.3.3
-      jiti: 2.6.1
-      terser: 5.44.0
-      tsx: 4.21.0
-      yaml: 2.8.2
-    transitivePeerDependencies:
-      - '@emnapi/core'
-      - '@emnapi/runtime'
-
   vitest@4.1.5(@types/node@25.6.0)(happy-dom@20.9.0)(vite@8.0.10(@types/node@25.6.0)(esbuild@0.27.7)(jiti@2.6.1)(terser@5.44.0)(tsx@4.21.0)(yaml@2.8.2)):
     dependencies:
       '@vitest/expect': 4.1.5
       '@vitest/mocker': 4.1.5(vite@8.0.10(@types/node@25.6.0)(esbuild@0.27.7)(jiti@2.6.1)(terser@5.44.0)(tsx@4.21.0)(yaml@2.8.2))
-      '@vitest/pretty-format': 4.1.5
-      '@vitest/runner': 4.1.5
-      '@vitest/snapshot': 4.1.5
-      '@vitest/spy': 4.1.5
-      '@vitest/utils': 4.1.5
-      es-module-lexer: 2.1.0
-      expect-type: 1.3.0
-      magic-string: 0.30.21
-      obug: 2.1.1
-      pathe: 2.0.3
-      picomatch: 4.0.4
-      std-env: 4.1.0
-      tinybench: 2.9.0
-      tinyexec: 1.1.2
-      tinyglobby: 0.2.16
-      tinyrainbow: 3.1.0
-      vite: 8.0.10(@types/node@25.6.0)(esbuild@0.27.7)(jiti@2.6.1)(terser@5.44.0)(tsx@4.21.0)(yaml@2.8.2)
-      why-is-node-running: 2.3.0
-    optionalDependencies:
-      '@types/node': 25.6.0
-      happy-dom: 20.9.0
-    transitivePeerDependencies:
-      - msw
-
-  vitest@4.1.5(@types/node@25.6.0)(vite@8.0.3(@emnapi/core@1.7.0)(@emnapi/runtime@1.7.0)(@types/node@25.6.0)(esbuild@0.27.7)(jiti@2.6.1)(terser@5.44.0)(tsx@4.21.0)(yaml@2.8.2)):
-    dependencies:
-      '@vitest/expect': 4.1.5
-      '@vitest/mocker': 4.1.5(vite@8.0.3(@emnapi/core@1.7.0)(@emnapi/runtime@1.7.0)(@types/node@25.6.0)(esbuild@0.27.7)(jiti@2.6.1)(terser@5.44.0)(tsx@4.21.0)(yaml@2.8.2))
       '@vitest/pretty-format': 4.1.5
       '@vitest/runner': 4.1.5
       '@vitest/snapshot': 4.1.5
@@ -12993,10 +11950,11 @@ snapshots:
       tinyexec: 1.1.1
       tinyglobby: 0.2.16
       tinyrainbow: 3.1.0
-      vite: 8.0.3(@emnapi/core@1.7.0)(@emnapi/runtime@1.7.0)(@types/node@25.6.0)(esbuild@0.27.7)(jiti@2.6.1)(terser@5.44.0)(tsx@4.21.0)(yaml@2.8.2)
+      vite: 8.0.10(@types/node@25.6.0)(esbuild@0.27.7)(jiti@2.6.1)(terser@5.44.0)(tsx@4.21.0)(yaml@2.8.2)
       why-is-node-running: 2.3.0
     optionalDependencies:
       '@types/node': 25.6.0
+      happy-dom: 20.9.0
     transitivePeerDependencies:
       - msw
 
@@ -13018,9 +11976,6 @@ snapshots:
   webpack-node-externals@3.0.0: {}
 
   webpack-sources@3.3.4: {}
-
-  webpack-sources@3.4.1:
-    optional: true
 
   webpack-virtual-modules@0.6.2: {}
 
@@ -13056,40 +12011,8 @@ snapshots:
       - esbuild
       - uglify-js
 
-  webpack@5.106.0(esbuild@0.27.7):
-    dependencies:
-      '@types/eslint-scope': 3.7.7
-      '@types/estree': 1.0.8
-      '@types/json-schema': 7.0.15
-      '@webassemblyjs/ast': 1.14.1
-      '@webassemblyjs/wasm-edit': 1.14.1
-      '@webassemblyjs/wasm-parser': 1.14.1
-      acorn: 8.16.0
-      acorn-import-phases: 1.0.4(acorn@8.16.0)
-      browserslist: 4.28.2
-      chrome-trace-event: 1.0.4
-      enhanced-resolve: 5.21.0
-      es-module-lexer: 2.1.0
-      eslint-scope: 5.1.1
-      events: 3.3.0
-      glob-to-regexp: 0.4.1
-      graceful-fs: 4.2.11
-      json-parse-even-better-errors: 2.3.1
-      loader-runner: 4.3.2
-      mime-types: 2.1.35
-      neo-async: 2.6.2
-      schema-utils: 4.3.3
-      tapable: 2.3.3
-      terser-webpack-plugin: 5.5.0(esbuild@0.27.7)(webpack@5.106.0(esbuild@0.27.7))
-      watchpack: 2.5.1
-      webpack-sources: 3.4.1
-    transitivePeerDependencies:
-      - '@swc/core'
-      - esbuild
-      - uglify-js
+  whatwg-mimetype@3.0.0:
     optional: true
-
-  whatwg-mimetype@3.0.0: {}
 
   which@2.0.2:
     dependencies:

--- a/renovate.json
+++ b/renovate.json
@@ -1,5 +1,11 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": ["config:recommended"],
-  "ignoreDeps": ["tods-competition-factory"]
+  "ignoreDeps": ["tods-competition-factory"],
+  "packageRules": [
+    {
+      "matchManagers": ["npm"],
+      "semanticCommitType": "chore"
+    }
+  ]
 }

--- a/src/modules/providers/provider-catalog.service.ts
+++ b/src/modules/providers/provider-catalog.service.ts
@@ -1,0 +1,99 @@
+import { Inject, Injectable, NotFoundException } from '@nestjs/common';
+import { randomUUID } from 'crypto';
+
+import {
+  PROVIDER_CATALOG_STORAGE,
+  type IProviderCatalogStorage,
+  type CatalogItemRow,
+  type CatalogType,
+} from 'src/storage/interfaces/provider-catalog-storage.interface';
+import { SUCCESS } from 'src/common/constants/app';
+
+const VALID_TYPES: ReadonlyArray<CatalogType> = ['composition', 'tieFormat', 'policy'];
+
+export interface CatalogItemDto {
+  catalogId: string;
+  catalogType: CatalogType;
+  name: string;
+  description?: string | null;
+  data: any;
+  metadata?: any;
+  createdAt: Date;
+  updatedAt: Date;
+}
+
+function toDto(row: CatalogItemRow): CatalogItemDto {
+  return {
+    catalogId: row.catalogId,
+    catalogType: row.catalogType,
+    name: row.name,
+    description: row.description,
+    data: row.data,
+    metadata: row.metadata,
+    createdAt: row.createdAt,
+    updatedAt: row.updatedAt,
+  };
+}
+
+export function assertCatalogType(input: string): CatalogType {
+  if (!VALID_TYPES.includes(input as CatalogType)) {
+    throw new NotFoundException(`Unknown catalog type: ${input}`);
+  }
+  return input as CatalogType;
+}
+
+@Injectable()
+export class ProviderCatalogService {
+  constructor(
+    @Inject(PROVIDER_CATALOG_STORAGE) private readonly storage: IProviderCatalogStorage,
+  ) {}
+
+  async list(providerId: string, catalogType: CatalogType): Promise<{ items: CatalogItemDto[] }> {
+    const rows = await this.storage.findByProvider(providerId, catalogType);
+    return { items: rows.map(toDto) };
+  }
+
+  async getOne(
+    providerId: string,
+    catalogType: CatalogType,
+    catalogId: string,
+  ): Promise<CatalogItemDto> {
+    const row = await this.storage.getOne(providerId, catalogType, catalogId);
+    if (!row) throw new NotFoundException('Catalog item not found');
+    return toDto(row);
+  }
+
+  async create(
+    providerId: string,
+    catalogType: CatalogType,
+    body: { name: string; description?: string; data: any; metadata?: any },
+  ): Promise<CatalogItemDto> {
+    const row = await this.storage.create({
+      catalogId: randomUUID(),
+      providerId,
+      catalogType,
+      name: body.name,
+      description: body.description ?? null,
+      data: body.data,
+      metadata: body.metadata,
+    });
+    return toDto(row);
+  }
+
+  async update(
+    providerId: string,
+    catalogType: CatalogType,
+    catalogId: string,
+    patch: { name?: string; description?: string; data?: any; metadata?: any },
+  ) {
+    const existing = await this.storage.getOne(providerId, catalogType, catalogId);
+    if (!existing) throw new NotFoundException('Catalog item not found');
+    await this.storage.update(providerId, catalogType, catalogId, patch);
+    const updated = await this.storage.getOne(providerId, catalogType, catalogId);
+    return { ...SUCCESS, item: updated ? toDto(updated) : null };
+  }
+
+  async remove(providerId: string, catalogType: CatalogType, catalogId: string) {
+    return this.storage.remove(providerId, catalogType, catalogId);
+  }
+}

--- a/src/modules/providers/providers.controller.ts
+++ b/src/modules/providers/providers.controller.ts
@@ -1,6 +1,7 @@
 import {
   Body,
   Controller,
+  Delete,
   ForbiddenException,
   Get,
   HttpCode,
@@ -16,6 +17,8 @@ import { ModifyProviderDto } from './dto/modifyProvider.dto';
 import { Public } from '../auth/decorators/public.decorator';
 import { Roles } from '../auth/decorators/roles.decorator';
 import { ProvidersService } from './providers.service';
+import { TopologiesService } from './topologies.service';
+import { ProviderCatalogService, assertCatalogType } from './provider-catalog.service';
 import { AddProviderDto } from './dto/addProvider.dto';
 import { GetProviderDto } from './dto/getProvider.dto';
 import { GetCalendarDto } from './dto/getCalendar.dto';
@@ -24,7 +27,145 @@ import { RolesGuard } from '../auth/guards/role.guard';
 @UseGuards(RolesGuard)
 @Controller('provider')
 export class ProvidersController {
-  constructor(private readonly providers: ProvidersService) {}
+  constructor(
+    private readonly providers: ProvidersService,
+    private readonly topologies: TopologiesService,
+    private readonly catalog: ProviderCatalogService,
+  ) {}
+
+  /**
+   * Per-provider topology catalog. PROVIDER_ADMIN of the target provider
+   * or SUPER_ADMIN may read/write. Topology IDs are referenced by
+   * `allowedDrawTypes` in `providerConfigSettings` so the Allowed
+   * Selections chip widget can surface provider-defined draw structures
+   * alongside the factory enum.
+   */
+  private assertProviderAdmin(providerId: string, ctx: UserContext): void {
+    const isProviderAdmin = ctx?.providerRoles?.[providerId] === PROVIDER_ADMIN;
+    if (!ctx?.isSuperAdmin && !isProviderAdmin) {
+      throw new ForbiddenException('PROVIDER_ADMIN role required');
+    }
+  }
+
+  @Get(':providerId/topologies')
+  @Roles([CLIENT, ADMIN, SUPER_ADMIN])
+  listTopologies(@Param('providerId') providerId: string, @UserCtx() ctx: UserContext) {
+    this.assertProviderAdmin(providerId, ctx);
+    return this.topologies.listForProvider(providerId);
+  }
+
+  @Get(':providerId/topologies/:topologyId')
+  @Roles([CLIENT, ADMIN, SUPER_ADMIN])
+  getTopology(
+    @Param('providerId') providerId: string,
+    @Param('topologyId') topologyId: string,
+    @UserCtx() ctx: UserContext,
+  ) {
+    this.assertProviderAdmin(providerId, ctx);
+    return this.topologies.getOne(providerId, topologyId);
+  }
+
+  @Post(':providerId/topologies')
+  @Roles([CLIENT, ADMIN, SUPER_ADMIN])
+  @HttpCode(HttpStatus.OK)
+  createTopology(
+    @Param('providerId') providerId: string,
+    @Body() body: { name: string; description?: string; state: any },
+    @UserCtx() ctx: UserContext,
+  ) {
+    this.assertProviderAdmin(providerId, ctx);
+    return this.topologies.create(providerId, body);
+  }
+
+  @Put(':providerId/topologies/:topologyId')
+  @Roles([CLIENT, ADMIN, SUPER_ADMIN])
+  updateTopology(
+    @Param('providerId') providerId: string,
+    @Param('topologyId') topologyId: string,
+    @Body() body: { name?: string; description?: string; state?: any },
+    @UserCtx() ctx: UserContext,
+  ) {
+    this.assertProviderAdmin(providerId, ctx);
+    return this.topologies.update(providerId, topologyId, body);
+  }
+
+  @Delete(':providerId/topologies/:topologyId')
+  @Roles([CLIENT, ADMIN, SUPER_ADMIN])
+  removeTopology(
+    @Param('providerId') providerId: string,
+    @Param('topologyId') topologyId: string,
+    @UserCtx() ctx: UserContext,
+  ) {
+    this.assertProviderAdmin(providerId, ctx);
+    return this.topologies.remove(providerId, topologyId);
+  }
+
+  /**
+   * Per-provider catalog items: compositions, tieFormats, and policies.
+   * Same auth model as topologies (PROVIDER_ADMIN of target or SUPER_ADMIN).
+   * `:type` is one of `composition` | `tieFormat` | `policy` — invalid
+   * values 404 via the service's `assertCatalogType`.
+   */
+  @Get(':providerId/catalog/:type')
+  @Roles([CLIENT, ADMIN, SUPER_ADMIN])
+  listCatalog(
+    @Param('providerId') providerId: string,
+    @Param('type') type: string,
+    @UserCtx() ctx: UserContext,
+  ) {
+    this.assertProviderAdmin(providerId, ctx);
+    return this.catalog.list(providerId, assertCatalogType(type));
+  }
+
+  @Get(':providerId/catalog/:type/:catalogId')
+  @Roles([CLIENT, ADMIN, SUPER_ADMIN])
+  getCatalogItem(
+    @Param('providerId') providerId: string,
+    @Param('type') type: string,
+    @Param('catalogId') catalogId: string,
+    @UserCtx() ctx: UserContext,
+  ) {
+    this.assertProviderAdmin(providerId, ctx);
+    return this.catalog.getOne(providerId, assertCatalogType(type), catalogId);
+  }
+
+  @Post(':providerId/catalog/:type')
+  @Roles([CLIENT, ADMIN, SUPER_ADMIN])
+  @HttpCode(HttpStatus.OK)
+  createCatalogItem(
+    @Param('providerId') providerId: string,
+    @Param('type') type: string,
+    @Body() body: { name: string; description?: string; data: any; metadata?: any },
+    @UserCtx() ctx: UserContext,
+  ) {
+    this.assertProviderAdmin(providerId, ctx);
+    return this.catalog.create(providerId, assertCatalogType(type), body);
+  }
+
+  @Put(':providerId/catalog/:type/:catalogId')
+  @Roles([CLIENT, ADMIN, SUPER_ADMIN])
+  updateCatalogItem(
+    @Param('providerId') providerId: string,
+    @Param('type') type: string,
+    @Param('catalogId') catalogId: string,
+    @Body() body: { name?: string; description?: string; data?: any; metadata?: any },
+    @UserCtx() ctx: UserContext,
+  ) {
+    this.assertProviderAdmin(providerId, ctx);
+    return this.catalog.update(providerId, assertCatalogType(type), catalogId, body);
+  }
+
+  @Delete(':providerId/catalog/:type/:catalogId')
+  @Roles([CLIENT, ADMIN, SUPER_ADMIN])
+  removeCatalogItem(
+    @Param('providerId') providerId: string,
+    @Param('type') type: string,
+    @Param('catalogId') catalogId: string,
+    @UserCtx() ctx: UserContext,
+  ) {
+    this.assertProviderAdmin(providerId, ctx);
+    return this.catalog.remove(providerId, assertCatalogType(type), catalogId);
+  }
 
   /** Public calendar — used by courthive-public and epixodic. Unchanged. */
   @Public()

--- a/src/modules/providers/providers.module.ts
+++ b/src/modules/providers/providers.module.ts
@@ -1,10 +1,12 @@
 import { ProvidersController } from './providers.controller';
 import { ProvidersService } from './providers.service';
+import { TopologiesService } from './topologies.service';
+import { ProviderCatalogService } from './provider-catalog.service';
 import { Module } from '@nestjs/common';
 
 @Module({
   controllers: [ProvidersController],
-  providers: [ProvidersService],
-  exports: [ProvidersService],
+  providers: [ProvidersService, TopologiesService, ProviderCatalogService],
+  exports: [ProvidersService, TopologiesService, ProviderCatalogService],
 })
 export class ProvidersModule {}

--- a/src/modules/providers/providers.service.spec.ts
+++ b/src/modules/providers/providers.service.spec.ts
@@ -1,6 +1,8 @@
 import { ProvidersController } from './providers.controller';
 import { StorageModule } from 'src/storage/storage.module';
 import { ProvidersService } from './providers.service';
+import { TopologiesService } from './topologies.service';
+import { ProviderCatalogService } from './provider-catalog.service';
 import { Test, TestingModule } from '@nestjs/testing';
 import { CacheModule } from '../cache/cache.module';
 import { UsersModule } from '../users/users.module';
@@ -14,7 +16,7 @@ describe('ProvidersService', () => {
   beforeAll(async () => {
     app = await Test.createTestingModule({
       imports: [AuthModule, UsersModule, CacheModule, StorageModule],
-      providers: [ProvidersService, ConfigService],
+      providers: [ProvidersService, TopologiesService, ProviderCatalogService, ConfigService],
       controllers: [ProvidersController],
     }).compile();
 

--- a/src/modules/providers/topologies.service.ts
+++ b/src/modules/providers/topologies.service.ts
@@ -1,0 +1,77 @@
+import { Inject, Injectable, NotFoundException } from '@nestjs/common';
+import { randomUUID } from 'crypto';
+
+import {
+  TOPOLOGY_STORAGE,
+  type ITopologyStorage,
+  type TopologyRow,
+} from 'src/storage/interfaces/topology-storage.interface';
+import { SUCCESS } from 'src/common/constants/app';
+
+export interface TopologyDto {
+  topologyId: string;
+  name: string;
+  description?: string | null;
+  state: any;
+  createdAt: Date;
+  updatedAt: Date;
+}
+
+function toDto(row: TopologyRow): TopologyDto {
+  return {
+    topologyId: row.topologyId,
+    name: row.name,
+    description: row.description,
+    state: row.state,
+    createdAt: row.createdAt,
+    updatedAt: row.updatedAt,
+  };
+}
+
+@Injectable()
+export class TopologiesService {
+  constructor(
+    @Inject(TOPOLOGY_STORAGE) private readonly topologyStorage: ITopologyStorage,
+  ) {}
+
+  async listForProvider(providerId: string): Promise<{ topologies: TopologyDto[] }> {
+    const rows = await this.topologyStorage.findByProvider(providerId);
+    return { topologies: rows.map(toDto) };
+  }
+
+  async getOne(providerId: string, topologyId: string): Promise<TopologyDto> {
+    const row = await this.topologyStorage.getOne(providerId, topologyId);
+    if (!row) throw new NotFoundException('Topology not found');
+    return toDto(row);
+  }
+
+  async create(
+    providerId: string,
+    body: { name: string; description?: string; state: any },
+  ): Promise<TopologyDto> {
+    const row = await this.topologyStorage.create({
+      topologyId: randomUUID(),
+      providerId,
+      name: body.name,
+      description: body.description ?? null,
+      state: body.state,
+    });
+    return toDto(row);
+  }
+
+  async update(
+    providerId: string,
+    topologyId: string,
+    patch: { name?: string; description?: string; state?: any },
+  ) {
+    const existing = await this.topologyStorage.getOne(providerId, topologyId);
+    if (!existing) throw new NotFoundException('Topology not found');
+    await this.topologyStorage.update(providerId, topologyId, patch);
+    const updated = await this.topologyStorage.getOne(providerId, topologyId);
+    return { ...SUCCESS, topology: updated ? toDto(updated) : null };
+  }
+
+  async remove(providerId: string, topologyId: string) {
+    return this.topologyStorage.remove(providerId, topologyId);
+  }
+}

--- a/src/storage/interfaces/provider-catalog-storage.interface.ts
+++ b/src/storage/interfaces/provider-catalog-storage.interface.ts
@@ -1,0 +1,42 @@
+export const PROVIDER_CATALOG_STORAGE = Symbol('PROVIDER_CATALOG_STORAGE');
+
+export type CatalogType = 'composition' | 'tieFormat' | 'policy';
+
+export interface CatalogItemRow {
+  catalogId: string;
+  providerId: string;
+  catalogType: CatalogType;
+  name: string;
+  description?: string | null;
+  data: any;
+  metadata?: any;
+  createdAt: Date;
+  updatedAt: Date;
+}
+
+export interface IProviderCatalogStorage {
+  /** List all catalog items of `catalogType` authored by `providerId`. */
+  findByProvider(providerId: string, catalogType: CatalogType): Promise<CatalogItemRow[]>;
+
+  /** Get one item, scoped to (provider, type) so the request handler can't accidentally read another provider's row. */
+  getOne(
+    providerId: string,
+    catalogType: CatalogType,
+    catalogId: string,
+  ): Promise<CatalogItemRow | null>;
+
+  create(row: Omit<CatalogItemRow, 'createdAt' | 'updatedAt'>): Promise<CatalogItemRow>;
+
+  update(
+    providerId: string,
+    catalogType: CatalogType,
+    catalogId: string,
+    patch: Partial<Pick<CatalogItemRow, 'name' | 'description' | 'data' | 'metadata'>>,
+  ): Promise<{ success: boolean }>;
+
+  remove(
+    providerId: string,
+    catalogType: CatalogType,
+    catalogId: string,
+  ): Promise<{ success: boolean }>;
+}

--- a/src/storage/interfaces/topology-storage.interface.ts
+++ b/src/storage/interfaces/topology-storage.interface.ts
@@ -1,0 +1,36 @@
+export const TOPOLOGY_STORAGE = Symbol('TOPOLOGY_STORAGE');
+
+export interface TopologyRow {
+  topologyId: string;
+  providerId: string;
+  name: string;
+  description?: string | null;
+  state: any;
+  createdAt: Date;
+  updatedAt: Date;
+}
+
+export interface ITopologyStorage {
+  /** List all topologies authored by a provider, ordered by name. */
+  findByProvider(providerId: string): Promise<TopologyRow[]>;
+
+  /** Get a single topology by id, scoped to the owning provider. */
+  getOne(providerId: string, topologyId: string): Promise<TopologyRow | null>;
+
+  /** Insert a new topology. The caller supplies the topology id. */
+  create(row: Omit<TopologyRow, 'createdAt' | 'updatedAt'>): Promise<TopologyRow>;
+
+  /**
+   * Patch name / description / state on an existing topology. Provider
+   * scope is enforced here so a request handler can't accidentally
+   * mutate another provider's row by id alone.
+   */
+  update(
+    providerId: string,
+    topologyId: string,
+    patch: Partial<Pick<TopologyRow, 'name' | 'description' | 'state'>>,
+  ): Promise<{ success: boolean }>;
+
+  /** Permanent delete. */
+  remove(providerId: string, topologyId: string): Promise<{ success: boolean }>;
+}

--- a/src/storage/postgres/migrations/020-add-provider-topologies.sql
+++ b/src/storage/postgres/migrations/020-add-provider-topologies.sql
@@ -1,0 +1,24 @@
+-- 020-add-provider-topologies.sql
+-- Per-provider topology catalog for the admin-client Templates page.
+-- Each row is a saved topology (bracket structure) authored by a
+-- provider admin. Topology IDs are referenced by `allowedDrawTypes`
+-- in `providerConfigSettings` so the Allowed Selections chip widget
+-- can surface provider-defined draw structures alongside the factory
+-- enum.
+--
+-- Per-provider only: there is no system-wide topology catalog. Builtin
+-- topologies are read-only (provided by `standardTemplates` from
+-- `courthive-components`) and don't need server storage.
+
+CREATE TABLE IF NOT EXISTS provider_topologies (
+  topology_id   TEXT PRIMARY KEY,
+  provider_id   TEXT NOT NULL REFERENCES providers(provider_id) ON DELETE CASCADE,
+  name          TEXT NOT NULL,
+  description   TEXT,
+  state         JSONB NOT NULL,
+  created_at    TIMESTAMPTZ DEFAULT NOW(),
+  updated_at    TIMESTAMPTZ DEFAULT NOW(),
+  UNIQUE (provider_id, name)
+);
+
+CREATE INDEX IF NOT EXISTS idx_provider_topologies_provider ON provider_topologies(provider_id);

--- a/src/storage/postgres/migrations/021-add-provider-catalog-items.sql
+++ b/src/storage/postgres/migrations/021-add-provider-catalog-items.sql
@@ -1,0 +1,27 @@
+-- 021-add-provider-catalog-items.sql
+-- Per-provider catalog items shared across the Templates page (compositions,
+-- tieFormats) and the Policies page (policies). Topologies stay in their
+-- own table (`provider_topologies`, migration 020) since they shipped first
+-- and consolidating would require a data move; new types use this generic
+-- table to avoid copy-pasting near-identical storage classes per type.
+--
+-- `metadata` is reserved for type-specific fields the editor components
+-- need at the catalog-item level — for policies that's `policyType`
+-- (matches the `PolicyCatalogItem` shape from courthive-components); for
+-- compositions / tieFormats it's typically empty.
+
+CREATE TABLE IF NOT EXISTS provider_catalog_items (
+  catalog_id    TEXT PRIMARY KEY,
+  provider_id   TEXT NOT NULL REFERENCES providers(provider_id) ON DELETE CASCADE,
+  catalog_type  TEXT NOT NULL,
+  name          TEXT NOT NULL,
+  description   TEXT,
+  data          JSONB NOT NULL,
+  metadata      JSONB,
+  created_at    TIMESTAMPTZ DEFAULT NOW(),
+  updated_at    TIMESTAMPTZ DEFAULT NOW(),
+  UNIQUE (provider_id, catalog_type, name)
+);
+
+CREATE INDEX IF NOT EXISTS idx_provider_catalog_items_lookup
+  ON provider_catalog_items(provider_id, catalog_type);

--- a/src/storage/postgres/postgres-provider-catalog.storage.ts
+++ b/src/storage/postgres/postgres-provider-catalog.storage.ts
@@ -1,0 +1,127 @@
+import { Inject, Injectable } from '@nestjs/common';
+import { Pool } from 'pg';
+
+import {
+  CatalogItemRow,
+  CatalogType,
+  IProviderCatalogStorage,
+} from '../interfaces/provider-catalog-storage.interface';
+import { PG_POOL } from './postgres.config';
+import { SUCCESS } from 'src/common/constants/app';
+
+const COLS =
+  'catalog_id, provider_id, catalog_type, name, description, data, metadata, created_at, updated_at';
+
+@Injectable()
+export class PostgresProviderCatalogStorage implements IProviderCatalogStorage {
+  constructor(@Inject(PG_POOL) private readonly pool: Pool) {}
+
+  async findByProvider(providerId: string, catalogType: CatalogType): Promise<CatalogItemRow[]> {
+    const result = await this.pool.query(
+      `SELECT ${COLS} FROM provider_catalog_items
+       WHERE provider_id = $1 AND catalog_type = $2
+       ORDER BY name`,
+      [providerId, catalogType],
+    );
+    return result.rows.map(mapRow);
+  }
+
+  async getOne(
+    providerId: string,
+    catalogType: CatalogType,
+    catalogId: string,
+  ): Promise<CatalogItemRow | null> {
+    const result = await this.pool.query(
+      `SELECT ${COLS} FROM provider_catalog_items
+       WHERE provider_id = $1 AND catalog_type = $2 AND catalog_id = $3`,
+      [providerId, catalogType, catalogId],
+    );
+    return result.rows.length ? mapRow(result.rows[0]) : null;
+  }
+
+  async create(row: Omit<CatalogItemRow, 'createdAt' | 'updatedAt'>): Promise<CatalogItemRow> {
+    const result = await this.pool.query(
+      `INSERT INTO provider_catalog_items
+         (catalog_id, provider_id, catalog_type, name, description, data, metadata)
+       VALUES ($1, $2, $3, $4, $5, $6, $7)
+       RETURNING ${COLS}`,
+      [
+        row.catalogId,
+        row.providerId,
+        row.catalogType,
+        row.name,
+        row.description ?? null,
+        JSON.stringify(row.data),
+        row.metadata != null ? JSON.stringify(row.metadata) : null,
+      ],
+    );
+    return mapRow(result.rows[0]);
+  }
+
+  async update(
+    providerId: string,
+    catalogType: CatalogType,
+    catalogId: string,
+    patch: Partial<Pick<CatalogItemRow, 'name' | 'description' | 'data' | 'metadata'>>,
+  ): Promise<{ success: boolean }> {
+    const sets: string[] = [];
+    const values: any[] = [];
+    let idx = 1;
+
+    if (patch.name !== undefined) {
+      sets.push(`name = $${idx++}`);
+      values.push(patch.name);
+    }
+    if (patch.description !== undefined) {
+      sets.push(`description = $${idx++}`);
+      values.push(patch.description);
+    }
+    if (patch.data !== undefined) {
+      sets.push(`data = $${idx++}`);
+      values.push(JSON.stringify(patch.data));
+    }
+    if (patch.metadata !== undefined) {
+      sets.push(`metadata = $${idx++}`);
+      values.push(patch.metadata != null ? JSON.stringify(patch.metadata) : null);
+    }
+
+    if (!sets.length) return { ...SUCCESS };
+
+    sets.push('updated_at = NOW()');
+    values.push(providerId, catalogType, catalogId);
+
+    await this.pool.query(
+      `UPDATE provider_catalog_items SET ${sets.join(', ')}
+       WHERE provider_id = $${idx++} AND catalog_type = $${idx++} AND catalog_id = $${idx}`,
+      values,
+    );
+    return { ...SUCCESS };
+  }
+
+  async remove(
+    providerId: string,
+    catalogType: CatalogType,
+    catalogId: string,
+  ): Promise<{ success: boolean }> {
+    await this.pool.query(
+      `DELETE FROM provider_catalog_items
+       WHERE provider_id = $1 AND catalog_type = $2 AND catalog_id = $3`,
+      [providerId, catalogType, catalogId],
+    );
+    return { ...SUCCESS };
+  }
+}
+
+function mapRow(row: any): CatalogItemRow {
+  return {
+    catalogId: row.catalog_id,
+    providerId: row.provider_id,
+    catalogType: row.catalog_type as CatalogType,
+    name: row.name,
+    description: row.description,
+    data: row.data,
+    metadata: row.metadata,
+    createdAt: row.created_at,
+    updatedAt: row.updated_at,
+  };
+}

--- a/src/storage/postgres/postgres-topology.storage.spec.ts
+++ b/src/storage/postgres/postgres-topology.storage.spec.ts
@@ -1,0 +1,102 @@
+import { PostgresTopologyStorage } from './postgres-topology.storage';
+import { ITopologyStorage } from '../interfaces/topology-storage.interface';
+
+function makeMockPool() {
+  return { query: jest.fn() };
+}
+
+const NOW = new Date('2026-05-01');
+const SAMPLE_ROW = {
+  topology_id: 't1',
+  provider_id: 'prov1',
+  name: 'My Bracket',
+  description: 'Custom bracket',
+  state: { nodes: [], edges: [] },
+  created_at: NOW,
+  updated_at: NOW,
+};
+
+describe('PostgresTopologyStorage', () => {
+  let pool: ReturnType<typeof makeMockPool>;
+  let storage: ITopologyStorage;
+
+  beforeEach(() => {
+    pool = makeMockPool();
+    storage = new PostgresTopologyStorage(pool as any);
+  });
+
+  it('findByProvider scopes the SELECT to the provider id and orders by name', async () => {
+    pool.query.mockResolvedValueOnce({ rows: [SAMPLE_ROW] });
+    const rows = await storage.findByProvider('prov1');
+    expect(pool.query).toHaveBeenCalledWith(
+      expect.stringMatching(/WHERE provider_id = \$1.*ORDER BY name/),
+      ['prov1'],
+    );
+    expect(rows).toHaveLength(1);
+    expect(rows[0]).toEqual({
+      topologyId: 't1',
+      providerId: 'prov1',
+      name: 'My Bracket',
+      description: 'Custom bracket',
+      state: { nodes: [], edges: [] },
+      createdAt: NOW,
+      updatedAt: NOW,
+    });
+  });
+
+  it('getOne returns null when no row found', async () => {
+    pool.query.mockResolvedValueOnce({ rows: [] });
+    const row = await storage.getOne('prov1', 'missing');
+    expect(row).toBeNull();
+  });
+
+  it('getOne enforces provider scope in the WHERE clause', async () => {
+    pool.query.mockResolvedValueOnce({ rows: [SAMPLE_ROW] });
+    await storage.getOne('prov1', 't1');
+    expect(pool.query).toHaveBeenCalledWith(
+      expect.stringMatching(/WHERE provider_id = \$1 AND topology_id = \$2/),
+      ['prov1', 't1'],
+    );
+  });
+
+  it('create stringifies state and returns the inserted row mapped', async () => {
+    pool.query.mockResolvedValueOnce({ rows: [SAMPLE_ROW] });
+    const row = await storage.create({
+      topologyId: 't1',
+      providerId: 'prov1',
+      name: 'My Bracket',
+      description: 'Custom bracket',
+      state: { nodes: [], edges: [] },
+    });
+    const args = pool.query.mock.calls[0][1];
+    expect(args[0]).toBe('t1');
+    expect(args[1]).toBe('prov1');
+    expect(args[4]).toBe('{"nodes":[],"edges":[]}');
+    expect(row.topologyId).toBe('t1');
+  });
+
+  it('update is a no-op when patch is empty', async () => {
+    const result = await storage.update('prov1', 't1', {});
+    expect(pool.query).not.toHaveBeenCalled();
+    expect(result.success).toBe(true);
+  });
+
+  it('update only sets supplied fields and includes provider scope in WHERE', async () => {
+    pool.query.mockResolvedValueOnce({});
+    await storage.update('prov1', 't1', { name: 'Renamed' });
+    const [sql, values] = pool.query.mock.calls[0];
+    expect(sql).toContain('SET name = $1');
+    expect(sql).toContain('updated_at = NOW()');
+    expect(sql).toContain('WHERE provider_id = $2 AND topology_id = $3');
+    expect(values).toEqual(['Renamed', 'prov1', 't1']);
+  });
+
+  it('remove enforces provider scope', async () => {
+    pool.query.mockResolvedValueOnce({});
+    await storage.remove('prov1', 't1');
+    expect(pool.query).toHaveBeenCalledWith(
+      expect.stringMatching(/DELETE FROM provider_topologies WHERE provider_id = \$1 AND topology_id = \$2/),
+      ['prov1', 't1'],
+    );
+  });
+});

--- a/src/storage/postgres/postgres-topology.storage.ts
+++ b/src/storage/postgres/postgres-topology.storage.ts
@@ -1,0 +1,106 @@
+import { Inject, Injectable } from '@nestjs/common';
+import { Pool } from 'pg';
+
+import {
+  ITopologyStorage,
+  TopologyRow,
+} from '../interfaces/topology-storage.interface';
+import { PG_POOL } from './postgres.config';
+import { SUCCESS } from 'src/common/constants/app';
+
+const COLS =
+  'topology_id, provider_id, name, description, state, created_at, updated_at';
+
+@Injectable()
+export class PostgresTopologyStorage implements ITopologyStorage {
+  constructor(@Inject(PG_POOL) private readonly pool: Pool) {}
+
+  async findByProvider(providerId: string): Promise<TopologyRow[]> {
+    const result = await this.pool.query(
+      `SELECT ${COLS} FROM provider_topologies WHERE provider_id = $1 ORDER BY name`,
+      [providerId],
+    );
+    return result.rows.map(mapRow);
+  }
+
+  async getOne(providerId: string, topologyId: string): Promise<TopologyRow | null> {
+    const result = await this.pool.query(
+      `SELECT ${COLS} FROM provider_topologies WHERE provider_id = $1 AND topology_id = $2`,
+      [providerId, topologyId],
+    );
+    return result.rows.length ? mapRow(result.rows[0]) : null;
+  }
+
+  async create(
+    row: Omit<TopologyRow, 'createdAt' | 'updatedAt'>,
+  ): Promise<TopologyRow> {
+    const result = await this.pool.query(
+      `INSERT INTO provider_topologies (topology_id, provider_id, name, description, state)
+       VALUES ($1, $2, $3, $4, $5)
+       RETURNING ${COLS}`,
+      [
+        row.topologyId,
+        row.providerId,
+        row.name,
+        row.description ?? null,
+        JSON.stringify(row.state),
+      ],
+    );
+    return mapRow(result.rows[0]);
+  }
+
+  async update(
+    providerId: string,
+    topologyId: string,
+    patch: Partial<Pick<TopologyRow, 'name' | 'description' | 'state'>>,
+  ): Promise<{ success: boolean }> {
+    const sets: string[] = [];
+    const values: any[] = [];
+    let idx = 1;
+
+    if (patch.name !== undefined) {
+      sets.push(`name = $${idx++}`);
+      values.push(patch.name);
+    }
+    if (patch.description !== undefined) {
+      sets.push(`description = $${idx++}`);
+      values.push(patch.description);
+    }
+    if (patch.state !== undefined) {
+      sets.push(`state = $${idx++}`);
+      values.push(JSON.stringify(patch.state));
+    }
+
+    if (!sets.length) return { ...SUCCESS };
+
+    sets.push('updated_at = NOW()');
+    values.push(providerId, topologyId);
+
+    await this.pool.query(
+      `UPDATE provider_topologies SET ${sets.join(', ')}
+       WHERE provider_id = $${idx++} AND topology_id = $${idx}`,
+      values,
+    );
+    return { ...SUCCESS };
+  }
+
+  async remove(providerId: string, topologyId: string): Promise<{ success: boolean }> {
+    await this.pool.query(
+      'DELETE FROM provider_topologies WHERE provider_id = $1 AND topology_id = $2',
+      [providerId, topologyId],
+    );
+    return { ...SUCCESS };
+  }
+}
+
+function mapRow(row: any): TopologyRow {
+  return {
+    topologyId: row.topology_id,
+    providerId: row.provider_id,
+    name: row.name,
+    description: row.description,
+    state: row.state,
+    createdAt: row.created_at,
+    updatedAt: row.updated_at,
+  };
+}

--- a/src/storage/storage.module.ts
+++ b/src/storage/storage.module.ts
@@ -13,6 +13,8 @@ import { TOURNAMENT_STORAGE } from './interfaces/tournament-storage.interface';
 import { ASSIGNMENT_STORAGE } from './interfaces/assignment-storage.interface';
 import { AUTH_CODE_STORAGE } from './interfaces/auth-code-storage.interface';
 import { PROVIDER_STORAGE } from './interfaces/provider-storage.interface';
+import { TOPOLOGY_STORAGE } from './interfaces/topology-storage.interface';
+import { PROVIDER_CATALOG_STORAGE } from './interfaces/provider-catalog-storage.interface';
 import { CALENDAR_STORAGE } from './interfaces/calendar-storage.interface';
 import { AUDIT_STORAGE } from './interfaces/audit-storage.interface';
 import { USER_STORAGE } from './interfaces/user-storage.interface';
@@ -32,6 +34,8 @@ import { PostgresBoltHistoryStorage } from './postgres/postgres-bolt-history.sto
 import { PostgresTournamentStorage } from './postgres/postgres-tournament.storage';
 import { PostgresAssignmentStorage } from './postgres/postgres-assignment.storage';
 import { PostgresProviderStorage } from './postgres/postgres-provider.storage';
+import { PostgresTopologyStorage } from './postgres/postgres-topology.storage';
+import { PostgresProviderCatalogStorage } from './postgres/postgres-provider-catalog.storage';
 import { PostgresCalendarStorage } from './postgres/postgres-calendar.storage';
 import { PostgresAuthCodeStorage } from './postgres/postgres-auth-code.storage';
 import { PostgresUserStorage } from './postgres/postgres-user.storage';
@@ -58,6 +62,11 @@ function makeStorageProvider(token: symbol, storageClass: any) {
 const tournamentStorageProvider = makeStorageProvider(TOURNAMENT_STORAGE, PostgresTournamentStorage);
 const userStorageProvider = makeStorageProvider(USER_STORAGE, PostgresUserStorage);
 const providerStorageProvider = makeStorageProvider(PROVIDER_STORAGE, PostgresProviderStorage);
+const topologyStorageProvider = makeStorageProvider(TOPOLOGY_STORAGE, PostgresTopologyStorage);
+const providerCatalogStorageProvider = makeStorageProvider(
+  PROVIDER_CATALOG_STORAGE,
+  PostgresProviderCatalogStorage,
+);
 const calendarStorageProvider = makeStorageProvider(CALENDAR_STORAGE, PostgresCalendarStorage);
 const authCodeStorageProvider = makeStorageProvider(AUTH_CODE_STORAGE, PostgresAuthCodeStorage);
 const officiatingStorageProvider = makeStorageProvider(OFFICIATING_STORAGE, PostgresOfficiatingStorage);
@@ -82,6 +91,8 @@ const userProvisionerStorageProvider = makeStorageProvider(USER_PROVISIONER_STOR
     tournamentStorageProvider,
     userStorageProvider,
     providerStorageProvider,
+    topologyStorageProvider,
+    providerCatalogStorageProvider,
     calendarStorageProvider,
     authCodeStorageProvider,
     officiatingStorageProvider,
@@ -104,6 +115,8 @@ const userProvisionerStorageProvider = makeStorageProvider(USER_PROVISIONER_STOR
     TOURNAMENT_STORAGE,
     USER_STORAGE,
     PROVIDER_STORAGE,
+    TOPOLOGY_STORAGE,
+    PROVIDER_CATALOG_STORAGE,
     CALENDAR_STORAGE,
     AUTH_CODE_STORAGE,
     OFFICIATING_STORAGE,


### PR DESCRIPTION
## Summary

13 commits accumulated since `main` deliver an end-to-end redesign of the admin-client provider experience:

- **Settings panel** rewritten as an in-page two-column layout (left topic nav + right structured editor) replacing the old modal — Permissions, Allowed Selections, Policies, Defaults, Print Configuration, Categories. Save button + dirty tracking + per-topic editors.
- **Allowed Selections** chip widget supports three modes: provisioner-restricted (`pinnedUniverse`), closed factory enum (`fullUniverse`, new), and free-form text (matchUpFormatCode only). Draw Types universe also folds in this provider's saved topologies.
- **Templates page** (new `/templates/:view` route): per-provider catalogs for Topologies (`TopologyBuilderControl`), Compositions (`createCompositionEditor`), and Tie Formats (JSON editor pending a real UI editor port from TMX). Builtin items render with a small lock-icon marker.
- **Policies page** (new `/policies` route): `createPolicyCatalog` from courthive-components seeded with 15 factory-fixture builtins (scheduling/scoring/seeding + 10 ranking-points variants). Per-provider user policies persist via the generic catalog endpoint.
- **Settings → Policies** is now a picker over the policy catalog (was raw JSON paste). Selection snapshots `policyData` inline; orphan hint surfaces if stored policy doesn't match any catalog entry.
- **Server-side**: migrations 020 (`provider_topologies`) and 021 (`provider_catalog_items` with type discriminator), interfaces + Postgres impls + services + 10 REST endpoints under `/provider/:id/topologies` and `/provider/:id/catalog/:type`. PROVIDER_ADMIN-or-SUPER_ADMIN auth via shared `assertProviderAdmin`.
- **Renovate-loop fix**: `chore(renovate)` packageRule re-classifies dependency bumps as `chore:` so they no longer trigger release-please patches.

## Test plan

- [x] `pnpm check-types` — admin-client + server clean
- [x] `pnpm lint` — admin-client + server clean
- [x] `pnpm test` (admin-client vitest) — 58/58 pass
- [x] `pnpm test --testPathPatterns=providers` (server jest) — 110/110 pass
- [x] `pnpm test:e2e --grep "Allowed Selections"` — 10/10 Playwright pass
- [ ] After merge: server restart runs migrations 020 + 021 via `MigrationRunnerService`
- [ ] Manual verification: impersonate a provider, build a topology, save it, then check Settings → Allowed Selections → Draw Types includes it as `<name> (custom)`
- [ ] Manual verification: create a custom policy on `/policies`, then Settings → Policies surfaces it in the picker for the matching policy type