### PR TITLE
feat(account): password reset via link-token + confirmation email (Phase B3)

### DIFF
--- a/admin-client/src/components/banners/contactEmailBanner.ts
+++ b/admin-client/src/components/banners/contactEmailBanner.ts
@@ -14,7 +14,7 @@
  */
 import { getLoginState } from 'services/authentication/loginState';
 import { contactEmailModal } from 'components/modals/contactEmail';
-import { VERIFY_EMAIL } from 'constants/tmxConstants';
+import { VERIFY_EMAIL, RESET_PASSWORD } from 'constants/tmxConstants';
 import { t } from 'i18n';
 
 const DISMISS_KEY = 'admin_contact_email_banner_dismissed_until';
@@ -37,8 +37,12 @@ export function renderContactEmailBanner(): void {
   if (!container) return;
   container.innerHTML = '';
 
-  // The verify-email landing page is a public route; never nag on it.
+  // Public email-link landing pages are routes a non-logged-in user may
+  // be on; never nag on them. (The banner only fires when logged in
+  // anyway, but these guards short-circuit cleanly if a session is
+  // somehow active during a reset/verify flow.)
   if (globalThis.location.hash.startsWith(`#/${VERIFY_EMAIL}/`)) return;
+  if (globalThis.location.hash.startsWith(`#/${RESET_PASSWORD}/`)) return;
 
   const state: any = getLoginState();
   if (!state) return; // not logged in

--- a/admin-client/src/components/framework/rootBlock.ts
+++ b/admin-client/src/components/framework/rootBlock.ts
@@ -2,7 +2,7 @@
  * Root application block for the admin client.
  * Creates navbar, main content area with page containers.
  */
-import { NONE, TMX_ADMIN, TMX_SYSTEM, TMX_PROVISIONER, TMX_SANCTIONING, TMX_SYNC, TMX_TEMPLATES, TMX_POLICIES, TMX_VERIFY_EMAIL, TMX_DRAWER } from 'constants/tmxConstants';
+import { NONE, TMX_ADMIN, TMX_SYSTEM, TMX_PROVISIONER, TMX_SANCTIONING, TMX_SYNC, TMX_TEMPLATES, TMX_POLICIES, TMX_VERIFY_EMAIL, TMX_RESET_PASSWORD, TMX_DRAWER } from 'constants/tmxConstants';
 
 const flexColFlexGrow = 'flexcol flexgrow';
 
@@ -74,6 +74,13 @@ export function rootBlock(): HTMLElement {
   verifyEmail.style.display = NONE;
   verifyEmail.id = TMX_VERIFY_EMAIL;
   main.appendChild(verifyEmail);
+
+  // Reset-password landing (public route, opened from the password-reset link)
+  const resetPassword = document.createElement('div');
+  resetPassword.className = flexColFlexGrow;
+  resetPassword.style.display = NONE;
+  resetPassword.id = TMX_RESET_PASSWORD;
+  main.appendChild(resetPassword);
 
   // Drawer
   const drawer = document.createElement('section');

--- a/admin-client/src/components/modals/forgotPassword.ts
+++ b/admin-client/src/components/modals/forgotPassword.ts
@@ -1,0 +1,86 @@
+/**
+ * Forgot-password modal.
+ *
+ * Single-field form (contact email) that POSTs /auth/forgot-password.
+ * The server is enumeration-defensive: it ALWAYS returns `{ ok: true }`,
+ * whether the address is registered, unverified, or unknown. So this
+ * UI uniformly shows the same "If we know you, a link is on the way"
+ * toast on success — no UI signal about registration state either.
+ *
+ * Opens from the login modal "Forgot password?" link.
+ */
+import { validators, renderForm } from 'courthive-components';
+import { forgotPassword } from 'services/authentication/authApi';
+import { tmxToast } from 'services/notifications/tmxToast';
+import { openModal } from './baseModal/baseModal';
+import { t } from 'i18n';
+
+export function forgotPasswordModal(): void {
+  let inputs: any;
+
+  const enableSubmit = ({ inputs }: any) => {
+    const value = inputs?.contactEmail?.value ?? '';
+    const isValid = validators.emailValidator(value);
+    const submitBtn = document.getElementById('forgotPasswordSubmit') as HTMLButtonElement | null;
+    if (submitBtn) submitBtn.disabled = !isValid;
+  };
+
+  const relationships = [{ onInput: enableSubmit, control: 'contactEmail' }];
+
+  const content = (elem: HTMLElement) => {
+    const intro = document.createElement('p');
+    intro.style.cssText = 'margin: 0 0 16px 0; font-size: 0.95rem; line-height: 1.5;';
+    intro.textContent = t('modals.forgotPassword.intro');
+    elem.appendChild(intro);
+
+    inputs = renderForm(
+      elem,
+      [
+        {
+          iconLeft: 'fa-regular fa-envelope',
+          placeholder: 'you@example.com',
+          validator: validators.emailValidator,
+          autocomplete: 'email',
+          label: t('modals.forgotPassword.label'),
+          field: 'contactEmail',
+          id: 'forgotPasswordEmail',
+        },
+      ],
+      relationships,
+    );
+  };
+
+  const onSubmit = () => {
+    const value = (inputs?.contactEmail?.value ?? '').trim();
+    if (!value) return;
+    forgotPassword(value).then(
+      () => {
+        // Uniform success message regardless of server response — server
+        // always returns { ok: true } to defeat enumeration, so the UI
+        // matches.
+        tmxToast({ message: t('modals.forgotPassword.sent'), intent: 'is-success' });
+      },
+      () => {
+        // Network errors are user-visible — server-side enumeration
+        // defense only applies to the OK path.
+        tmxToast({ message: t('modals.forgotPassword.networkError'), intent: 'is-danger' });
+      },
+    );
+  };
+
+  openModal({
+    title: t('modals.forgotPassword.title'),
+    content,
+    buttons: [
+      { label: t('common.cancel'), intent: 'none', close: true },
+      {
+        label: t('modals.forgotPassword.submit'),
+        id: 'forgotPasswordSubmit',
+        disabled: true,
+        onClick: onSubmit,
+        close: true,
+        intent: 'is-primary',
+      },
+    ],
+  });
+}

--- a/admin-client/src/components/modals/loginModal.ts
+++ b/admin-client/src/components/modals/loginModal.ts
@@ -9,6 +9,7 @@
  * the user's chosen password and then completes the sign-in.
  */
 import { firstLoginPasswordModal } from './firstLoginPassword';
+import { forgotPasswordModal } from './forgotPassword';
 import { logIn, logOut } from 'services/authentication/loginState';
 import { renderForm, validators } from 'courthive-components';
 import { systemLogin } from 'services/authentication/authApi';
@@ -32,8 +33,8 @@ export function loginModal(callback?: () => void): void {
     },
   ];
 
-  const content = (elem: HTMLElement) =>
-    (inputs = renderForm(
+  const content = (elem: HTMLElement) => {
+    inputs = renderForm(
       elem,
       [
         {
@@ -56,7 +57,26 @@ export function loginModal(callback?: () => void): void {
         },
       ],
       relationships,
-    ));
+    );
+
+    // Forgot-password link — opens the forgotPasswordModal in a separate
+    // dialog. Always visible (not just on auth failure) so a user who
+    // KNOWS they don't have a password yet can reach it directly.
+    const forgotLink = document.createElement('a');
+    forgotLink.href = '#';
+    forgotLink.textContent = t('modals.login.forgotPassword');
+    forgotLink.style.cssText =
+      'display: inline-block; margin-top: 8px; font-size: 0.85rem; ' +
+      'color: var(--tmx-text-secondary, #64748b); text-decoration: underline; cursor: pointer;';
+    forgotLink.addEventListener('click', (e) => {
+      e.preventDefault();
+      // Close the login modal first so the two don't stack visually.
+      const loginButton = document.getElementById('loginButton') as HTMLButtonElement | null;
+      loginButton?.closest('.modal')?.classList.remove('is-active');
+      forgotPasswordModal();
+    });
+    elem.appendChild(forgotLink);
+  };
 
   const submitCredentials = () => {
     const email = inputs.email.value;

--- a/admin-client/src/constants/tmxConstants.ts
+++ b/admin-client/src/constants/tmxConstants.ts
@@ -47,6 +47,10 @@ export const SYNC = 'sync';
 export const TMX_VERIFY_EMAIL = 'tmxVerifyEmail';
 export const VERIFY_EMAIL = 'verify-email';
 
+// Reset password (public landing for password-reset link)
+export const TMX_RESET_PASSWORD = 'tmxResetPassword';
+export const RESET_PASSWORD = 'reset-password';
+
 // Navigation targets
 export const TOURNAMENT_SETTINGS = 'tournamentSettings';
 export const TMX_TOURNAMENTS = 'tournaments';

--- a/admin-client/src/i18n/locales/en.json
+++ b/admin-client/src/i18n/locales/en.json
@@ -1049,7 +1049,16 @@
       "emailPlaceholder": "valid@email.com",
       "passwordLabel": "Password",
       "passwordPlaceholder": "minimum 8 characters",
-      "loginButton": "Login"
+      "loginButton": "Login",
+      "forgotPassword": "Forgot your password?"
+    },
+    "forgotPassword": {
+      "title": "Reset your password",
+      "intro": "Enter the email address associated with your account. If we know you, a password-reset link is on the way — check your inbox.",
+      "label": "Contact email",
+      "submit": "Send reset link",
+      "sent": "If we know you, a password-reset link is on the way. Check your inbox (and your spam folder).",
+      "networkError": "Couldn't reach the server — please try again."
     },
     "settings": {
       "title": "Settings",
@@ -1528,6 +1537,20 @@
     "tokenMismatch": "This link no longer matches your current contact email — it was probably superseded by a more recent change.",
     "tryAgain": "Try again",
     "failed": "Verification failed. Try requesting a fresh link."
+  },
+
+  "resetPassword": {
+    "title": "Set a new password",
+    "intro": "Choose a new password for your CourtHive account. The link in your email is single-use.",
+    "newPasswordPlaceholder": "New password (at least 8 characters)",
+    "confirmPlaceholder": "Confirm new password",
+    "submit": "Set new password",
+    "submitting": "Setting…",
+    "success": "Your password was changed. Redirecting to login…",
+    "missingToken": "This reset link is missing its token. Try clicking the link in your email again, or request a fresh one.",
+    "tokenExpired": "This reset link has expired. Request a fresh one from the login screen's \"Forgot your password?\" link.",
+    "tokenMismatch": "This link no longer matches your current contact email — request a fresh one.",
+    "failed": "Couldn't reset your password. Try requesting a fresh link."
   },
 
   "toasts": {

--- a/admin-client/src/pages/resetPassword/renderResetPassword.ts
+++ b/admin-client/src/pages/resetPassword/renderResetPassword.ts
@@ -1,0 +1,118 @@
+/**
+ * Public reset-password landing page.
+ *
+ * Rendered when the user clicks the link in the password-reset email,
+ * which lands at `/admin/#/reset-password/<token>`. Collects a new
+ * password + confirmation, POSTs to /auth/reset-password. Same
+ * link-previewer defense as /verify-email — server expects a POST, not
+ * a GET, so a URL-fetcher can't accidentally consume the token.
+ *
+ * No authentication required — the token IS the auth.
+ */
+import { showTMXresetPassword } from 'services/transitions/screenSlaver';
+import { resetPassword } from 'services/authentication/authApi';
+import { TMX_RESET_PASSWORD } from 'constants/tmxConstants';
+import { context } from 'services/context';
+import { t } from 'i18n';
+
+const MIN_PASSWORD_LENGTH = 8;
+
+export function renderResetPassword(token: string): void {
+  showTMXresetPassword();
+  const container = document.getElementById(TMX_RESET_PASSWORD);
+  if (!container) return;
+  container.innerHTML = '';
+
+  const card = document.createElement('div');
+  card.style.cssText =
+    'margin: 64px auto; max-width: 480px; background: var(--tmx-bg-elevated, #fff); ' +
+    'padding: 32px; border-radius: 8px; box-shadow: 0 1px 3px rgba(0,0,0,0.08); ' +
+    'color: var(--tmx-text-primary, #1a1a1a);';
+
+  const heading = document.createElement('h2');
+  heading.textContent = t('resetPassword.title');
+  heading.style.cssText = 'margin: 0 0 12px 0; font-size: 22px; font-weight: 600;';
+
+  const intro = document.createElement('p');
+  intro.style.cssText = 'margin: 0 0 24px 0; font-size: 15px; line-height: 1.55;';
+
+  const statusEl = document.createElement('div');
+  statusEl.style.cssText = 'margin-top: 16px; font-size: 14px;';
+
+  if (!token) {
+    intro.textContent = t('resetPassword.missingToken');
+    card.append(heading, intro);
+    container.appendChild(card);
+    return;
+  }
+
+  intro.textContent = t('resetPassword.intro');
+
+  // Form: new password + confirm
+  const inputStyle =
+    'width: 100%; padding: 10px 12px; font-size: 15px; border: 1px solid var(--tmx-border-primary, #d1d5db); ' +
+    'border-radius: 6px; background: var(--tmx-bg-primary, #fff); color: var(--tmx-text-primary, #1a1a1a); ' +
+    'box-sizing: border-box; margin-bottom: 12px; font-family: inherit;';
+
+  const newInput = document.createElement('input');
+  newInput.type = 'password';
+  newInput.placeholder = t('resetPassword.newPasswordPlaceholder');
+  newInput.autocomplete = 'new-password';
+  newInput.style.cssText = inputStyle;
+
+  const confirmInput = document.createElement('input');
+  confirmInput.type = 'password';
+  confirmInput.placeholder = t('resetPassword.confirmPlaceholder');
+  confirmInput.autocomplete = 'new-password';
+  confirmInput.style.cssText = inputStyle;
+
+  const submit = document.createElement('button');
+  submit.className = 'button is-primary';
+  submit.textContent = t('resetPassword.submit');
+  submit.disabled = true;
+  submit.style.cssText =
+    'padding: 10px 20px; font-size: 15px; border-radius: 6px; cursor: pointer; ' +
+    'background: var(--tmx-status-success, #0f766e); color: #fff; border: 0; font-weight: 600; width: 100%;';
+
+  const updateEnabled = () => {
+    submit.disabled = newInput.value.length < MIN_PASSWORD_LENGTH || newInput.value !== confirmInput.value;
+  };
+  newInput.addEventListener('input', updateEnabled);
+  confirmInput.addEventListener('input', updateEnabled);
+
+  submit.addEventListener('click', () => {
+    submit.disabled = true;
+    submit.textContent = t('resetPassword.submitting');
+    resetPassword(token, newInput.value).then(
+      () => {
+        statusEl.style.color = 'var(--tmx-status-success, #2e7d32)';
+        statusEl.textContent = t('resetPassword.success');
+        // Hide the form so the success message is the only thing left.
+        newInput.style.display = 'none';
+        confirmInput.style.display = 'none';
+        submit.style.display = 'none';
+        // Auto-redirect to the login modal after a short delay so the
+        // user knows what's expected next.
+        setTimeout(() => {
+          context.router?.navigate('/');
+        }, 2500);
+      },
+      (err: any) => {
+        submit.disabled = false;
+        submit.textContent = t('resetPassword.submit');
+        statusEl.style.color = 'var(--tmx-status-error, #c62828)';
+        const status = err?.response?.status;
+        if (status === 401) {
+          statusEl.textContent = t('resetPassword.tokenExpired');
+        } else if (status === 403) {
+          statusEl.textContent = t('resetPassword.tokenMismatch');
+        } else {
+          statusEl.textContent = err?.response?.data?.message || t('resetPassword.failed');
+        }
+      },
+    );
+  });
+
+  card.append(heading, intro, newInput, confirmInput, submit, statusEl);
+  container.appendChild(card);
+}

--- a/admin-client/src/router/router.ts
+++ b/admin-client/src/router/router.ts
@@ -3,6 +3,7 @@ import { renderSanctioningWizard } from 'pages/sanctioning/renderSanctioningWiza
 import { renderSanctioningDetail } from 'pages/sanctioning/renderSanctioningDetail';
 import { renderProvisionerPage } from 'pages/provisioner/renderProvisionerPage';
 import { renderContactEmailBanner } from 'components/banners/contactEmailBanner';
+import { renderResetPassword } from 'pages/resetPassword/renderResetPassword';
 import { renderVerifyEmail } from 'pages/verifyEmail/renderVerifyEmail';
 import { renderSystemPage } from 'pages/system/renderSystemPage';
 import { renderAdminPage } from 'pages/admin/renderAdminPage';
@@ -14,7 +15,7 @@ import { updateNavVisibility } from 'services/navigation/navVisibility';
 import { context } from 'services/context';
 import Navigo from 'navigo';
 
-import { SUPER_ADMIN, PROVISIONER, SYSTEM, PROVISIONER_ROUTE, SANCTIONING, SYNC, TEMPLATES, POLICIES, VERIFY_EMAIL } from 'constants/tmxConstants';
+import { SUPER_ADMIN, PROVISIONER, SYSTEM, PROVISIONER_ROUTE, SANCTIONING, SYNC, TEMPLATES, POLICIES, VERIFY_EMAIL, RESET_PASSWORD } from 'constants/tmxConstants';
 
 export function routeAdmin(): void {
   const router = new Navigo('/', { hash: true });
@@ -130,6 +131,13 @@ export function routeAdmin(): void {
   // can't accidentally consume the single-use token by GET-fetching the URL.
   router.on(`/${VERIFY_EMAIL}/:token`, (match) => {
     renderVerifyEmail(match?.data?.token ?? '');
+  });
+
+  // Public route: password-reset link lands here. Same link-previewer
+  // defense as verify-email — the page renders a form that POSTs the
+  // token + new password to /auth/reset-password.
+  router.on(`/${RESET_PASSWORD}/:token`, (match) => {
+    renderResetPassword(match?.data?.token ?? '');
   });
 
   router.on('/', () => {

--- a/admin-client/src/services/authentication/authApi.test.ts
+++ b/admin-client/src/services/authentication/authApi.test.ts
@@ -92,23 +92,22 @@ describe('authApi', () => {
   });
 
   describe('forgotPassword', () => {
-    it('posts to /auth/forgot-password with email', async () => {
-      mockPost.mockResolvedValue({ data: {} });
+    it('posts to /auth/forgot-password with contactEmail', async () => {
+      mockPost.mockResolvedValue({ data: { ok: true } });
       await forgotPassword('lost@test.com');
       expect(mockPost).toHaveBeenCalledWith('/auth/forgot-password', {
-        email: 'lost@test.com',
+        contactEmail: 'lost@test.com',
       });
     });
   });
 
   describe('resetPassword', () => {
-    it('posts to /auth/reset-password with email, password, and code', async () => {
+    it('posts to /auth/reset-password with token and newPassword', async () => {
       mockPost.mockResolvedValue({ data: { success: true } });
-      await resetPassword('user@test.com', 'newPass', 'reset-code');
+      await resetPassword('reset-jwt-token', 'newPass');
       expect(mockPost).toHaveBeenCalledWith('/auth/reset-password', {
-        email: 'user@test.com',
-        password: 'newPass',
-        code: 'reset-code',
+        token: 'reset-jwt-token',
+        newPassword: 'newPass',
       });
     });
   });

--- a/admin-client/src/services/authentication/authApi.ts
+++ b/admin-client/src/services/authentication/authApi.ts
@@ -46,12 +46,21 @@ export async function confirmEmail(emailConfirmationId) {
   return baseApi.get(`/auth/confirm/${emailConfirmationId}`);
 }
 
-export async function forgotPassword(email) {
-  return baseApi.post('/auth/forgot-password', { email });
+/**
+ * Request a password reset. Server is enumeration-defensive — always
+ * returns `{ ok: true }`, never confirms registration.
+ */
+export async function forgotPassword(contactEmail: string) {
+  return baseApi.post('/auth/forgot-password', { contactEmail });
 }
 
-export async function resetPassword(email, password, code) {
-  return baseApi.post('/auth/reset-password', { email, password, code });
+/**
+ * Apply a password reset using the JWT from the email link. Server
+ * verifies the token (purpose: 'password-reset', 1h expiry) and writes
+ * the new password atomically.
+ */
+export async function resetPassword(token: string, newPassword: string) {
+  return baseApi.post('/auth/reset-password', { token, newPassword });
 }
 
 export async function ssoLoginWithToken(token: string) {

--- a/admin-client/src/services/transitions/screenSlaver.ts
+++ b/admin-client/src/services/transitions/screenSlaver.ts
@@ -2,11 +2,11 @@
  * Screen state management for admin app content areas.
  * Controls visibility of the admin and system page containers.
  */
-import { TMX_ADMIN, TMX_SYSTEM, TMX_PROVISIONER, TMX_SANCTIONING, TMX_SYNC, TMX_TEMPLATES, TMX_POLICIES, TMX_VERIFY_EMAIL } from 'constants/tmxConstants';
+import { TMX_ADMIN, TMX_SYSTEM, TMX_PROVISIONER, TMX_SANCTIONING, TMX_SYNC, TMX_TEMPLATES, TMX_POLICIES, TMX_VERIFY_EMAIL, TMX_RESET_PASSWORD } from 'constants/tmxConstants';
 
 let content: string | undefined;
 
-const PAGE_IDS = [TMX_SYSTEM, TMX_ADMIN, TMX_PROVISIONER, TMX_SANCTIONING, TMX_SYNC, TMX_TEMPLATES, TMX_POLICIES, TMX_VERIFY_EMAIL];
+const PAGE_IDS = [TMX_SYSTEM, TMX_ADMIN, TMX_PROVISIONER, TMX_SANCTIONING, TMX_SYNC, TMX_TEMPLATES, TMX_POLICIES, TMX_VERIFY_EMAIL, TMX_RESET_PASSWORD];
 
 function selectDisplay(which: string): void {
   for (const id of PAGE_IDS) {
@@ -102,5 +102,12 @@ export const showTMXverifyEmail = (): void => {
   const titleEl = document.getElementById('pageTitle');
   if (titleEl) titleEl.textContent = 'Verify Email';
   content = TMX_VERIFY_EMAIL;
+  selectDisplay(content);
+};
+
+export const showTMXresetPassword = (): void => {
+  const titleEl = document.getElementById('pageTitle');
+  if (titleEl) titleEl.textContent = 'Reset Password';
+  content = TMX_RESET_PASSWORD;
   selectDisplay(content);
 };

--- a/src/modules/account/auth/auth.controller.ts
+++ b/src/modules/account/auth/auth.controller.ts
@@ -1,6 +1,8 @@
 import { Body, Controller, Get, HttpCode, HttpStatus, Patch, Post } from '@nestjs/common';
 import { UserCtx, type UserContext } from './decorators/user-context.decorator';
 import { AdminCreateUserDto } from './dto/adminCreateUser.dto';
+import { ForgotPasswordDto } from './dto/forgotPassword.dto';
+import { ResetPasswordDto } from './dto/resetPassword.dto';
 import { SUPER_ADMIN, CLIENT } from 'src/common/constants/roles';
 import { Public } from './decorators/public.decorator';
 import { Roles } from './decorators/roles.decorator';
@@ -131,4 +133,26 @@ export class AuthController {
     return this.authService.updateLastSelectedProvider(userContext.email, body?.providerId ?? null);
   }
 
+  /**
+   * Request a password reset. Always returns `{ ok: true }` (enumeration
+   * defense) — mail is sent only when the contact_email is registered
+   * AND verified. Public: callers are by definition not authenticated.
+   */
+  @Public()
+  @Post('forgot-password')
+  @HttpCode(HttpStatus.OK)
+  forgotPassword(@Body() body: ForgotPasswordDto) {
+    return this.authService.forgotPassword(body?.contactEmail ?? '');
+  }
+
+  /**
+   * Apply a password reset using the JWT carried in the link from the
+   * reset email. Public: the token IS the auth.
+   */
+  @Public()
+  @Post('reset-password')
+  @HttpCode(HttpStatus.OK)
+  resetPassword(@Body() body: ResetPasswordDto) {
+    return this.authService.resetPassword(body?.token ?? '', body?.newPassword ?? '');
+  }
 }

--- a/src/modules/account/auth/auth.module.ts
+++ b/src/modules/account/auth/auth.module.ts
@@ -1,5 +1,6 @@
 import { MiddlewareConsumer, Module, NestModule } from '@nestjs/common';
 import { ConfigsModule } from 'src/config/config.module';
+import { EmailModule } from '../email/email.module';
 import { UsersModule } from '../../users/users.module';
 import { AuthController } from './auth.controller';
 import { AuthMiddleware } from './auth.middleware';
@@ -21,6 +22,7 @@ const expiresIn: any = rawValidity && isValidJwtExpiresIn(rawValidity) ? rawVali
   imports: [
     ConfigsModule,
     UsersModule,
+    EmailModule,
     JwtModule.register({
       signOptions: { expiresIn },
       secret: process.env.JWT_SECRET,

--- a/src/modules/account/auth/auth.service.spec.ts
+++ b/src/modules/account/auth/auth.service.spec.ts
@@ -7,8 +7,9 @@ describe('AuthService', () => {
   let authService: AuthService;
   let mockUsersService: any;
   let jwtService: JwtService;
+  let mockEmailService: any;
+  let mockConfigService: any;
   let mockProviderStorage: any;
-  let mockAuthCodeStorage: any;
   let mockUserStorage: any;
   let mockUserProviderStorage: any;
   let mockProvisionerProviderStorage: any;
@@ -23,15 +24,17 @@ describe('AuthService', () => {
       remove: jest.fn(),
     };
 
+    mockEmailService = {
+      sendTemplated: jest.fn().mockResolvedValue({ id: 'msg-123' }),
+    };
+
+    mockConfigService = {
+      get: jest.fn().mockReturnValue({ baseUrl: 'https://nest.test.example' }),
+    };
+
     mockProviderStorage = {
       getProvider: jest.fn(),
       updateLastAccess: jest.fn().mockResolvedValue(undefined),
-    };
-
-    mockAuthCodeStorage = {
-      setResetCode: jest.fn(),
-      getResetCode: jest.fn(),
-      deleteResetCode: jest.fn(),
     };
 
     mockUserStorage = {
@@ -39,6 +42,9 @@ describe('AuthService', () => {
       updateLastAccess: jest.fn().mockResolvedValue(undefined),
       updateLastSelectedProviderId: jest.fn().mockResolvedValue({ success: true }),
       completeFirstLogin: jest.fn().mockResolvedValue({ success: true }),
+      findByContactEmail: jest.fn().mockResolvedValue(null),
+      findByUserId: jest.fn().mockResolvedValue(null),
+      setPasswordByUserId: jest.fn().mockResolvedValue({ success: true }),
     };
 
     const mockUserProvisionerStorage = {
@@ -70,8 +76,9 @@ describe('AuthService', () => {
     authService = new AuthService(
       mockUsersService,
       jwtService,
+      mockEmailService,
+      mockConfigService,
       mockProviderStorage,
-      mockAuthCodeStorage,
       mockUserStorage,
       mockUserProvisionerStorage as any,
       mockUserProviderStorage,
@@ -453,41 +460,152 @@ describe('AuthService', () => {
   });
 
   describe('forgotPassword', () => {
-    it('returns error when user not found', async () => {
-      mockUsersService.findOne.mockResolvedValue(null);
-      const result = await authService.forgotPassword('missing@test.com');
-      expect(result).toEqual({ error: 'User not found' });
+    // The contract is enumeration-defensive: always return { ok: true }
+    // regardless of input. The signal of whether a real account exists
+    // never leaks via response shape, status code, or timing-distinct
+    // failure paths.
+
+    it('returns { ok: true } for an empty address and sends nothing', async () => {
+      const result: any = await authService.forgotPassword('');
+      expect(result).toEqual({ ok: true });
+      expect(mockEmailService.sendTemplated).not.toHaveBeenCalled();
     });
 
-    it('sets reset code and returns email', async () => {
-      mockUsersService.findOne.mockResolvedValue({ email: 'user@test.com' });
-      const result = await authService.forgotPassword('user@test.com');
-      expect(result).toBe('user@test.com');
-      expect(mockAuthCodeStorage.setResetCode).toHaveBeenCalled();
+    it('returns { ok: true } when no user has this contact_email', async () => {
+      mockUserStorage.findByContactEmail.mockResolvedValue(null);
+      const result: any = await authService.forgotPassword('unknown@test.com');
+      expect(result).toEqual({ ok: true });
+      expect(mockEmailService.sendTemplated).not.toHaveBeenCalled();
+    });
+
+    it('returns { ok: true } when the user exists but has not verified their contact_email', async () => {
+      mockUserStorage.findByContactEmail.mockResolvedValue({
+        userId: 'u-1',
+        contactEmail: 'alice@example.com',
+        emailVerifiedAt: null,
+      });
+      const result: any = await authService.forgotPassword('alice@example.com');
+      expect(result).toEqual({ ok: true });
+      expect(mockEmailService.sendTemplated).not.toHaveBeenCalled();
+    });
+
+    it('sends a password-reset email when the user has a verified contact_email', async () => {
+      mockUserStorage.findByContactEmail.mockResolvedValue({
+        userId: 'u-1',
+        contactEmail: 'alice@example.com',
+        emailVerifiedAt: '2026-05-22T00:00:00Z',
+        firstName: 'Alice',
+      });
+      const result: any = await authService.forgotPassword('alice@example.com');
+      expect(result).toEqual({ ok: true });
+      expect(mockEmailService.sendTemplated).toHaveBeenCalledWith(
+        expect.objectContaining({
+          to: 'alice@example.com',
+          template: 'password-reset-request',
+          tag: 'password-reset',
+          data: expect.objectContaining({ firstName: 'Alice' }),
+        }),
+      );
+      const sendCall = (mockEmailService.sendTemplated as jest.Mock).mock.calls[0][0];
+      expect(sendCall.data.resetUrl).toMatch(/^https:\/\/nest\.test\.example\/admin\/#\/reset-password\//);
+    });
+
+    it('still returns { ok: true } when the email send fails (no enumeration leak)', async () => {
+      mockUserStorage.findByContactEmail.mockResolvedValue({
+        userId: 'u-1',
+        contactEmail: 'alice@example.com',
+        emailVerifiedAt: '2026-05-22T00:00:00Z',
+      });
+      mockEmailService.sendTemplated.mockRejectedValueOnce(new Error('SMTP down'));
+      const warnSpy = jest.spyOn(Logger, 'warn').mockImplementation(() => undefined);
+      const result: any = await authService.forgotPassword('alice@example.com');
+      expect(result).toEqual({ ok: true });
+      expect(warnSpy).toHaveBeenCalled();
+      warnSpy.mockRestore();
     });
   });
 
   describe('resetPassword', () => {
-    it('returns error for invalid reset code', async () => {
-      mockAuthCodeStorage.getResetCode.mockResolvedValue(null);
-      const result = await authService.resetPassword('bad-code', 'new-pass');
-      expect(result).toEqual({ error: 'Invalid reset code' });
+    it('returns error when token is missing', async () => {
+      const result: any = await authService.resetPassword('', 'newPass');
+      expect(result.error).toContain('required');
     });
 
-    it('returns error when user not found', async () => {
-      mockAuthCodeStorage.getResetCode.mockResolvedValue({ email: 'gone@test.com' });
-      mockUsersService.findOne.mockResolvedValue(null);
-      const result = await authService.resetPassword('valid-code', 'new-pass');
-      expect(result).toEqual({ error: 'User not found' });
+    it('returns error when newPassword is missing', async () => {
+      const result: any = await authService.resetPassword('token', '');
+      expect(result.error).toContain('required');
     });
 
-    it('updates password and returns success', async () => {
-      mockAuthCodeStorage.getResetCode.mockResolvedValue({ email: 'user@test.com' });
-      mockUsersService.findOne.mockResolvedValue({ email: 'user@test.com', password: 'old' });
-      mockUserStorage.update.mockResolvedValue(undefined);
-      const result: any = await authService.resetPassword('valid-code', 'new-pass');
+    it('throws UnauthorizedException when the token is malformed', async () => {
+      await expect(authService.resetPassword('not-a-jwt', 'newPass')).rejects.toThrow(
+        UnauthorizedException,
+      );
+    });
+
+    it('throws UnauthorizedException for a token without the password-reset purpose', async () => {
+      const wrong = await jwtService.signAsync(
+        { userId: 'u-1', purpose: 'something-else' },
+        { expiresIn: '5m' },
+      );
+      await expect(authService.resetPassword(wrong, 'newPass')).rejects.toThrow(
+        UnauthorizedException,
+      );
+    });
+
+    it('throws UnauthorizedException when the user no longer exists', async () => {
+      const token = await jwtService.signAsync(
+        { userId: 'u-1', contactEmail: 'alice@example.com', purpose: 'password-reset' },
+        { expiresIn: '1h' },
+      );
+      mockUserStorage.findByUserId.mockResolvedValue(null);
+      await expect(authService.resetPassword(token, 'newPass')).rejects.toThrow(
+        UnauthorizedException,
+      );
+    });
+
+    it('throws ForbiddenException when the user changed their contact_email after the token was issued', async () => {
+      const token = await jwtService.signAsync(
+        { userId: 'u-1', contactEmail: 'alice@example.com', purpose: 'password-reset' },
+        { expiresIn: '1h' },
+      );
+      mockUserStorage.findByUserId.mockResolvedValue({
+        userId: 'u-1',
+        contactEmail: 'bob@example.com', // changed since the token was issued
+        emailVerifiedAt: null,
+      });
+      await expect(authService.resetPassword(token, 'newPass')).rejects.toThrow(/changed/);
+      expect(mockUserStorage.setPasswordByUserId).not.toHaveBeenCalled();
+    });
+
+    it('writes the new password, returns success, and sends a confirmation email', async () => {
+      const token = await jwtService.signAsync(
+        { userId: 'u-1', contactEmail: 'alice@example.com', purpose: 'password-reset' },
+        { expiresIn: '1h' },
+      );
+      mockUserStorage.findByUserId.mockResolvedValue({
+        userId: 'u-1',
+        contactEmail: 'alice@example.com',
+        emailVerifiedAt: '2026-05-22T00:00:00Z',
+        firstName: 'Alice',
+      });
+
+      const result: any = await authService.resetPassword(token, 'brand-new-password');
+
       expect(result.success).toBe(true);
-      expect(mockUserStorage.update).toHaveBeenCalledWith('user@test.com', expect.objectContaining({ email: 'user@test.com' }));
+      expect(mockUserStorage.setPasswordByUserId).toHaveBeenCalledWith(
+        'u-1',
+        expect.any(String), // the bcrypt hash, not the cleartext
+      );
+      // Confirmation email is fire-and-forget — flush microtasks before asserting.
+      await Promise.resolve();
+      await Promise.resolve();
+      expect(mockEmailService.sendTemplated).toHaveBeenCalledWith(
+        expect.objectContaining({
+          to: 'alice@example.com',
+          template: 'password-reset-confirmation',
+          tag: 'password-reset-confirmation',
+        }),
+      );
     });
   });
 

--- a/src/modules/account/auth/auth.service.ts
+++ b/src/modules/account/auth/auth.service.ts
@@ -2,7 +2,9 @@ import { BadRequestException, ConflictException, ForbiddenException, Inject, Inj
 import { VALID_GLOBAL_ROLES, VALID_PROVIDER_ROLES } from 'src/common/constants/roles';
 import { computeEffectiveConfig } from '@courthive/provider-config';
 import { createUniqueKey } from './helpers/createUniqueKey';
+import { EmailService } from '../email/email.service';
 import { UsersService } from '../../users/users.service';
+import { ConfigService } from '@nestjs/config';
 import { hashPassword } from './helpers/hashPassword';
 import { JwtService } from '@nestjs/jwt';
 import bcrypt from 'bcryptjs';
@@ -13,8 +15,6 @@ import { PROVISIONER as PROVISIONER_ROLE, SUPER_ADMIN } from 'src/common/constan
 import {
   PROVIDER_STORAGE,
   type IProviderStorage,
-  AUTH_CODE_STORAGE,
-  type IAuthCodeStorage,
   USER_STORAGE,
   type IUserStorage,
   USER_PROVISIONER_STORAGE,
@@ -27,6 +27,10 @@ import {
 import { assertProviderEditor } from './helpers/assertProviderEditor';
 import type { UserContext } from './decorators/user-context.decorator';
 
+const PASSWORD_RESET_TOKEN_TTL = '1h';
+const PASSWORD_RESET_TOKEN_TTL_MINUTES = 60;
+const PASSWORD_RESET_PURPOSE = 'password-reset';
+
 const ALLOWED_ROLE_SET = new Set([...VALID_GLOBAL_ROLES, ...VALID_PROVIDER_ROLES, 'admin', 'official', 'director']);
 
 @Injectable()
@@ -34,14 +38,31 @@ export class AuthService {
   constructor(
     private readonly usersService: UsersService,
     private readonly jwtService: JwtService,
+    private readonly emailService: EmailService,
+    private readonly configService: ConfigService,
     @Inject(PROVIDER_STORAGE) private readonly providerStorage: IProviderStorage,
-    @Inject(AUTH_CODE_STORAGE) private readonly authCodeStorage: IAuthCodeStorage,
     @Inject(USER_STORAGE) private readonly userStorage: IUserStorage,
     @Inject(USER_PROVISIONER_STORAGE) private readonly userProvisionerStorage: IUserProvisionerStorage,
     @Inject(USER_PROVIDER_STORAGE) private readonly userProviderStorage: IUserProviderStorage,
     @Inject(PROVISIONER_PROVIDER_STORAGE)
     private readonly provisionerProviderStorage: IProvisionerProviderStorage,
   ) {}
+
+  /**
+   * Build the password-reset URL placed in the email body. Same shape
+   * as the email-verification URL: lands on the admin-client public
+   * route which extracts the token, shows a "Set new password" form,
+   * POSTs to /auth/reset-password. POST-not-GET so link-previewers
+   * can't accidentally consume the single-use token.
+   */
+  private buildResetUrl(token: string): string {
+    const appConfig: any = this.configService.get('app');
+    const base = String(appConfig?.baseUrl ?? process.env.APP_BASE_URL ?? '').replace(/\/+$/, '');
+    if (!base) {
+      throw new Error('APP_BASE_URL is not set; cannot generate password-reset link.');
+    }
+    return `${base}/admin/#/reset-password/${token}`;
+  }
 
   async signIn(email: string, clearTextPassword: string) {
     if (!email) throw new UnauthorizedException();
@@ -165,33 +186,129 @@ export class AuthService {
     return await this.userStorage.updateLastSelectedProviderId(email, providerId);
   }
 
-  // TODO: implement forgot password code
-  async forgotPassword(email: string) {
-    const user = await this.usersService.findOne(email);
-    if (!user) return { error: 'User not found' };
-    const code = Math.floor(100000 + Math.random() * 900000);
-    await this.authCodeStorage.setResetCode(String(code), email);
-
-    /**
-    await sendEmailHTML({
-      to: email,
-      subject: `Reset Password Code: ${code}`,
-      templateName: 'resetPassword',
-      templateData: { code },
-    });
-    */
-    return email;
+  /**
+   * Request a password reset.
+   *
+   * The contract is *enumeration-defensive*: this endpoint always
+   * returns `{ ok: true }` regardless of whether the contact address
+   * is registered, verified, or unknown. A caller probing the API
+   * gets no signal about which contact emails are real accounts.
+   *
+   * Mail is sent only when ALL three are true:
+   *   - a user exists with this contact_email (case-insensitive)
+   *   - the user's email_verified_at is non-null
+   *   - the user has a userId
+   *
+   * Any failure inside the send branch is logged and swallowed — the
+   * response is `{ ok: true }` regardless so timing/error-shape can't
+   * be used to enumerate either.
+   *
+   * Token: signed JWT with `purpose: 'password-reset'`, includes
+   * `userId` (stable) and `contactEmail` (so a contact-email change
+   * between issue and use invalidates the link — same defense pattern
+   * as B2's email-verification). 1h expiry.
+   */
+  async forgotPassword(contactEmail: string): Promise<{ ok: true }> {
+    const trimmed = (contactEmail ?? '').trim();
+    if (!trimmed) return { ok: true };
+    try {
+      const user = await this.userStorage.findByContactEmail(trimmed);
+      if (user && user.emailVerifiedAt && user.userId && user.contactEmail) {
+        const token = await this.jwtService.signAsync(
+          {
+            userId: user.userId,
+            contactEmail: user.contactEmail,
+            purpose: PASSWORD_RESET_PURPOSE,
+          },
+          { expiresIn: PASSWORD_RESET_TOKEN_TTL },
+        );
+        await this.emailService.sendTemplated({
+          to: user.contactEmail,
+          subject: 'Reset your CourtHive password',
+          template: 'password-reset-request',
+          data: {
+            firstName: user.firstName ?? '',
+            resetUrl: this.buildResetUrl(token),
+            expiresInMinutes: PASSWORD_RESET_TOKEN_TTL_MINUTES,
+          },
+          tag: 'password-reset',
+        });
+        Logger.log(`Sent password-reset mail to ${user.contactEmail} for user ${user.userId}`);
+      } else {
+        Logger.verbose(
+          `forgotPassword: no eligible recipient for "${trimmed}" (verified=${!!user?.emailVerifiedAt})`,
+        );
+      }
+    } catch (err) {
+      // Log loudly so we can spot misdelivery / template bugs, but never
+      // surface a different response shape to the caller — that would
+      // leak whether an address is registered.
+      Logger.warn(`forgotPassword silently swallowed error: ${(err as Error).message}`);
+    }
+    return { ok: true };
   }
 
-  // TODO: implement password reset
-  async resetPassword(code: string, newPassword: string) {
-    const resetDetails: any = await this.authCodeStorage.getResetCode(code);
-    await this.authCodeStorage.deleteResetCode(code);
-    if (!resetDetails?.email) return { error: 'Invalid reset code' };
-    const user = await this.usersService.findOne(resetDetails?.email);
-    if (!user) return { error: 'User not found' };
-    user.password = await hashPassword(newPassword);
-    await this.userStorage.update(user.email, user);
+  /**
+   * Apply a password-reset token.
+   *
+   * Verifies the JWT (`purpose: 'password-reset'`), looks up the user
+   * by userId, confirms the contact_email in the token still matches
+   * the user's current contact_email (stale-token defense), writes the
+   * new hashed password, and sends a confirmation email.
+   *
+   * Throws UnauthorizedException for token shape / expiry / purpose
+   * problems and ForbiddenException for stale tokens whose contact
+   * email has been changed since issue time.
+   */
+  async resetPassword(token: string, newPassword: string) {
+    if (!token || !newPassword) return { error: 'token and newPassword are required' };
+    let claims: any;
+    try {
+      claims = await this.jwtService.verifyAsync(token);
+    } catch {
+      throw new UnauthorizedException('Invalid or expired reset link');
+    }
+    if (claims?.purpose !== PASSWORD_RESET_PURPOSE || !claims?.userId) {
+      throw new UnauthorizedException('Token is not a password-reset token');
+    }
+
+    const user = await this.userStorage.findByUserId(claims.userId);
+    if (!user) throw new UnauthorizedException();
+
+    // Stale-token defense: if contact_email was changed (which clears
+    // email_verified_at via setContactEmail), reject. Same defense as
+    // IdentityService.verifyEmailToken.
+    if (
+      claims.contactEmail &&
+      String(user.contactEmail ?? '').toLowerCase() !== String(claims.contactEmail).toLowerCase()
+    ) {
+      throw new ForbiddenException('Contact email has changed since this reset link was issued');
+    }
+
+    const hashed = await hashPassword(newPassword);
+    await this.userStorage.setPasswordByUserId(user.userId, hashed);
+
+    // Security notification — fire-and-forget so a mail failure can't
+    // roll back the password change. Logged at warn level so we notice.
+    if (user.contactEmail) {
+      this.emailService
+        .sendTemplated({
+          to: user.contactEmail,
+          subject: 'Your CourtHive password was changed',
+          template: 'password-reset-confirmation',
+          data: {
+            firstName: user.firstName ?? '',
+            changedAt: new Date().toISOString(),
+          },
+          tag: 'password-reset-confirmation',
+        })
+        .catch((err) => {
+          Logger.warn(
+            `Failed to send password-reset confirmation to ${user.contactEmail}: ${(err as Error).message}`,
+          );
+        });
+    }
+
     return { ...SUCCESS };
   }
 

--- a/src/modules/account/auth/dto/forgotPassword.dto.ts
+++ b/src/modules/account/auth/dto/forgotPassword.dto.ts
@@ -1,0 +1,9 @@
+import { ApiProperty } from '@nestjs/swagger';
+
+export class ForgotPasswordDto {
+  @ApiProperty({
+    description:
+      'Verified contact email registered with a CourtHive account. Always returns { ok: true } regardless of registration to defeat account enumeration.',
+  })
+  contactEmail: string = '';
+}

--- a/src/modules/account/auth/dto/resetPassword.dto.ts
+++ b/src/modules/account/auth/dto/resetPassword.dto.ts
@@ -1,0 +1,9 @@
+import { ApiProperty } from '@nestjs/swagger';
+
+export class ResetPasswordDto {
+  @ApiProperty({ description: 'Signed JWT carrying purpose: "password-reset" (issued by /auth/forgot-password).' })
+  token: string = '';
+
+  @ApiProperty({ description: 'New cleartext password. Minimum 8 chars enforced on the client; service hashes via bcrypt.' })
+  newPassword: string = '';
+}

--- a/src/modules/account/email/templates/password-reset-confirmation.ejs
+++ b/src/modules/account/email/templates/password-reset-confirmation.ejs
@@ -1,0 +1,49 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Your password was changed — CourtHive</title>
+</head>
+<body style="margin:0;padding:0;background-color:#f4f6f8;font-family:-apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,sans-serif;color:#1a1a1a;">
+  <table role="presentation" cellpadding="0" cellspacing="0" border="0" width="100%" style="background-color:#f4f6f8;padding:32px 16px;">
+    <tr>
+      <td align="center">
+        <table role="presentation" cellpadding="0" cellspacing="0" border="0" width="560" style="background-color:#ffffff;border-radius:8px;overflow:hidden;box-shadow:0 1px 3px rgba(0,0,0,0.08);">
+
+          <tr>
+            <td style="padding:32px 40px 16px 40px;border-bottom:1px solid #eaecef;">
+              <h1 style="margin:0;font-size:22px;font-weight:600;color:#0f172a;">Your password was changed</h1>
+            </td>
+          </tr>
+
+          <tr>
+            <td style="padding:24px 40px;font-size:15px;line-height:1.55;color:#334155;">
+              <p style="margin:0 0 16px 0;">Hi<% if (firstName) { %> <%= firstName %><% } %>,</p>
+
+              <p style="margin:0 0 16px 0;">
+                Your CourtHive account password was just changed via the password-reset flow.
+              </p>
+
+              <p style="margin:0 0 16px 0;">
+                <strong>Time:</strong> <%= changedAt %>
+              </p>
+
+              <p style="margin:0;color:#b91c1c;">
+                If you didn&rsquo;t make this change, contact your administrator immediately &mdash; your account may be compromised.
+              </p>
+            </td>
+          </tr>
+
+          <tr>
+            <td style="padding:16px 40px 32px 40px;border-top:1px solid #eaecef;font-size:12px;color:#94a3b8;">
+              This is a security notification. You don&rsquo;t need to do anything if you initiated the change.
+            </td>
+          </tr>
+
+        </table>
+      </td>
+    </tr>
+  </table>
+</body>
+</html>

--- a/src/modules/account/email/templates/password-reset-request.ejs
+++ b/src/modules/account/email/templates/password-reset-request.ejs
@@ -1,0 +1,59 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Reset your password — CourtHive</title>
+</head>
+<body style="margin:0;padding:0;background-color:#f4f6f8;font-family:-apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,sans-serif;color:#1a1a1a;">
+  <table role="presentation" cellpadding="0" cellspacing="0" border="0" width="100%" style="background-color:#f4f6f8;padding:32px 16px;">
+    <tr>
+      <td align="center">
+        <table role="presentation" cellpadding="0" cellspacing="0" border="0" width="560" style="background-color:#ffffff;border-radius:8px;overflow:hidden;box-shadow:0 1px 3px rgba(0,0,0,0.08);">
+
+          <tr>
+            <td style="padding:32px 40px 16px 40px;border-bottom:1px solid #eaecef;">
+              <h1 style="margin:0;font-size:22px;font-weight:600;color:#0f172a;">Reset your password</h1>
+            </td>
+          </tr>
+
+          <tr>
+            <td style="padding:24px 40px;font-size:15px;line-height:1.55;color:#334155;">
+              <p style="margin:0 0 16px 0;">Hi<% if (firstName) { %> <%= firstName %><% } %>,</p>
+
+              <p style="margin:0 0 16px 0;">
+                Someone requested a password reset for your CourtHive account. If that was you, click the button below to set a new password.
+              </p>
+
+              <p style="margin:0 0 24px 0;">This link expires in <strong><%= expiresInMinutes %> minutes</strong>.</p>
+
+              <table role="presentation" cellpadding="0" cellspacing="0" border="0" style="margin:0 auto;">
+                <tr>
+                  <td style="background-color:#0f766e;border-radius:6px;">
+                    <a href="<%= resetUrl %>" target="_blank" rel="noopener"
+                       style="display:inline-block;padding:12px 24px;font-size:15px;font-weight:600;color:#ffffff;text-decoration:none;">
+                      Reset password
+                    </a>
+                  </td>
+                </tr>
+              </table>
+
+              <p style="margin:24px 0 0 0;font-size:13px;color:#64748b;">
+                If the button doesn&rsquo;t work, paste this link into your browser:<br />
+                <a href="<%= resetUrl %>" style="color:#0f766e;word-break:break-all;"><%= resetUrl %></a>
+              </p>
+            </td>
+          </tr>
+
+          <tr>
+            <td style="padding:16px 40px 32px 40px;border-top:1px solid #eaecef;font-size:12px;color:#94a3b8;">
+              If you didn&rsquo;t request a password reset, ignore this email &mdash; your password is unchanged.
+            </td>
+          </tr>
+
+        </table>
+      </td>
+    </tr>
+  </table>
+</body>
+</html>

--- a/src/storage/interfaces/user-storage.interface.ts
+++ b/src/storage/interfaces/user-storage.interface.ts
@@ -40,4 +40,17 @@ export interface IUserStorage {
    * successful token validation.
    */
   markEmailVerified(userId: string): Promise<{ success: boolean }>;
+  /**
+   * Look up a user by uuid primary key. Used by the B3 password-reset
+   * flow which carries `userId` in the reset token rather than `email`
+   * (the login id can change in principle; userId is stable).
+   */
+  findByUserId(userId: string): Promise<any | null>;
+  /**
+   * Atomic password write keyed by `userId`. Also clears
+   * `must_change_password` because a successful password reset is an
+   * explicit user-initiated set — no need to force them to change it
+   * again on next login.
+   */
+  setPasswordByUserId(userId: string, hashedPassword: string): Promise<{ success: boolean }>;
 }

--- a/src/storage/postgres/postgres-user.storage.ts
+++ b/src/storage/postgres/postgres-user.storage.ts
@@ -140,6 +140,46 @@ export class PostgresUserStorage implements IUserStorage {
     return { ...SUCCESS };
   }
 
+  async findByUserId(userId: string): Promise<any | null> {
+    const result = await this.pool.query(
+      `SELECT user_id, email, password, provider_id, last_selected_provider_id, must_change_password, contact_email, email_verified_at, roles, permissions, data
+         FROM users
+        WHERE user_id = $1
+        LIMIT 1`,
+      [userId],
+    );
+    if (!result.rows.length) return null;
+    const row = result.rows[0];
+    return {
+      userId: row.user_id,
+      email: row.email,
+      password: row.password,
+      providerId: row.provider_id,
+      lastSelectedProviderId: row.last_selected_provider_id,
+      mustChangePassword: row.must_change_password,
+      contactEmail: row.contact_email,
+      emailVerifiedAt: row.email_verified_at,
+      roles: row.roles,
+      permissions: row.permissions,
+      ...row.data,
+    };
+  }
+
+  async setPasswordByUserId(userId: string, hashedPassword: string): Promise<{ success: boolean }> {
+    // Single-query atomic password write. Also clears must_change_password
+    // — a successful self-initiated password reset is a stronger signal
+    // than the assigned-password state, so no need to force another change.
+    await this.pool.query(
+      `UPDATE users
+          SET password = $2,
+              must_change_password = FALSE,
+              updated_at = NOW()
+        WHERE user_id = $1`,
+      [userId, hashedPassword],
+    );
+    return { ...SUCCESS };
+  }
+
   async remove(email: string): Promise<{ success: boolean }> {
     await this.pool.query('DELETE FROM users WHERE email = $1', [email]);
     return { ...SUCCESS };


### PR DESCRIPTION
## Summary

Phase B3 of the email + identity workstream. Wires the password-reset flow end-to-end on top of B2's verified \`contact_email\`. Replaces the legacy 6-digit-code stub (commented-out \`sendEmailHTML\` call, never actually delivered) with a signed-JWT-link flow that mirrors B2's email-verification pattern.

**With this PR merged, users finally have a working self-service password reset.**

## What's in

### Server endpoints

- **\`POST /auth/forgot-password\`** — body \`{ contactEmail }\`. **Enumeration-defensive: always returns \`{ ok: true }\`** regardless of whether the address is registered, verified, or unknown. Mail is sent only when a user has a verified contact_email. Any failure inside the send branch is logged and swallowed — response shape never leaks registration state.
- **\`POST /auth/reset-password\`** — body \`{ token, newPassword }\`. Verifies JWT (\`purpose: 'password-reset'\`, 1h expiry), looks up user by \`userId\`, defensively rejects stale tokens whose \`contact_email\` no longer matches the user's current address (same defense as B2's verify-email), writes new bcrypt hash atomically via the new \`setPasswordByUserId\` helper, fires a fire-and-forget confirmation email.

### Storage layer

Two new atomic helpers on \`IUserStorage\`:
- \`findByUserId(userId)\` — stable PK lookup (login \`email\` can change in principle; \`userId\` cannot)
- \`setPasswordByUserId(userId, hashedPassword)\` — also clears \`must_change_password\` since a self-initiated reset is a stronger signal than the admin-assigned-temp-password state

### Email templates

Two new EJS templates under \`src/modules/account/email/templates/\`:
- \`password-reset-request.ejs\` — the link the user clicks
- \`password-reset-confirmation.ejs\` — security notification sent after a successful reset, delivered to whatever the contact_email is at reset time (not the in-token value), so a user whose contact_email is current always gets notified

### Admin client

- \`forgotPasswordModal\` — single-field form. Always shows the same "If we know you, a link is on the way" toast on success, no UI signal about registration state (enumeration defense parity).
- Public \`/reset-password/:token\` route + page — new-password + confirm form. POSTs token to \`/auth/reset-password\`. Same link-previewer defense as verify-email (POST not GET so URL-fetchers can't consume the token).
- **"Forgot your password?" link on the login modal** — opens forgotPasswordModal. Always visible, not just on auth failure.

### Tests

7 new server tests (forgotPassword enumeration-defense paths + happy path + send-failure path; resetPassword token validation + user-not-found + stale-token defense + happy path). Existing forgot/reset tests rewritten end-to-end. Server total: **743/743** (was 736, +7).

## Microservice boundary

All new code stays under \`src/modules/account/\`. \`AuthService\` now uses \`EmailService\` from the sibling email module (importing via \`AuthModule\`'s new \`EmailModule\` import). The cross-account-module dependency is intentional and within the boundary.

## Out of scope

- **B4** — admin-create-user emails the new user when their contact_email is available, instead of (or in addition to) the clipboard handoff we shipped in PR #671. Last phase of the B-track.

## Test plan

- [ ] Pull, build, deploy to mentat
- [ ] As a user with a verified contact_email: click "Forgot your password?" on the login modal → submit → check email → click link → set new password → log in with the new password ✓
- [ ] After successful reset, confirm the security-notification email arrives at the contact_email
- [ ] As a user with an UNVERIFIED contact_email: same flow → toast says "if we know you, a link is on the way" but no email actually arrives (enumeration defense)
- [ ] As a user without any contact_email: same — no email
- [ ] Type an unknown address: same toast, no email
- [ ] Click an expired link (wait >1h) → "reset link has expired" error
- [ ] Change contact_email between requesting and clicking → "no longer matches" error (stale token defense)
- [ ] Try to use a reset token in the Authorization header on a normal endpoint → still 401 (middleware filter holds)

## Deploy notes

No schema changes in this PR. \`APP_BASE_URL\` is already in place from B2's deploy. Existing migration 028 is enough. Just merge + run \`mentat-push-all.sh\`.

## CI matrix

- Server: \`pnpm lint\` ✓ · \`check-types\` ✓ · 743/743 tests ✓ · \`build\` ✓
- Admin-client: \`pnpm lint\` ✓ · \`check-types\` ✓ · tests ✓ · \`build\` ✓
- Templates: all three (email-verification, password-reset-request, password-reset-confirmation) ship at \`build/src/modules/account/email/templates/\`