### PR TITLE
fix(users): normalize email to lowercase for case-insensitive auth

### DIFF
--- a/src/modules/users/users.service.ts
+++ b/src/modules/users/users.service.ts
@@ -39,22 +39,25 @@ export class UsersService {
   ];
 
   async findOne(email: string) {
+    const normalizedEmail = email?.toLowerCase().trim();
     const mode = this.configService.get('APP')?.mode;
-    const devModeTestUser = mode === 'development' && (await this.testUsers.find((user) => user.email === email));
+    const devModeTestUser =
+      mode === 'development' && (await this.testUsers.find((user) => user.email === normalizedEmail));
     if (devModeTestUser) return devModeTestUser;
-    return await this.userStorage.findOne(email);
+    return await this.userStorage.findOne(normalizedEmail);
   }
 
   async create(user: User) {
-    const { password, ...value } = user;
+    const { password, email, ...value } = user;
     if (!password) return { error: 'Password is required' };
-    const hashedUser = { ...value, password: await hashPassword(password) };
+    const hashedUser = { ...value, email: email?.toLowerCase().trim(), password: await hashPassword(password) };
     return await this.userStorage.create(hashedUser as any);
   }
 
   async remove(email: string) {
-    const result = await this.userStorage.remove(email);
-    console.log('remove result', { key: email }, result);
+    const normalizedEmail = email?.toLowerCase().trim();
+    const result = await this.userStorage.remove(normalizedEmail);
+    console.log('remove result', { key: normalizedEmail }, result);
     return { ...SUCCESS };
   }
 
@@ -75,11 +78,12 @@ export class UsersService {
 
   async requestMagicLink(email: string) {
     if (!email) return { error: 'Invalid request' };
+    const normalizedEmail = email.toLowerCase().trim();
 
-    const user = await this.userStorage.findOne(email);
+    const user = await this.userStorage.findOne(normalizedEmail);
     if (user) {
       const magicLinkCode = createUniqueKey();
-      await this.authCodeStorage.setAccessCode(magicLinkCode, email);
+      await this.authCodeStorage.setAccessCode(magicLinkCode, normalizedEmail);
 
       // TODO: The magic link URL will need to launch the web server / end user app
       /*


### PR DESCRIPTION
## The bug

`UsersService.findOne` and `.create` pass emails to the storage layer unchanged. LevelDB key lookups are byte-exact, so a stored user `amber@example.com` cannot be found if the client sends `Amber@example.com`. This causes silent `UnauthorizedException` failures whenever an email reaches the service with different casing than at registration time.

The most common trigger is mobile browsers' default auto-capitalization on `<input type="text">` email fields — but it can also happen with copy-paste from email clients that quote the local-part, or any inviter typing capitals into the invite form.

## The fix

Normalize email to `toLowerCase().trim()` at every entry point in `UsersService`:

- `findOne`: normalize the lookup key
- `create`: normalize stored email so registration is canonical
- `remove`: normalize the lookup key
- `requestMagicLink`: normalize before storage and before issuing the access code

Storage now consistently holds canonical lowercase emails, and lookups normalize the query before hitting the storage layer. `auth.service.ts` callers (signIn, invite, register, forgotPassword, resetPassword) all funnel through `UsersService` so they're transitively covered.

## Notes

- Optional chaining (`email?.toLowerCase()`) preserves the existing `if (!email)` guard pattern.
- Dev mode test user (`axel@castle.com`) already has a lowercase email, so the equality check still works after normalizing the input side.
- This does not migrate already-capitalized emails in storage. A one-time migration would be a separate change; this PR ensures the bug stops happening going forward.

## Related

Companion frontend fix (TMX): adds `type='email'` to the login input to prevent the symptom at the source.