### PR TITLE
feat(account): contact-email + verification flow (Phase B2)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -33,6 +33,10 @@ PG_DATABASE='courthive'
 RESEND_API_KEY=''
 EMAIL_FROM='CourtHive <no-reply@send.courthive.com>'
 
+# Public-facing base URL used by email-verification + password-reset
+# links. Example: 'https://nest.courthive.com'. No trailing slash.
+APP_BASE_URL=''
+
 # Arena relay (Wave 1c)
 INSTANCE_ROLE=local                            # 'local' (Mac mini in arena) | 'cloud' (public relay)
 LOCAL_VENUE_ID=arena-dev-00                    # unique per Mac mini, used in cloud ingest auth

--- a/admin-client/src/components/banners/contactEmailBanner.ts
+++ b/admin-client/src/components/banners/contactEmailBanner.ts
@@ -1,0 +1,91 @@
+/**
+ * Post-login nag banner for users whose `contact_email` is missing or
+ * unverified. Without a verified contact address, the password-reset
+ * flow (B3) has no destination — so the banner exists to push users
+ * into the IdentityService.setContactEmail call before B3 starts
+ * needing it.
+ *
+ * Re-evaluated on every router navigation (cheap — just decodes the
+ * cached JWT). Dismissable per-session via localStorage; dismissals
+ * re-arm 24h later so a user who logs in tomorrow gets nagged again.
+ *
+ * Lives at #globalBanner (added in rootBlock), above the page
+ * containers and below the navbar.
+ */
+import { getLoginState } from 'services/authentication/loginState';
+import { contactEmailModal } from 'components/modals/contactEmail';
+import { VERIFY_EMAIL } from 'constants/tmxConstants';
+import { t } from 'i18n';
+
+const DISMISS_KEY = 'admin_contact_email_banner_dismissed_until';
+const DISMISS_TTL_MS = 24 * 60 * 60 * 1000;
+
+function isDismissed(): boolean {
+  const raw = globalThis.localStorage?.getItem(DISMISS_KEY);
+  if (!raw) return false;
+  const until = Number(raw);
+  if (!Number.isFinite(until)) return false;
+  return Date.now() < until;
+}
+
+function dismiss(): void {
+  globalThis.localStorage?.setItem(DISMISS_KEY, String(Date.now() + DISMISS_TTL_MS));
+}
+
+export function renderContactEmailBanner(): void {
+  const container = document.getElementById('globalBanner');
+  if (!container) return;
+  container.innerHTML = '';
+
+  // The verify-email landing page is a public route; never nag on it.
+  if (globalThis.location.hash.startsWith(`#/${VERIFY_EMAIL}/`)) return;
+
+  const state: any = getLoginState();
+  if (!state) return; // not logged in
+  if (isDismissed()) return;
+
+  const contactEmail: string | undefined = state.contactEmail;
+  const emailVerifiedAt: string | undefined = state.emailVerifiedAt;
+  if (contactEmail && emailVerifiedAt) return; // all good
+
+  // Build the banner
+  const banner = document.createElement('div');
+  banner.style.cssText =
+    'display: flex; align-items: center; justify-content: space-between; gap: 16px; ' +
+    'padding: 10px 16px; background: var(--tmx-status-warning-bg, #fff8e1); ' +
+    'color: var(--tmx-text-primary, #1a1a1a); ' +
+    'border-bottom: 1px solid var(--tmx-status-warning, #b58900); font-size: 0.95rem;';
+
+  const text = document.createElement('span');
+  text.textContent = contactEmail
+    ? t('banners.contactEmail.pending', { email: contactEmail })
+    : t('banners.contactEmail.missing');
+
+  const actions = document.createElement('div');
+  actions.style.cssText = 'display: flex; gap: 8px; align-items: center;';
+
+  const setupBtn = document.createElement('button');
+  setupBtn.className = 'button is-small';
+  setupBtn.style.cssText =
+    'padding: 4px 10px; font-size: 0.85rem; border-radius: 4px; cursor: pointer; ' +
+    'background: var(--tmx-status-success, #0f766e); color: #fff; border: 0; font-weight: 600;';
+  setupBtn.textContent = contactEmail
+    ? t('banners.contactEmail.review')
+    : t('banners.contactEmail.setUp');
+  setupBtn.addEventListener('click', () => contactEmailModal(renderContactEmailBanner));
+
+  const dismissBtn = document.createElement('button');
+  dismissBtn.className = 'button is-small is-light';
+  dismissBtn.style.cssText =
+    'padding: 4px 10px; font-size: 0.85rem; border-radius: 4px; cursor: pointer; ' +
+    'background: transparent; color: var(--tmx-text-primary, #1a1a1a); border: 1px solid var(--tmx-border-primary, #ccc);';
+  dismissBtn.textContent = t('common.dismiss');
+  dismissBtn.addEventListener('click', () => {
+    dismiss();
+    renderContactEmailBanner();
+  });
+
+  actions.append(setupBtn, dismissBtn);
+  banner.append(text, actions);
+  container.appendChild(banner);
+}

--- a/admin-client/src/components/framework/rootBlock.ts
+++ b/admin-client/src/components/framework/rootBlock.ts
@@ -2,13 +2,20 @@
  * Root application block for the admin client.
  * Creates navbar, main content area with page containers.
  */
-import { NONE, TMX_ADMIN, TMX_SYSTEM, TMX_PROVISIONER, TMX_SANCTIONING, TMX_SYNC, TMX_TEMPLATES, TMX_POLICIES, TMX_DRAWER } from 'constants/tmxConstants';
+import { NONE, TMX_ADMIN, TMX_SYSTEM, TMX_PROVISIONER, TMX_SANCTIONING, TMX_SYNC, TMX_TEMPLATES, TMX_POLICIES, TMX_VERIFY_EMAIL, TMX_DRAWER } from 'constants/tmxConstants';
 
 const flexColFlexGrow = 'flexcol flexgrow';
 
 export function rootBlock(): HTMLElement {
   const app = document.getElementById('app')!;
   app.appendChild(createNavbar());
+
+  // Global banner host — sits between the navbar and the page containers.
+  // Populated by services like the contactEmail nag banner on every nav.
+  // Renders nothing when no banner is active.
+  const globalBanner = document.createElement('div');
+  globalBanner.id = 'globalBanner';
+  document.getElementById('navMain')!.parentElement?.insertBefore(globalBanner, document.getElementById('navMain'));
 
   const main = document.getElementById('navMain')!;
 
@@ -60,6 +67,13 @@ export function rootBlock(): HTMLElement {
   policies.style.display = NONE;
   policies.id = TMX_POLICIES;
   main.appendChild(policies);
+
+  // Verify-email landing (public route, opened from the email-verification link)
+  const verifyEmail = document.createElement('div');
+  verifyEmail.className = flexColFlexGrow;
+  verifyEmail.style.display = NONE;
+  verifyEmail.id = TMX_VERIFY_EMAIL;
+  main.appendChild(verifyEmail);
 
   // Drawer
   const drawer = document.createElement('section');

--- a/admin-client/src/components/modals/contactEmail.ts
+++ b/admin-client/src/components/modals/contactEmail.ts
@@ -1,0 +1,151 @@
+/**
+ * Contact email management modal.
+ *
+ * Lets the logged-in user set or change `users.contact_email` and trigger
+ * a verification email. Distinct from `users.email` which is the LOGIN
+ * identifier (often a non-email string for legacy accounts).
+ *
+ * Live state comes from GET /auth/me on open so the user sees the
+ * verified-at timestamp even if their cached JWT is stale.
+ */
+import { validators, renderForm } from 'courthive-components';
+import { setContactEmail, resendVerification, getMe } from 'services/authentication/authApi';
+import { tmxToast } from 'services/notifications/tmxToast';
+import { openModal } from './baseModal/baseModal';
+import { t } from 'i18n';
+
+type ContactEmailState = {
+  contactEmail?: string | null;
+  emailVerifiedAt?: string | null;
+};
+
+export function contactEmailModal(onClose?: () => void): void {
+  let inputs: any;
+  let liveState: ContactEmailState = {};
+
+  const renderStatus = (statusEl: HTMLElement, state: ContactEmailState) => {
+    statusEl.innerHTML = '';
+    const text = document.createElement('div');
+    text.style.cssText = 'font-size: 0.9rem; margin-bottom: 12px;';
+    if (!state.contactEmail) {
+      text.textContent = t('modals.contactEmail.statusNotSet');
+      text.style.color = 'var(--tmx-status-warning, #b58900)';
+    } else if (state.emailVerifiedAt) {
+      text.textContent = t('modals.contactEmail.statusVerified', { email: state.contactEmail });
+      text.style.color = 'var(--tmx-status-success, #2e7d32)';
+    } else {
+      text.textContent = t('modals.contactEmail.statusPending', { email: state.contactEmail });
+      text.style.color = 'var(--tmx-status-warning, #b58900)';
+    }
+    statusEl.appendChild(text);
+  };
+
+  const enableSubmit = ({ inputs }: any) => {
+    const value = inputs?.contactEmail?.value ?? '';
+    const isValid = validators.emailValidator(value);
+    const saveBtn = document.getElementById('contactEmailSave') as HTMLButtonElement | null;
+    if (saveBtn) saveBtn.disabled = !isValid;
+    // Resend button is enabled only when there's a pending (unverified)
+    // address on the LIVE state — typing a new address doesn't enable
+    // resend because that would resend the OLD pending address.
+    const resendBtn = document.getElementById('contactEmailResend') as HTMLButtonElement | null;
+    if (resendBtn) {
+      resendBtn.disabled = !liveState.contactEmail || Boolean(liveState.emailVerifiedAt);
+    }
+  };
+
+  const relationships = [{ onInput: enableSubmit, control: 'contactEmail' }];
+
+  const statusContainer = document.createElement('div');
+  statusContainer.id = 'contactEmailStatus';
+
+  const content = (elem: HTMLElement) => {
+    elem.appendChild(statusContainer);
+    renderStatus(statusContainer, liveState);
+
+    inputs = renderForm(
+      elem,
+      [
+        {
+          iconLeft: 'fa-regular fa-envelope',
+          placeholder: 'you@example.com',
+          validator: validators.emailValidator,
+          autocomplete: 'email',
+          label: t('modals.contactEmail.label'),
+          field: 'contactEmail',
+          id: 'contactEmailInput',
+          value: liveState.contactEmail ?? '',
+        },
+      ],
+      relationships,
+    );
+
+    // Refresh live state in the background. If we get a newer view we
+    // re-render the status block in place. Failures are non-fatal —
+    // the user can still try to save the form.
+    getMe().then(
+      (res: any) => {
+        const data = res?.data ?? {};
+        liveState = { contactEmail: data.contactEmail, emailVerifiedAt: data.emailVerifiedAt };
+        renderStatus(statusContainer, liveState);
+        if (inputs?.contactEmail && !inputs.contactEmail.value) {
+          inputs.contactEmail.value = liveState.contactEmail ?? '';
+        }
+        enableSubmit({ inputs });
+      },
+      () => {
+        /* live refresh failed — keep showing JWT-derived state */
+      },
+    );
+  };
+
+  const onSave = () => {
+    const value = (inputs?.contactEmail?.value ?? '').trim();
+    if (!value) return;
+    setContactEmail(value).then(
+      (res: any) => {
+        if (res?.data?.error) {
+          tmxToast({ message: res.data.error, intent: 'is-danger' });
+          return;
+        }
+        tmxToast({
+          message: t('modals.contactEmail.savedPending', { email: value }),
+          intent: 'is-success',
+        });
+      },
+      (err: any) => {
+        const message = err?.response?.data?.message || err?.message || t('modals.contactEmail.failed');
+        tmxToast({ message, intent: 'is-danger' });
+      },
+    );
+  };
+
+  const onResend = () => {
+    resendVerification().then(
+      (res: any) => {
+        const status = res?.data?.status;
+        if (status === 'already_verified') {
+          tmxToast({ message: t('modals.contactEmail.alreadyVerified'), intent: 'is-success' });
+        } else if (status === 'no_contact_email') {
+          tmxToast({ message: t('modals.contactEmail.statusNotSet'), intent: 'is-warning' });
+        } else {
+          tmxToast({ message: t('modals.contactEmail.resent'), intent: 'is-success' });
+        }
+      },
+      () => {
+        tmxToast({ message: t('modals.contactEmail.failed'), intent: 'is-danger' });
+      },
+    );
+  };
+
+  openModal({
+    title: t('modals.contactEmail.title'),
+    content,
+    onClose,
+    buttons: [
+      { label: t('modals.contactEmail.resend'), id: 'contactEmailResend', disabled: true, onClick: onResend, intent: 'none' },
+      { label: t('common.cancel'), intent: 'none', close: true },
+      { label: t('modals.contactEmail.save'), id: 'contactEmailSave', disabled: true, onClick: onSave, close: true, intent: 'is-primary' },
+    ],
+  });
+}

--- a/admin-client/src/constants/tmxConstants.ts
+++ b/admin-client/src/constants/tmxConstants.ts
@@ -43,6 +43,10 @@ export const POLICIES = 'policies';
 export const TMX_SYNC = 'tmxSync';
 export const SYNC = 'sync';
 
+// Verify email (public landing for email-verification link)
+export const TMX_VERIFY_EMAIL = 'tmxVerifyEmail';
+export const VERIFY_EMAIL = 'verify-email';
+
 // Navigation targets
 export const TOURNAMENT_SETTINGS = 'tournamentSettings';
 export const TMX_TOURNAMENTS = 'tournaments';

--- a/admin-client/src/i18n/locales/en.json
+++ b/admin-client/src/i18n/locales/en.json
@@ -1011,6 +1011,7 @@
     "yes": "Yes",
     "no": "No",
     "confirm": "Confirm",
+    "dismiss": "Dismiss",
     "loading": "Loading...",
     "error": "Error",
     "success": "Success",
@@ -1259,6 +1260,19 @@
       "failed": "Failed to set new password.",
       "tokenExpired": "Your sign-in expired. Please log in again."
     },
+    "contactEmail": {
+      "title": "Contact email",
+      "label": "Email address",
+      "save": "Save",
+      "resend": "Resend verification",
+      "savedPending": "Verification email sent to {{email}}. Check your inbox.",
+      "resent": "Verification email re-sent.",
+      "alreadyVerified": "Your contact email is already verified.",
+      "failed": "Could not save contact email.",
+      "statusNotSet": "No contact email is set yet. Set one so you can recover your password by email.",
+      "statusPending": "Pending verification: {{email}}. Click the link in your inbox.",
+      "statusVerified": "Verified: {{email}}"
+    },
     "editUser": {
       "providers": "Providers",
       "noProviders": "This user has no provider associations.",
@@ -1491,6 +1505,29 @@
         "FEED_IN": "Staggered entry draw where participants enter the bracket at different rounds."
       }
     }
+  },
+
+  "banners": {
+    "contactEmail": {
+      "missing": "Set up a contact email so you can recover your password by email.",
+      "pending": "Verify {{email}} so you can recover your password by email.",
+      "setUp": "Set up email",
+      "review": "Review"
+    }
+  },
+
+  "verifyEmail": {
+    "title": "Verify your email",
+    "intro": "Click the button below to confirm that this email is yours.",
+    "verifyButton": "Verify email",
+    "verifying": "Verifying…",
+    "success": "Verified ✓ — you can now receive password-recovery email at {{email}}. You may close this tab.",
+    "successPlain": "Verified ✓. You may close this tab.",
+    "missingToken": "This verification link is missing its token. Try clicking the link in your email again, or request a fresh one from the contact-email settings.",
+    "tokenExpired": "This verification link has expired. Request a fresh one from your contact-email settings.",
+    "tokenMismatch": "This link no longer matches your current contact email — it was probably superseded by a more recent change.",
+    "tryAgain": "Try again",
+    "failed": "Verification failed. Try requesting a fresh link."
   },
 
   "toasts": {

--- a/admin-client/src/pages/verifyEmail/renderVerifyEmail.ts
+++ b/admin-client/src/pages/verifyEmail/renderVerifyEmail.ts
@@ -1,0 +1,85 @@
+/**
+ * Public verify-email page.
+ *
+ * Rendered when the user clicks the link in the verification email,
+ * which lands at `/admin/#/verify-email/<token>`. Shows a "Verify" button
+ * that POSTs to /auth/verify-email so a link-previewer (Slack, Discord,
+ * spam scanner) can't consume the single-use token by GET-fetching the
+ * URL.
+ *
+ * No authentication required — the token IS the auth.
+ */
+import { showTMXverifyEmail } from 'services/transitions/screenSlaver';
+import { verifyEmail } from 'services/authentication/authApi';
+import { TMX_VERIFY_EMAIL } from 'constants/tmxConstants';
+import { t } from 'i18n';
+
+export function renderVerifyEmail(token: string): void {
+  showTMXverifyEmail();
+  const container = document.getElementById(TMX_VERIFY_EMAIL);
+  if (!container) return;
+  container.innerHTML = '';
+
+  const card = document.createElement('div');
+  card.style.cssText =
+    'margin: 64px auto; max-width: 480px; background: var(--tmx-bg-elevated, #fff); ' +
+    'padding: 32px; border-radius: 8px; box-shadow: 0 1px 3px rgba(0,0,0,0.08); ' +
+    'text-align: center; color: var(--tmx-text-primary, #1a1a1a);';
+
+  const heading = document.createElement('h2');
+  heading.textContent = t('verifyEmail.title');
+  heading.style.cssText = 'margin: 0 0 16px 0; font-size: 22px; font-weight: 600;';
+
+  const body = document.createElement('p');
+  body.style.cssText = 'margin: 0 0 24px 0; font-size: 15px; line-height: 1.55;';
+
+  const statusEl = document.createElement('div');
+  statusEl.style.cssText = 'margin-top: 16px; font-size: 14px;';
+
+  const button = document.createElement('button');
+  button.className = 'button is-primary';
+  button.textContent = t('verifyEmail.verifyButton');
+  button.style.cssText =
+    'padding: 10px 20px; font-size: 15px; border-radius: 6px; cursor: pointer; ' +
+    'background: var(--tmx-status-success, #0f766e); color: #fff; border: 0; font-weight: 600;';
+
+  if (!token) {
+    body.textContent = t('verifyEmail.missingToken');
+    card.append(heading, body);
+    container.appendChild(card);
+    return;
+  }
+
+  body.textContent = t('verifyEmail.intro');
+
+  button.addEventListener('click', () => {
+    button.disabled = true;
+    button.textContent = t('verifyEmail.verifying');
+    verifyEmail(token).then(
+      (res: any) => {
+        const email = res?.data?.contactEmail ?? '';
+        statusEl.style.color = 'var(--tmx-status-success, #2e7d32)';
+        statusEl.textContent = email
+          ? t('verifyEmail.success', { email })
+          : t('verifyEmail.successPlain');
+        button.style.display = 'none';
+      },
+      (err: any) => {
+        button.disabled = false;
+        button.textContent = t('verifyEmail.tryAgain');
+        statusEl.style.color = 'var(--tmx-status-error, #c62828)';
+        const status = err?.response?.status;
+        if (status === 401) {
+          statusEl.textContent = t('verifyEmail.tokenExpired');
+        } else if (status === 403) {
+          statusEl.textContent = t('verifyEmail.tokenMismatch');
+        } else {
+          statusEl.textContent = err?.response?.data?.message || t('verifyEmail.failed');
+        }
+      },
+    );
+  });
+
+  card.append(heading, body, button, statusEl);
+  container.appendChild(card);
+}

--- a/admin-client/src/router/router.ts
+++ b/admin-client/src/router/router.ts
@@ -2,6 +2,8 @@ import { renderSanctioningDashboard } from 'pages/sanctioning/renderSanctioningD
 import { renderSanctioningWizard } from 'pages/sanctioning/renderSanctioningWizard';
 import { renderSanctioningDetail } from 'pages/sanctioning/renderSanctioningDetail';
 import { renderProvisionerPage } from 'pages/provisioner/renderProvisionerPage';
+import { renderContactEmailBanner } from 'components/banners/contactEmailBanner';
+import { renderVerifyEmail } from 'pages/verifyEmail/renderVerifyEmail';
 import { renderSystemPage } from 'pages/system/renderSystemPage';
 import { renderAdminPage } from 'pages/admin/renderAdminPage';
 import { renderSyncPage } from 'pages/sync/renderSyncPage';
@@ -12,7 +14,7 @@ import { updateNavVisibility } from 'services/navigation/navVisibility';
 import { context } from 'services/context';
 import Navigo from 'navigo';
 
-import { SUPER_ADMIN, PROVISIONER, SYSTEM, PROVISIONER_ROUTE, SANCTIONING, SYNC, TEMPLATES, POLICIES } from 'constants/tmxConstants';
+import { SUPER_ADMIN, PROVISIONER, SYSTEM, PROVISIONER_ROUTE, SANCTIONING, SYNC, TEMPLATES, POLICIES, VERIFY_EMAIL } from 'constants/tmxConstants';
 
 export function routeAdmin(): void {
   const router = new Navigo('/', { hash: true });
@@ -37,6 +39,7 @@ export function routeAdmin(): void {
   router.hooks({
     before(done) {
       updateNavVisibility();
+      renderContactEmailBanner();
       done();
     },
   });
@@ -119,6 +122,14 @@ export function routeAdmin(): void {
       return;
     }
     renderSyncPage();
+  });
+
+  // Public route: email-verification link lands here with the token in the
+  // path. No auth check — the token IS the auth, and IdentityService verifies
+  // it on the server. The page renders a "Verify" button so a link-previewer
+  // can't accidentally consume the single-use token by GET-fetching the URL.
+  router.on(`/${VERIFY_EMAIL}/:token`, (match) => {
+    renderVerifyEmail(match?.data?.token ?? '');
   });
 
   router.on('/', () => {

--- a/admin-client/src/services/authentication/authApi.ts
+++ b/admin-client/src/services/authentication/authApi.ts
@@ -26,6 +26,22 @@ export async function completeFirstLogin(limitedToken: string, newPassword: stri
   return baseApi.post('/auth/complete-first-login', { limitedToken, newPassword });
 }
 
+export async function setContactEmail(contactEmail: string) {
+  return baseApi.post('/account/contact-email/set', { contactEmail });
+}
+
+export async function resendVerification() {
+  return baseApi.post('/account/contact-email/resend-verification', {});
+}
+
+export async function verifyEmail(token: string) {
+  return baseApi.post('/auth/verify-email', { token });
+}
+
+export async function getMe() {
+  return baseApi.get('/auth/me');
+}
+
 export async function confirmEmail(emailConfirmationId) {
   return baseApi.get(`/auth/confirm/${emailConfirmationId}`);
 }

--- a/admin-client/src/services/authentication/loginState.ts
+++ b/admin-client/src/services/authentication/loginState.ts
@@ -34,6 +34,12 @@ export function logIn({ data, callback }: { data: { token: string }; callback?: 
     tmxToast({ message: t('toasts.loggedIn'), intent: 'is-success' });
     styleLogin(state);
 
+    // Show the contact-email nag banner immediately on login (the router's
+    // before-hook handles the post-login navigation, so without this the
+    // banner would only appear after the next manual navigation).
+    // Dynamic import to keep the static graph acyclic.
+    import('components/banners/contactEmailBanner').then((m) => m.renderContactEmailBanner());
+
     if (callback) {
       callback();
     } else {

--- a/admin-client/src/services/transitions/screenSlaver.ts
+++ b/admin-client/src/services/transitions/screenSlaver.ts
@@ -2,11 +2,11 @@
  * Screen state management for admin app content areas.
  * Controls visibility of the admin and system page containers.
  */
-import { TMX_ADMIN, TMX_SYSTEM, TMX_PROVISIONER, TMX_SANCTIONING, TMX_SYNC, TMX_TEMPLATES, TMX_POLICIES } from 'constants/tmxConstants';
+import { TMX_ADMIN, TMX_SYSTEM, TMX_PROVISIONER, TMX_SANCTIONING, TMX_SYNC, TMX_TEMPLATES, TMX_POLICIES, TMX_VERIFY_EMAIL } from 'constants/tmxConstants';
 
 let content: string | undefined;
 
-const PAGE_IDS = [TMX_SYSTEM, TMX_ADMIN, TMX_PROVISIONER, TMX_SANCTIONING, TMX_SYNC, TMX_TEMPLATES, TMX_POLICIES];
+const PAGE_IDS = [TMX_SYSTEM, TMX_ADMIN, TMX_PROVISIONER, TMX_SANCTIONING, TMX_SYNC, TMX_TEMPLATES, TMX_POLICIES, TMX_VERIFY_EMAIL];
 
 function selectDisplay(which: string): void {
   for (const id of PAGE_IDS) {
@@ -95,5 +95,12 @@ export const showTMXpolicies = (): void => {
   const titleEl = document.getElementById('pageTitle');
   if (titleEl) titleEl.textContent = 'Policies';
   content = TMX_POLICIES;
+  selectDisplay(content);
+};
+
+export const showTMXverifyEmail = (): void => {
+  const titleEl = document.getElementById('pageTitle');
+  if (titleEl) titleEl.textContent = 'Verify Email';
+  content = TMX_VERIFY_EMAIL;
   selectDisplay(content);
 };

--- a/admin-client/src/types/tmx.ts
+++ b/admin-client/src/types/tmx.ts
@@ -20,6 +20,10 @@ export interface LoginState {
   provider?: ProviderValue;
   providerId?: string;
   providerIds?: string[];
+  /** Verified contact email (B2). Distinct from `email` (login id). */
+  contactEmail?: string | null;
+  /** ISO timestamp when contactEmail was verified; null until the user clicks the link. */
+  emailVerifiedAt?: string | null;
   exp: number;
 }
 

--- a/src/config/app/config.ts
+++ b/src/config/app/config.ts
@@ -7,4 +7,9 @@ export const APPConfig = registerAs(ConfigKey.App, () => ({
   storage: String(process.env.APP_STORAGE),
   mode: String(process.env.APP_MODE),
   name: String(process.env.APP_NAME),
+  // Public-facing base URL used by IdentityService to build email
+  // verification + (future) password-reset links. Example values:
+  //   prod:   https://nest.courthive.com
+  //   dev:    http://localhost:8383   (or whatever NGINX exposes)
+  baseUrl: process.env.APP_BASE_URL || '',
 }));

--- a/src/modules/account/account.module.ts
+++ b/src/modules/account/account.module.ts
@@ -12,12 +12,13 @@
  * infrastructure that both processes need) are documented in the
  * boundary planning doc.
  */
+import { IdentityModule } from './identity/identity.module';
 import { EmailModule } from './email/email.module';
 import { AuthModule } from './auth/auth.module';
 import { Module } from '@nestjs/common';
 
 @Module({
-  imports: [AuthModule, EmailModule],
-  exports: [AuthModule, EmailModule],
+  imports: [AuthModule, EmailModule, IdentityModule],
+  exports: [AuthModule, EmailModule, IdentityModule],
 })
 export class AccountModule {}

--- a/src/modules/account/auth/decorators/user-context.decorator.ts
+++ b/src/modules/account/auth/decorators/user-context.decorator.ts
@@ -38,6 +38,20 @@ export interface UserContext {
    * — all consumers treat absent-or-empty as "no provisioner access".
    */
   provisionerProviderIds?: string[];
+  /**
+   * Verified contact email — RFC 5322-shaped, distinct from `email`
+   * (the login identifier). Set via POST /account/contact-email/set,
+   * confirmed via the verification link. Used as the destination for
+   * password recovery and notifications. Optional so existing UserContext
+   * fixtures stay valid.
+   */
+  contactEmail?: string | null;
+  /**
+   * ISO timestamp when `contactEmail` was confirmed via the verification
+   * link. Null until verified. The admin client nags users whose
+   * contactEmail is missing or unverified.
+   */
+  emailVerifiedAt?: string | null;
 }
 
 /**

--- a/src/modules/account/auth/helpers/buildUserContext.ts
+++ b/src/modules/account/auth/helpers/buildUserContext.ts
@@ -102,5 +102,9 @@ export async function buildUserContext(
     providerRoles,
     providerIds: Object.keys(providerRoles),
     provisionerProviderIds,
+    contactEmail: user.contactEmail ?? null,
+    emailVerifiedAt: user.emailVerifiedAt
+      ? new Date(user.emailVerifiedAt).toISOString()
+      : null,
   };
 }

--- a/src/modules/account/email/adapters/resend.adapter.ts
+++ b/src/modules/account/email/adapters/resend.adapter.ts
@@ -40,7 +40,7 @@ export class ResendAdapter implements EmailAdapter {
     try {
       // eslint-disable-next-line @typescript-eslint/no-require-imports
       ResendCtor = require('resend').Resend;
-    } catch (err) {
+    } catch {
       throw new Error(
         "Resend SDK is not installed. Run `pnpm install` in competition-factory-server " +
         "to pick up the new `resend` dependency, then restart the server.",

--- a/src/modules/account/identity/dto/setContactEmail.dto.ts
+++ b/src/modules/account/identity/dto/setContactEmail.dto.ts
@@ -1,0 +1,6 @@
+import { ApiProperty } from '@nestjs/swagger';
+
+export class SetContactEmailDto {
+  @ApiProperty({ description: 'Verified mailbox to send password-recovery and account notices to.' })
+  contactEmail: string = '';
+}

--- a/src/modules/account/identity/identity.controller.ts
+++ b/src/modules/account/identity/identity.controller.ts
@@ -1,0 +1,65 @@
+import { Body, Controller, HttpCode, HttpStatus, Post } from '@nestjs/common';
+
+import { UserCtx, type UserContext } from '../auth/decorators/user-context.decorator';
+import { SetContactEmailDto } from './dto/setContactEmail.dto';
+import { CLIENT, SUPER_ADMIN } from 'src/common/constants/roles';
+import { Public } from '../auth/decorators/public.decorator';
+import { Roles } from '../auth/decorators/roles.decorator';
+import { User } from '../auth/decorators/user.decorator';
+import { IdentityService } from './identity.service';
+
+@Controller()
+export class IdentityController {
+  constructor(private readonly identityService: IdentityService) {}
+
+  /**
+   * Set or change the caller's `contact_email`. Always clears
+   * `email_verified_at` (the storage layer enforces this) and fires a
+   * fresh verification email.
+   */
+  @Post('account/contact-email/set')
+  @Roles([CLIENT, SUPER_ADMIN])
+  @HttpCode(HttpStatus.OK)
+  setContactEmail(
+    @Body() body: SetContactEmailDto,
+    @User() user?: any,
+    @UserCtx() userContext?: UserContext,
+  ) {
+    if (!userContext?.userId) return { error: 'Authentication required' };
+    return this.identityService.setContactEmail(
+      { userId: userContext.userId, firstName: user?.firstName },
+      body?.contactEmail ?? '',
+    );
+  }
+
+  /**
+   * Re-send the verification email if the caller has a pending
+   * (unverified) contact_email. Idempotent — no-op when already verified
+   * or when no contact_email is set.
+   */
+  @Post('account/contact-email/resend-verification')
+  @Roles([CLIENT, SUPER_ADMIN])
+  @HttpCode(HttpStatus.OK)
+  resendVerification(@User() user?: any, @UserCtx() userContext?: UserContext) {
+    if (!userContext?.userId || !userContext.email) {
+      return { error: 'Authentication required' };
+    }
+    return this.identityService.resendVerification({
+      userId: userContext.userId,
+      email: userContext.email,
+      firstName: user?.firstName,
+    });
+  }
+
+  /**
+   * Public endpoint — the verification link's `Verify` button POSTs
+   * here with the limited token from the URL. The token itself is the
+   * auth; nothing else is needed.
+   */
+  @Public()
+  @Post('auth/verify-email')
+  @HttpCode(HttpStatus.OK)
+  verifyEmail(@Body() body: { token: string }) {
+    return this.identityService.verifyEmailToken(body?.token);
+  }
+}

--- a/src/modules/account/identity/identity.module.ts
+++ b/src/modules/account/identity/identity.module.ts
@@ -1,0 +1,13 @@
+import { IdentityController } from './identity.controller';
+import { IdentityService } from './identity.service';
+import { EmailModule } from '../email/email.module';
+import { ConfigsModule } from 'src/config/config.module';
+import { Module } from '@nestjs/common';
+
+@Module({
+  imports: [ConfigsModule, EmailModule],
+  providers: [IdentityService],
+  controllers: [IdentityController],
+  exports: [IdentityService],
+})
+export class IdentityModule {}

--- a/src/modules/account/identity/identity.service.spec.ts
+++ b/src/modules/account/identity/identity.service.spec.ts
@@ -1,0 +1,178 @@
+import { ForbiddenException, UnauthorizedException } from '@nestjs/common';
+import { JwtService } from '@nestjs/jwt';
+
+import { IdentityService } from './identity.service';
+
+describe('IdentityService', () => {
+  let identityService: IdentityService;
+  let jwtService: JwtService;
+  let mockUserStorage: any;
+  let mockEmailService: any;
+  let mockConfigService: any;
+
+  beforeEach(() => {
+    jwtService = new JwtService({ secret: 'test-secret' });
+
+    mockUserStorage = {
+      findOne: jest.fn(),
+      findByContactEmail: jest.fn(),
+      setContactEmail: jest.fn().mockResolvedValue({ success: true }),
+      markEmailVerified: jest.fn().mockResolvedValue({ success: true }),
+    };
+    mockEmailService = {
+      sendTemplated: jest.fn().mockResolvedValue({ id: 'msg-123' }),
+    };
+    mockConfigService = {
+      get: jest.fn().mockReturnValue({ baseUrl: 'https://nest.test.example' }),
+    };
+
+    identityService = new IdentityService(
+      jwtService,
+      mockEmailService,
+      mockConfigService,
+      mockUserStorage,
+    );
+  });
+
+  describe('setContactEmail', () => {
+    it('rejects an empty address', async () => {
+      const result: any = await identityService.setContactEmail({ userId: 'u-1' }, '');
+      expect(result.error).toContain('required');
+    });
+
+    it('rejects a non-RFC-shaped string', async () => {
+      const result: any = await identityService.setContactEmail({ userId: 'u-1' }, 'not-an-email');
+      expect(result.error).toContain('valid email');
+    });
+
+    it('writes the address (unverified), sends mail, returns pending status', async () => {
+      const result: any = await identityService.setContactEmail(
+        { userId: 'u-1', firstName: 'Alice' },
+        '  Alice@Example.COM  ',
+      );
+
+      expect(result.success).toBe(true);
+      expect(result.status).toBe('pending_verification');
+      expect(result.contactEmail).toBe('Alice@Example.COM');
+      expect(mockUserStorage.setContactEmail).toHaveBeenCalledWith('u-1', 'Alice@Example.COM');
+      expect(mockEmailService.sendTemplated).toHaveBeenCalledWith(
+        expect.objectContaining({
+          to: 'Alice@Example.COM',
+          template: 'email-verification',
+          tag: 'email-verification',
+          data: expect.objectContaining({ firstName: 'Alice', email: 'Alice@Example.COM' }),
+        }),
+      );
+      // The verify URL embeds the configured base URL.
+      const sendCall = (mockEmailService.sendTemplated as jest.Mock).mock.calls[0][0];
+      expect(sendCall.data.verifyUrl).toMatch(/^https:\/\/nest\.test\.example\/admin\/#\/verify-email\//);
+    });
+
+    it('throws when APP_BASE_URL is not configured', async () => {
+      mockConfigService.get.mockReturnValue({});
+      const previous = process.env.APP_BASE_URL;
+      delete process.env.APP_BASE_URL;
+      try {
+        await expect(
+          identityService.setContactEmail({ userId: 'u-1' }, 'alice@example.com'),
+        ).rejects.toThrow(/APP_BASE_URL/);
+      } finally {
+        if (previous !== undefined) process.env.APP_BASE_URL = previous;
+      }
+    });
+  });
+
+  describe('resendVerification', () => {
+    it('is a no-op when the user has no contact_email yet', async () => {
+      mockUserStorage.findOne.mockResolvedValue({ contactEmail: null });
+      const result: any = await identityService.resendVerification({
+        userId: 'u-1',
+        email: 'u-1@login',
+      });
+      expect(result.status).toBe('no_contact_email');
+      expect(mockEmailService.sendTemplated).not.toHaveBeenCalled();
+    });
+
+    it('is a no-op when contact_email is already verified', async () => {
+      mockUserStorage.findOne.mockResolvedValue({
+        contactEmail: 'alice@example.com',
+        emailVerifiedAt: '2026-05-22T10:00:00Z',
+      });
+      const result: any = await identityService.resendVerification({
+        userId: 'u-1',
+        email: 'u-1@login',
+      });
+      expect(result.status).toBe('already_verified');
+      expect(mockEmailService.sendTemplated).not.toHaveBeenCalled();
+    });
+
+    it('sends a fresh verification mail when contact_email is pending', async () => {
+      mockUserStorage.findOne.mockResolvedValue({
+        contactEmail: 'alice@example.com',
+        emailVerifiedAt: null,
+        firstName: 'Alice',
+      });
+      const result: any = await identityService.resendVerification({
+        userId: 'u-1',
+        email: 'u-1@login',
+        firstName: 'Alice',
+      });
+      expect(result.status).toBe('pending_verification');
+      expect(mockEmailService.sendTemplated).toHaveBeenCalledWith(
+        expect.objectContaining({ to: 'alice@example.com', tag: 'email-verification' }),
+      );
+    });
+  });
+
+  describe('verifyEmailToken', () => {
+    it('rejects a missing token', async () => {
+      await expect(identityService.verifyEmailToken('')).rejects.toThrow(UnauthorizedException);
+    });
+
+    it('rejects a malformed token', async () => {
+      await expect(identityService.verifyEmailToken('not-a-jwt')).rejects.toThrow(
+        UnauthorizedException,
+      );
+    });
+
+    it('rejects a token without the verification purpose', async () => {
+      const wrong = await jwtService.signAsync(
+        { userId: 'u-1', contactEmail: 'alice@example.com', purpose: 'something-else' },
+        { expiresIn: '5m' },
+      );
+      await expect(identityService.verifyEmailToken(wrong)).rejects.toThrow(UnauthorizedException);
+    });
+
+    it('rejects when the contact_email has changed since the token was issued', async () => {
+      const token = await jwtService.signAsync(
+        { userId: 'u-1', contactEmail: 'alice@example.com', purpose: 'email-verification' },
+        { expiresIn: '5m' },
+      );
+      mockUserStorage.findOne.mockResolvedValue(null);
+      mockUserStorage.findByContactEmail.mockResolvedValue({
+        userId: 'u-1',
+        contactEmail: 'bob@example.com', // user changed it after the token was issued
+      });
+      await expect(identityService.verifyEmailToken(token)).rejects.toThrow(ForbiddenException);
+      expect(mockUserStorage.markEmailVerified).not.toHaveBeenCalled();
+    });
+
+    it('marks the email verified on a valid matching token', async () => {
+      const token = await jwtService.signAsync(
+        { userId: 'u-1', contactEmail: 'alice@example.com', purpose: 'email-verification' },
+        { expiresIn: '5m' },
+      );
+      mockUserStorage.findOne.mockResolvedValue(null);
+      mockUserStorage.findByContactEmail.mockResolvedValue({
+        userId: 'u-1',
+        contactEmail: 'alice@example.com',
+      });
+
+      const result: any = await identityService.verifyEmailToken(token);
+
+      expect(result.success).toBe(true);
+      expect(result.contactEmail).toBe('alice@example.com');
+      expect(mockUserStorage.markEmailVerified).toHaveBeenCalledWith('u-1');
+    });
+  });
+});

--- a/src/modules/account/identity/identity.service.ts
+++ b/src/modules/account/identity/identity.service.ts
@@ -1,0 +1,161 @@
+/**
+ * IdentityService — owns the separation between `users.email` (the LOGIN
+ * identifier, historically often a non-email string) and
+ * `users.contact_email` (the verified mailbox we send password recovery
+ * + account notices to).
+ *
+ * Three operations:
+ *
+ *   - setContactEmail(userId, address) — validates RFC, stamps the new
+ *     address, clears `email_verified_at`, fires a verification email
+ *     with a short-lived signed token (purpose: 'email-verification').
+ *
+ *   - resendVerification(userId) — re-sends the verification email if
+ *     the user has a contact_email pending. No-op if already verified.
+ *
+ *   - verifyEmailToken(token, newPassword?) — accepts the token from
+ *     the link, marks the row verified.
+ *
+ * The token is a short-lived JWT carrying `purpose:
+ * 'email-verification'`; the auth.middleware rejects tokens carrying a
+ * `purpose` claim at normal endpoints so this token can't be used to
+ * authenticate anything else.
+ */
+import { ForbiddenException, Inject, Injectable, Logger, UnauthorizedException } from '@nestjs/common';
+import { JwtService } from '@nestjs/jwt';
+import { ConfigService } from '@nestjs/config';
+
+import { USER_STORAGE, type IUserStorage } from 'src/storage/interfaces';
+import { EmailService } from '../email/email.service';
+
+const VERIFICATION_TOKEN_TTL = '24h';
+const VERIFICATION_TOKEN_TTL_MINUTES = 24 * 60;
+const EMAIL_VERIFICATION_PURPOSE = 'email-verification';
+
+// Conservative RFC-shaped check — same regex as the migration backfill.
+// Strict enough to reject obvious garbage (no `@`, `user@@host`, etc.)
+// without trying to be a full RFC 5322 parser. The verification email
+// itself is the real test of deliverability.
+const EMAIL_REGEX = /^[A-Z0-9._%+-]+@[A-Z0-9.-]+\.[A-Z]{2,}$/i;
+
+@Injectable()
+export class IdentityService {
+  private readonly logger = new Logger(IdentityService.name);
+
+  constructor(
+    private readonly jwtService: JwtService,
+    private readonly emailService: EmailService,
+    private readonly configService: ConfigService,
+    @Inject(USER_STORAGE) private readonly userStorage: IUserStorage,
+  ) {}
+
+  /**
+   * Build the verification URL placed in the email body. Lands on the
+   * admin-client public route which extracts the token, shows a Verify
+   * button, and POSTs to /auth/verify-email. We deliberately avoid a
+   * raw GET so link-previewers (Slack, Discord, anti-spam scanners)
+   * don't accidentally consume the single-use token.
+   */
+  private buildVerifyUrl(token: string): string {
+    const appConfig: any = this.configService.get('app');
+    const base = String(appConfig?.baseUrl ?? process.env.APP_BASE_URL ?? '').replace(/\/+$/, '');
+    if (!base) {
+      throw new Error('APP_BASE_URL is not set; cannot generate verification link.');
+    }
+    return `${base}/admin/#/verify-email/${token}`;
+  }
+
+  async setContactEmail(
+    user: { userId: string; firstName?: string },
+    contactEmail: string,
+  ): Promise<{ success: true; status: 'pending_verification'; contactEmail: string } | { error: string }> {
+    const trimmed = (contactEmail ?? '').trim();
+    if (!trimmed) return { error: 'contactEmail is required' };
+    if (!EMAIL_REGEX.test(trimmed)) return { error: 'Not a valid email address' };
+    if (!user?.userId) return { error: 'Authentication required' };
+
+    await this.userStorage.setContactEmail(user.userId, trimmed);
+
+    const token = await this.jwtService.signAsync(
+      { userId: user.userId, contactEmail: trimmed, purpose: EMAIL_VERIFICATION_PURPOSE },
+      { expiresIn: VERIFICATION_TOKEN_TTL },
+    );
+
+    await this.emailService.sendTemplated({
+      to: trimmed,
+      subject: 'Verify your email — CourtHive',
+      template: 'email-verification',
+      data: {
+        firstName: user.firstName ?? '',
+        email: trimmed,
+        verifyUrl: this.buildVerifyUrl(token),
+        expiresInMinutes: VERIFICATION_TOKEN_TTL_MINUTES,
+      },
+      tag: 'email-verification',
+    });
+
+    this.logger.log(`Sent verification mail to ${trimmed} for user ${user.userId}`);
+    return { success: true, status: 'pending_verification', contactEmail: trimmed };
+  }
+
+  async resendVerification(
+    user: { userId: string; firstName?: string; email: string },
+  ): Promise<{ success: true; status: 'pending_verification' | 'already_verified' | 'no_contact_email' }> {
+    if (!user?.userId) throw new UnauthorizedException();
+    const record = await this.userStorage.findOne(user.email);
+    if (!record?.contactEmail) return { success: true, status: 'no_contact_email' };
+    if (record.emailVerifiedAt) return { success: true, status: 'already_verified' };
+
+    const token = await this.jwtService.signAsync(
+      { userId: user.userId, contactEmail: record.contactEmail, purpose: EMAIL_VERIFICATION_PURPOSE },
+      { expiresIn: VERIFICATION_TOKEN_TTL },
+    );
+
+    await this.emailService.sendTemplated({
+      to: record.contactEmail,
+      subject: 'Verify your email — CourtHive',
+      template: 'email-verification',
+      data: {
+        firstName: user.firstName ?? record.firstName ?? '',
+        email: record.contactEmail,
+        verifyUrl: this.buildVerifyUrl(token),
+        expiresInMinutes: VERIFICATION_TOKEN_TTL_MINUTES,
+      },
+      tag: 'email-verification',
+    });
+
+    this.logger.log(`Re-sent verification mail to ${record.contactEmail} for user ${user.userId}`);
+    return { success: true, status: 'pending_verification' };
+  }
+
+  async verifyEmailToken(token: string): Promise<{ success: true; contactEmail: string }> {
+    if (!token) throw new UnauthorizedException('Missing token');
+    let claims: any;
+    try {
+      claims = await this.jwtService.verifyAsync(token);
+    } catch {
+      throw new UnauthorizedException('Invalid or expired verification token');
+    }
+    if (claims?.purpose !== EMAIL_VERIFICATION_PURPOSE || !claims?.userId || !claims?.contactEmail) {
+      throw new UnauthorizedException('Token is not a verification token');
+    }
+
+    // Defensive: confirm the contact_email on the user record still matches
+    // the one in the token. If the user changed their contact_email after
+    // the token was issued, this stale token must not verify the new
+    // address — re-verification has to start over.
+    const record = await this.userStorage.findOne(claims?.email ?? '');  // best-effort by email
+    // Most common path: look up by contact_email which is unique-ish.
+    const byContact = record ?? (await this.userStorage.findByContactEmail(claims.contactEmail));
+    if (!byContact || byContact.userId !== claims.userId) {
+      throw new ForbiddenException('Verification token does not match the current contact address');
+    }
+    if (byContact.contactEmail?.toLowerCase() !== String(claims.contactEmail).toLowerCase()) {
+      throw new ForbiddenException('Contact email has changed since this link was issued');
+    }
+
+    await this.userStorage.markEmailVerified(claims.userId);
+    this.logger.log(`Verified contact email ${claims.contactEmail} for user ${claims.userId}`);
+    return { success: true, contactEmail: claims.contactEmail };
+  }
+}

--- a/src/storage/interfaces/user-storage.interface.ts
+++ b/src/storage/interfaces/user-storage.interface.ts
@@ -21,4 +21,23 @@ export interface IUserStorage {
    * field updates on the same row.
    */
   completeFirstLogin(email: string, hashedPassword: string): Promise<{ success: boolean }>;
+  /**
+   * Case-insensitive lookup by contact_email — used by the eventual
+   * forgot-password flow (B3) to find a user from the contact address
+   * they typed. Returns the same shape as `findOne`.
+   */
+  findByContactEmail(contactEmail: string): Promise<any | null>;
+  /**
+   * Write a new contact email and CLEAR `email_verified_at` atomically.
+   * Re-verification is required after any change — otherwise a session
+   * holder could swap to an address they don't control and inherit
+   * the previous verified-state.
+   */
+  setContactEmail(userId: string, contactEmail: string): Promise<{ success: boolean }>;
+  /**
+   * Stamp `email_verified_at = NOW()` after the user clicks the link in
+   * the verification email. The verify endpoint calls this on
+   * successful token validation.
+   */
+  markEmailVerified(userId: string): Promise<{ success: boolean }>;
 }

--- a/src/storage/postgres/migrations/028-add-contact-email.sql
+++ b/src/storage/postgres/migrations/028-add-contact-email.sql
@@ -1,0 +1,39 @@
+-- AFFECTS: end-users
+-- Splits the long-overdue separation between users.email (the LOGIN
+-- identifier — historically often a non-email string like "alice" or
+-- "pro-shop-1") and users.contact_email (the verified RFC 5322 address
+-- mail is sent to). Password reset, account notifications, and any
+-- future user-facing email flow targets contact_email — never email.
+--
+-- Backfill is conservative: copy `email` → `contact_email` only when
+-- the login string is unambiguously email-shaped. Everyone else gets
+-- NULL and is nagged into setting one via the admin-client banner.
+-- `email_verified_at` stays NULL for all rows, including the backfilled
+-- ones — users still need to click the verification link before the
+-- address is trusted for outbound mail.
+
+ALTER TABLE users
+  ADD COLUMN IF NOT EXISTS contact_email     TEXT,
+  ADD COLUMN IF NOT EXISTS email_verified_at TIMESTAMPTZ;
+
+-- Functional unique-ish index for case-insensitive lookups (the verify
+-- flow + the eventual forgot-password flow both look up by lower-cased
+-- contact_email). Not UNIQUE because two users can legitimately share a
+-- contact email (a family / shared mailbox) — the constraint that
+-- matters at sign-in is users.email uniqueness, not contact_email.
+CREATE INDEX IF NOT EXISTS idx_users_contact_email_lower
+  ON users (LOWER(contact_email))
+  WHERE contact_email IS NOT NULL;
+
+-- Conservative backfill: only seed contact_email where the login email
+-- is RFC-shaped. Local-part: word chars + . _ % + -. Domain: at least
+-- one dot, TLD ≥ 2 letters. Case-insensitive (~*). Skips:
+--   - non-email logins ('alice', 'pro-shop-1')
+--   - malformed locals ('user@@example.com', 'user@')
+--   - single-label hosts ('user@localhost')
+-- Users matching this regex still need to verify; we just give them a
+-- one-click pre-fill in the settings UI.
+UPDATE users
+   SET contact_email = email
+ WHERE contact_email IS NULL
+   AND email ~* '^[A-Z0-9._%+-]+@[A-Z0-9.-]+\.[A-Z]{2,}$';

--- a/src/storage/postgres/postgres-user.storage.ts
+++ b/src/storage/postgres/postgres-user.storage.ts
@@ -11,7 +11,7 @@ export class PostgresUserStorage implements IUserStorage {
 
   async findOne(email: string): Promise<any | null> {
     const result = await this.pool.query(
-      'SELECT user_id, email, password, provider_id, last_selected_provider_id, must_change_password, roles, permissions, data FROM users WHERE email = $1',
+      'SELECT user_id, email, password, provider_id, last_selected_provider_id, must_change_password, contact_email, email_verified_at, roles, permissions, data FROM users WHERE email = $1',
       [email],
     );
     if (!result.rows.length) return null;
@@ -23,6 +23,33 @@ export class PostgresUserStorage implements IUserStorage {
       providerId: row.provider_id,
       lastSelectedProviderId: row.last_selected_provider_id,
       mustChangePassword: row.must_change_password,
+      contactEmail: row.contact_email,
+      emailVerifiedAt: row.email_verified_at,
+      roles: row.roles,
+      permissions: row.permissions,
+      ...row.data,
+    };
+  }
+
+  async findByContactEmail(contactEmail: string): Promise<any | null> {
+    const result = await this.pool.query(
+      `SELECT user_id, email, password, provider_id, last_selected_provider_id, must_change_password, contact_email, email_verified_at, roles, permissions, data
+         FROM users
+        WHERE LOWER(contact_email) = LOWER($1)
+        LIMIT 1`,
+      [contactEmail],
+    );
+    if (!result.rows.length) return null;
+    const row = result.rows[0];
+    return {
+      userId: row.user_id,
+      email: row.email,
+      password: row.password,
+      providerId: row.provider_id,
+      lastSelectedProviderId: row.last_selected_provider_id,
+      mustChangePassword: row.must_change_password,
+      contactEmail: row.contact_email,
+      emailVerifiedAt: row.email_verified_at,
       roles: row.roles,
       permissions: row.permissions,
       ...row.data,
@@ -81,6 +108,34 @@ export class PostgresUserStorage implements IUserStorage {
               updated_at = NOW()
         WHERE email = $1`,
       [email, hashedPassword],
+    );
+    return { ...SUCCESS };
+  }
+
+  async setContactEmail(userId: string, contactEmail: string): Promise<{ success: boolean }> {
+    // Atomic one-query write: stamps the new contact_email and (importantly)
+    // CLEARS email_verified_at so an already-verified user changing their
+    // contact email has to verify again. Without the clear, a malicious
+    // user could swap their contact email after a stolen session and gain
+    // a verified channel they don't own.
+    await this.pool.query(
+      `UPDATE users
+          SET contact_email = $2,
+              email_verified_at = NULL,
+              updated_at = NOW()
+        WHERE user_id = $1`,
+      [userId, contactEmail],
+    );
+    return { ...SUCCESS };
+  }
+
+  async markEmailVerified(userId: string): Promise<{ success: boolean }> {
+    await this.pool.query(
+      `UPDATE users
+          SET email_verified_at = NOW(),
+              updated_at = NOW()
+        WHERE user_id = $1`,
+      [userId],
     );
     return { ...SUCCESS };
   }


### PR DESCRIPTION
## Summary

Phase B2 of the email + identity workstream. Splits the long-overdue separation between `users.email` (the LOGIN identifier — historically often a non-email string like \`alice\` or \`pro-shop-1\`) and `users.contact_email` (the verified RFC 5322 address mail is sent to). Adds the verification flow end-to-end.

**Foundation in place for B3** (forgot-password + reset-password). Nothing in B3 will work without a verified contact_email; this PR makes that gate possible.

## What's in

### Schema (Migration 028)

Adds `contact_email` + `email_verified_at` to `users`. Idempotent, AFFECTS: end-users. Conservative regex backfill seeds `contact_email` from `email` only when the login string is unambiguously RFC-shaped (matches \`^[A-Z0-9._%+-]+@[A-Z0-9.-]+\\.[A-Z]{2,}$\` case-insensitive). Everyone else stays NULL until they explicitly set one.

`email_verified_at` stays NULL even for backfilled rows — the column existing is not the same as the user having clicked the link.

### Server — `src/modules/account/identity/`

- \`POST /account/contact-email/set\` (authed) — validate RFC, write the address with \`email_verified_at = NULL\`, email a signed JWT (purpose: \`email-verification\`, 24h expiry). Re-uses B1's EmailService + Resend adapter + email-verification.ejs.
- \`POST /account/contact-email/resend-verification\` (authed) — idempotent; no-op when no contact_email or already verified.
- \`POST /auth/verify-email\` (Public) — verifies token, defensively checks the current contact_email still matches the one in the token (rejects stale tokens after the user changed their address), stamps \`email_verified_at = NOW()\`.

The existing auth.middleware \`purpose\`-claim filter already rejects these tokens at normal endpoints — same pattern as \`first-login-password-change\`. No middleware change required.

### Storage layer

- \`findOne\` / \`findAll\` / \`create\` / \`update\` read + write both new columns.
- New atomic helpers:
  - \`findByContactEmail(contactEmail)\` — case-insensitive lookup, will power B3's forgot-password
  - \`setContactEmail(userId, contactEmail)\` — writes the address and **clears \`email_verified_at\`**. Required: a stolen session must not inherit a verified channel by swapping the address.
  - \`markEmailVerified(userId)\` — called on successful token validation

### Admin client

- **\`contactEmail\` modal** — set / change address + resend verification. Calls \`GET /auth/me\` on open so the user sees the live verified timestamp even if their cached JWT is stale.
- **Public \`/verify-email/:token\` route + page** — lands here from the email link with a "Verify" button that POSTs the token. Deliberately not a GET endpoint so link-previewers (Slack, Discord, anti-spam scanners) can't accidentally consume the single-use token by GET-fetching the URL.
- **Global \`contactEmailBanner\`** — shown post-login when contact_email is missing or unverified. Dismissable per-session (localStorage TTL 24h). Re-evaluated on every router \`before\` hook + immediately after \`logIn()\`.

### Microservice boundary

All new code lives under \`src/modules/account/identity/\` per the boundary rule documented in \`Mentat/planning/ACCOUNT_SERVICE_BOUNDARY.md\`. \`AccountModule\` re-exports \`IdentityModule\` alongside \`AuthModule\` and \`EmailModule\` — still a single public surface for the future microservice lift-out.

## Out of scope

- **B3**: forgot-password + reset-password wiring via the now-verified contact_email. Schema + the \`findByContactEmail\` helper are in place; the endpoints remain stubbed.
- **B4**: admin-create-user emails the new user when their contact_email is available.

## Test plan

- [ ] Pull, \`pnpm install\` (no new deps), \`pnpm build\`. Boot Factory-Server on mentat with \`APP_BASE_URL\` set in \`.env\`. Confirm migration 028 applies cleanly (check \`schema_migrations\` table for an entry and \`users\` for the new columns).
- [ ] After boot, the backfill should have set \`contact_email\` for users whose \`email\` looks like an email. Spot-check a few rows.
- [ ] Log in as any user whose contact_email is NULL → expect the post-login banner.
- [ ] Click "Set up email" → modal opens. Submit an email → toast confirms, email arrives at the address. Resend works.
- [ ] Click the verification link in the email → lands on \`/admin/#/verify-email/<token>\` → click Verify → success state. Re-login → banner is gone.
- [ ] Try to verify with a stale token (set a different contact_email between issue and verify) → expect 403 with "no longer matches".
- [ ] Try the \`/auth/verify-email\` route with the limited-purpose token in the Authorization header → expect normal endpoints to still 401 (middleware filter holds).

## Deploy checklist

- [ ] Set \`APP_BASE_URL='https://nest.courthive.com'\` in \`shared/.env\` on nest BEFORE this PR deploys
- [ ] Repeat for mentat dev with the appropriate URL
- [ ] After deploy, the migration runner auto-applies 028 on Factory-Server boot
- [ ] Smoke-test the verification flow against a real recipient before announcing to users

## CI matrix

- Server: \`pnpm lint\` ✓ · \`check-types\` ✓ · 736/736 tests ✓ (+12 new IdentityService) · \`build\` ✓
- Admin-client: \`pnpm lint\` ✓ · \`check-types\` ✓ · tests ✓ · \`build\` ✓