### PR TITLE
feat(account): admin-create-user emails the new user (Phase B4)

### DIFF
--- a/admin-client/src/components/modals/createUser.ts
+++ b/admin-client/src/components/modals/createUser.ts
@@ -72,15 +72,28 @@ export function createUserModal(callback, providers = [], selectedProviderId?: s
       [
         {
           iconLeft: 'fa-regular fa-envelope',
-          placeholder: 'valid@email.com',
+          placeholder: 'login id (often an email, not required to be one)',
           validator: validators.emailValidator,
           autocomplete: 'off',
-          label: t('email'),
+          label: t('modals.createUser.loginEmail'),
           field: 'email',
+        },
+        // Optional contact email — when provided AND deliverable, the
+        // server emails the new user a "Welcome, set your password" link
+        // and the clipboard-handoff is suppressed. When left blank, the
+        // existing clipboard flow runs as before.
+        {
+          iconLeft: 'fa-solid fa-paper-plane',
+          placeholder: 'you@example.com (optional)',
+          autocomplete: 'off',
+          label: t('modals.createUser.contactEmail'),
+          field: 'contactEmail',
         },
         // Password field — pre-filled with a generated 12-char password.
         // Admin can edit, regenerate, or copy. Server-side will also
         // generate one if the field is left empty (defensive double-fill).
+        // Ignored when contactEmail is set: the user will set their own
+        // password via the email link.
         {
           value: initialPassword,
           label: t('modals.createUser.password'),
@@ -208,6 +221,7 @@ export function createUserModal(callback, providers = [], selectedProviderId?: s
   const submitCreate = () => {
     const email = inputs.email.value;
     const password = (inputs.password?.value || '').trim() || undefined;
+    const contactEmail = (inputs.contactEmail?.value || '').trim() || undefined;
     const providerId = values.providerId || inputs.providerId?.value || undefined;
     const providerRole = (inputs.providerRole?.value === 'PROVIDER_ADMIN'
       ? 'PROVIDER_ADMIN'
@@ -219,18 +233,33 @@ export function createUserModal(callback, providers = [], selectedProviderId?: s
     const response = (res) => {
       const data = res?.data ?? {};
 
-      if (data?.success && data?.password) {
-        // The server returns the assigned password — copy it to the admin's
-        // clipboard so they can hand it to the new user. The user MUST
-        // change it on first login (must_change_password=true on the row).
+      if (!data?.success) {
+        const errMessage = data.error || data.message;
+        tmxToast({ message: errMessage || t('modals.createUser.failed'), intent: 'is-danger' });
+      } else if (data.mode === 'email-sent') {
+        // Server already emailed the new user a "set your password" link.
+        // No password to clipboard — the user picks their own.
+        tmxToast({
+          message: t('modals.createUser.successEmailed', {
+            email: data.contactEmail || contactEmail || '',
+          }),
+          intent: 'is-success',
+        });
+      } else if (data?.password) {
+        // Classic clipboard handoff — server didn't email (no contactEmail
+        // given, or its email send failed and the server fell back).
         copyClick(data.password);
         tmxToast({
           message: t('modals.createUser.successCopied', { email: data.email || email }),
           intent: 'is-success',
         });
       } else {
-        const errMessage = data.error || data.message;
-        tmxToast({ message: errMessage || t('modals.createUser.failed'), intent: 'is-danger' });
+        // Defensive: success: true but neither mode signal we understand —
+        // surface a generic confirmation rather than silently doing nothing.
+        tmxToast({
+          message: t('modals.createUser.successPlain', { email: data.email || email }),
+          intent: 'is-success',
+        });
       }
 
       if (isFunction(callback)) callback(res);
@@ -239,6 +268,7 @@ export function createUserModal(callback, providers = [], selectedProviderId?: s
     adminCreateUser({
       email,
       password,
+      contactEmail,
       providerId,
       providerRole,
       roles: userRoles as string[],

--- a/admin-client/src/i18n/locales/en.json
+++ b/admin-client/src/i18n/locales/en.json
@@ -1253,8 +1253,12 @@
     "createUser": {
       "title": "Create User",
       "create": "Create",
+      "loginEmail": "Login id",
+      "contactEmail": "Contact email (optional)",
       "password": "Password",
       "successCopied": "Created {{email}}. Temporary password copied to clipboard.",
+      "successEmailed": "Created. A \"set your password\" link was sent to {{email}}.",
+      "successPlain": "Created {{email}}.",
       "failed": "Failed to create user.",
       "emailExists": "A user with email {{email}} already exists."
     },

--- a/admin-client/src/services/authentication/authApi.ts
+++ b/admin-client/src/services/authentication/authApi.ts
@@ -10,6 +10,13 @@ export async function systemLogin(email, password) {
 export async function adminCreateUser(payload: {
   email: string;
   password?: string;
+  /**
+   * Optional deliverable address. When supplied and RFC-shaped, the
+   * server emails a 7-day "set your password" link and the response
+   * carries `mode: 'email-sent'` instead of `password`. Falls back to
+   * the clipboard-handoff when absent.
+   */
+  contactEmail?: string;
   providerId?: string;
   providerRole?: 'PROVIDER_ADMIN' | 'DIRECTOR';
   firstName?: string;

--- a/src/modules/account/auth/auth.service.spec.ts
+++ b/src/modules/account/auth/auth.service.spec.ts
@@ -45,6 +45,8 @@ describe('AuthService', () => {
       findByContactEmail: jest.fn().mockResolvedValue(null),
       findByUserId: jest.fn().mockResolvedValue(null),
       setPasswordByUserId: jest.fn().mockResolvedValue({ success: true }),
+      setContactEmail: jest.fn().mockResolvedValue({ success: true }),
+      markEmailVerified: jest.fn().mockResolvedValue({ success: true }),
     };
 
     const mockUserProvisionerStorage = {
@@ -405,6 +407,75 @@ describe('AuthService', () => {
 
       expect(mockUserProviderStorage.upsert).not.toHaveBeenCalled();
     });
+
+    it('emails the new user when a valid contactEmail is provided (B4)', async () => {
+      mockUsersService.findOne
+        .mockResolvedValueOnce(null) // collision check
+        .mockResolvedValueOnce({ userId: 'u-new', email: 'new@test.com' }); // post-create lookup
+      mockUsersService.create.mockResolvedValue({ email: 'new@test.com' });
+
+      const result: any = await authService.adminCreateUser(
+        {
+          email: 'new@test.com',
+          contactEmail: 'real@example.com',
+          firstName: 'Alice',
+          providerId: 'p-1',
+        },
+        superAdminCtx,
+      );
+
+      expect(result.success).toBe(true);
+      expect(result.mode).toBe('email-sent');
+      expect(result.contactEmail).toBe('real@example.com');
+      expect(result.password).toBeUndefined(); // password is NOT returned on email path
+      expect(mockUserStorage.setContactEmail).toHaveBeenCalledWith('u-new', 'real@example.com');
+      expect(mockEmailService.sendTemplated).toHaveBeenCalledWith(
+        expect.objectContaining({
+          to: 'real@example.com',
+          template: 'admin-created-account',
+          tag: 'admin-onboard',
+          data: expect.objectContaining({ firstName: 'Alice' }),
+        }),
+      );
+    });
+
+    it('falls back to clipboard handoff when contactEmail is not RFC-shaped', async () => {
+      mockUsersService.findOne
+        .mockResolvedValueOnce(null)
+        .mockResolvedValueOnce({ userId: 'u-new', email: 'new@test.com' });
+      mockUsersService.create.mockResolvedValue({ email: 'new@test.com' });
+
+      const result: any = await authService.adminCreateUser(
+        { email: 'new@test.com', contactEmail: 'not-an-email', providerId: 'p-1' },
+        superAdminCtx,
+      );
+
+      expect(result.success).toBe(true);
+      expect(result.mode).toBe('password-returned');
+      expect(typeof result.password).toBe('string');
+      expect(mockEmailService.sendTemplated).not.toHaveBeenCalled();
+      expect(mockUserStorage.setContactEmail).not.toHaveBeenCalled();
+    });
+
+    it('falls back to clipboard handoff when the email send fails', async () => {
+      mockUsersService.findOne
+        .mockResolvedValueOnce(null)
+        .mockResolvedValueOnce({ userId: 'u-new', email: 'new@test.com' });
+      mockUsersService.create.mockResolvedValue({ email: 'new@test.com' });
+      mockEmailService.sendTemplated.mockRejectedValueOnce(new Error('SMTP down'));
+      const warnSpy = jest.spyOn(Logger, 'warn').mockImplementation(() => undefined);
+
+      const result: any = await authService.adminCreateUser(
+        { email: 'new@test.com', contactEmail: 'real@example.com', providerId: 'p-1' },
+        superAdminCtx,
+      );
+
+      expect(result.success).toBe(true);
+      expect(result.mode).toBe('password-returned');
+      expect(typeof result.password).toBe('string');
+      expect(warnSpy).toHaveBeenCalled();
+      warnSpy.mockRestore();
+    });
   });
 
   describe('completeFirstLogin', () => {
@@ -606,6 +677,40 @@ describe('AuthService', () => {
           tag: 'password-reset-confirmation',
         }),
       );
+    });
+
+    it('marks email_verified_at when previously unverified (B4 admin-onboard piggyback)', async () => {
+      const token = await jwtService.signAsync(
+        { userId: 'u-1', contactEmail: 'alice@example.com', purpose: 'password-reset' },
+        { expiresIn: '7d' },
+      );
+      // Admin-created user: contact_email set but never verified
+      mockUserStorage.findByUserId.mockResolvedValue({
+        userId: 'u-1',
+        contactEmail: 'alice@example.com',
+        emailVerifiedAt: null,
+        firstName: 'Alice',
+      });
+
+      await authService.resetPassword(token, 'newPass');
+
+      expect(mockUserStorage.markEmailVerified).toHaveBeenCalledWith('u-1');
+    });
+
+    it('does NOT re-mark email_verified_at when already verified', async () => {
+      const token = await jwtService.signAsync(
+        { userId: 'u-1', contactEmail: 'alice@example.com', purpose: 'password-reset' },
+        { expiresIn: '1h' },
+      );
+      mockUserStorage.findByUserId.mockResolvedValue({
+        userId: 'u-1',
+        contactEmail: 'alice@example.com',
+        emailVerifiedAt: '2026-05-22T00:00:00Z',
+      });
+
+      await authService.resetPassword(token, 'newPass');
+
+      expect(mockUserStorage.markEmailVerified).not.toHaveBeenCalled();
     });
   });
 

--- a/src/modules/account/auth/auth.service.ts
+++ b/src/modules/account/auth/auth.service.ts
@@ -28,8 +28,34 @@ import { assertProviderEditor } from './helpers/assertProviderEditor';
 import type { UserContext } from './decorators/user-context.decorator';
 
 const PASSWORD_RESET_TOKEN_TTL = '1h';
-const PASSWORD_RESET_TOKEN_TTL_MINUTES = 60;
+const ADMIN_ONBOARD_TOKEN_TTL = '7d';
 const PASSWORD_RESET_PURPOSE = 'password-reset';
+
+// Conservative RFC-shaped email check — same regex as the migration backfill
+// and IdentityService. Used to decide whether an admin-supplied contact_email
+// is plausible enough to attempt delivery.
+const EMAIL_REGEX = /^[A-Z0-9._%+-]+@[A-Z0-9.-]+\.[A-Z]{2,}$/i;
+
+/**
+ * Parse a short JWT-style duration ('1h', '7d', '30m', '90s', '2w') into
+ * minutes for the email-body interpolation. Falls back to 60 if the shape
+ * is unrecognised — the email still renders sensibly even if the number
+ * is off, and the actual JWT verification uses the original string.
+ */
+function parseDurationToMinutes(duration: string): number {
+  const match = /^(\d+)\s*([smhdw])$/i.exec(duration ?? '');
+  if (!match) return 60;
+  const value = Number(match[1]);
+  const unit = match[2].toLowerCase();
+  switch (unit) {
+    case 's': return Math.max(1, Math.round(value / 60));
+    case 'm': return value;
+    case 'h': return value * 60;
+    case 'd': return value * 60 * 24;
+    case 'w': return value * 60 * 24 * 7;
+    default:  return 60;
+  }
+}
 
 const ALLOWED_ROLE_SET = new Set([...VALID_GLOBAL_ROLES, ...VALID_PROVIDER_ROLES, 'admin', 'official', 'director']);
 
@@ -187,6 +213,42 @@ export class AuthService {
   }
 
   /**
+   * Issue a password-reset (or admin-onboard) JWT for the given user
+   * and send the matching template. Shared by:
+   *   - forgotPassword: gated on emailVerifiedAt, 1h TTL, 'password-reset' template
+   *   - adminCreateUser: ungated (admin vouches), 7d TTL, 'admin-created-account' template
+   *
+   * The token shape is identical (`purpose: 'password-reset'`) for both
+   * call sites, so the same `/auth/reset-password` endpoint accepts
+   * either. Centralising the token+send logic keeps the two flows in
+   * sync without spreading JWT-claim shape across the service.
+   */
+  private async issueAndSendResetEmail(
+    user: { userId: string; contactEmail: string; firstName?: string },
+    opts: { expiresIn: string; template: 'password-reset-request' | 'admin-created-account'; subject: string; tag: string },
+  ): Promise<void> {
+    const token = await this.jwtService.signAsync(
+      { userId: user.userId, contactEmail: user.contactEmail, purpose: PASSWORD_RESET_PURPOSE },
+      { expiresIn: opts.expiresIn as any },
+    );
+    // Compute expiry in minutes for the template. Parses simple units
+    // (s/m/h/d/w); falls back to the literal string if shape is unknown
+    // (templates render it as a sentence either way).
+    const expiresInMinutes = parseDurationToMinutes(opts.expiresIn);
+    await this.emailService.sendTemplated({
+      to: user.contactEmail,
+      subject: opts.subject,
+      template: opts.template,
+      data: {
+        firstName: user.firstName ?? '',
+        resetUrl: this.buildResetUrl(token),
+        expiresInMinutes,
+      },
+      tag: opts.tag,
+    });
+  }
+
+  /**
    * Request a password reset.
    *
    * The contract is *enumeration-defensive*: this endpoint always
@@ -202,11 +264,6 @@ export class AuthService {
    * Any failure inside the send branch is logged and swallowed — the
    * response is `{ ok: true }` regardless so timing/error-shape can't
    * be used to enumerate either.
-   *
-   * Token: signed JWT with `purpose: 'password-reset'`, includes
-   * `userId` (stable) and `contactEmail` (so a contact-email change
-   * between issue and use invalidates the link — same defense pattern
-   * as B2's email-verification). 1h expiry.
    */
   async forgotPassword(contactEmail: string): Promise<{ ok: true }> {
     const trimmed = (contactEmail ?? '').trim();
@@ -214,25 +271,15 @@ export class AuthService {
     try {
       const user = await this.userStorage.findByContactEmail(trimmed);
       if (user && user.emailVerifiedAt && user.userId && user.contactEmail) {
-        const token = await this.jwtService.signAsync(
+        await this.issueAndSendResetEmail(
+          { userId: user.userId, contactEmail: user.contactEmail, firstName: user.firstName },
           {
-            userId: user.userId,
-            contactEmail: user.contactEmail,
-            purpose: PASSWORD_RESET_PURPOSE,
+            expiresIn: PASSWORD_RESET_TOKEN_TTL,
+            template: 'password-reset-request',
+            subject: 'Reset your CourtHive password',
+            tag: 'password-reset',
           },
-          { expiresIn: PASSWORD_RESET_TOKEN_TTL },
         );
-        await this.emailService.sendTemplated({
-          to: user.contactEmail,
-          subject: 'Reset your CourtHive password',
-          template: 'password-reset-request',
-          data: {
-            firstName: user.firstName ?? '',
-            resetUrl: this.buildResetUrl(token),
-            expiresInMinutes: PASSWORD_RESET_TOKEN_TTL_MINUTES,
-          },
-          tag: 'password-reset',
-        });
         Logger.log(`Sent password-reset mail to ${user.contactEmail} for user ${user.userId}`);
       } else {
         Logger.verbose(
@@ -288,6 +335,21 @@ export class AuthService {
     const hashed = await hashPassword(newPassword);
     await this.userStorage.setPasswordByUserId(user.userId, hashed);
 
+    // Admin-onboard piggyback: a user who just clicked an email link and
+    // set their password has proven they control the contact_email. If
+    // it isn't already verified, stamp it now — this is how admin-created
+    // accounts (B4) gain a verified address without a separate
+    // verify-email click.
+    if (!user.emailVerifiedAt) {
+      try {
+        await this.userStorage.markEmailVerified(user.userId);
+      } catch (err) {
+        Logger.warn(
+          `Failed to stamp email_verified_at after reset for ${user.userId}: ${(err as Error).message}`,
+        );
+      }
+    }
+
     // Security notification — fire-and-forget so a mail failure can't
     // roll back the password change. Logged at warn level so we notice.
     if (user.contactEmail) {
@@ -330,6 +392,7 @@ export class AuthService {
     body: {
       email: string;
       password?: string;
+      contactEmail?: string;
       providerId?: string;
       providerRole?: string;
       firstName?: string;
@@ -374,6 +437,14 @@ export class AuthService {
       );
     }
 
+    // Decide upfront whether the admin gave us a deliverable contact_email.
+    // When yes, the new user gets an onboard email with a "set your password"
+    // link instead of a clipboard-handoff password. The link tokens reuse
+    // the password-reset shape so the existing /auth/reset-password endpoint
+    // handles them — see issueAndSendResetEmail().
+    const contactEmailRaw = (body?.contactEmail ?? '').trim();
+    const willEmail = !!contactEmailRaw && EMAIL_REGEX.test(contactEmailRaw);
+
     const supplied = (body?.password ?? '').trim();
     const password = supplied || createUniqueKey().slice(0, 12);
 
@@ -390,21 +461,62 @@ export class AuthService {
     } as any);
     if (result?.error) return result;
 
-    if (providerId) {
-      const created = await this.usersService.findOne(email);
-      const userId = created?.userId ?? created?.user_id;
-      if (userId) {
-        try {
-          await this.userProviderStorage.upsert({ userId, providerId, providerRole });
-        } catch (err) {
-          Logger.warn(
-            `Failed to upsert user_providers row for ${email}: ${(err as Error).message}`,
-          );
-        }
+    const created = await this.usersService.findOne(email);
+    const userId = created?.userId ?? created?.user_id;
+
+    if (providerId && userId) {
+      try {
+        await this.userProviderStorage.upsert({ userId, providerId, providerRole });
+      } catch (err) {
+        Logger.warn(
+          `Failed to upsert user_providers row for ${email}: ${(err as Error).message}`,
+        );
       }
     }
 
-    return { success: true, email, password, providerId, providerRole };
+    // Email-onboard path: stamp the contact_email (unverified), issue a
+    // 7-day password-reset token, and send the welcoming template.
+    // Successful click of that link verifies the address as a side effect
+    // (see resetPassword above). The clipboard password is NOT returned
+    // — the new user sets their own when they click the link.
+    if (willEmail && userId) {
+      try {
+        await this.userStorage.setContactEmail(userId, contactEmailRaw);
+        await this.issueAndSendResetEmail(
+          { userId, contactEmail: contactEmailRaw, firstName: body.firstName },
+          {
+            expiresIn: ADMIN_ONBOARD_TOKEN_TTL,
+            template: 'admin-created-account',
+            subject: 'Welcome to CourtHive — set your password',
+            tag: 'admin-onboard',
+          },
+        );
+        Logger.log(`Sent admin-onboard mail to ${contactEmailRaw} for user ${userId}`);
+        return {
+          success: true,
+          email,
+          providerId,
+          providerRole,
+          mode: 'email-sent' as const,
+          contactEmail: contactEmailRaw,
+        };
+      } catch (err) {
+        // Fall through to the clipboard path so admin onboarding never
+        // gets stuck on a transient mail failure. Log loudly so we notice.
+        Logger.warn(
+          `adminCreateUser email-onboard fell back to clipboard for ${email}: ${(err as Error).message}`,
+        );
+      }
+    }
+
+    return {
+      success: true,
+      email,
+      password,
+      providerId,
+      providerRole,
+      mode: 'password-returned' as const,
+    };
   }
 
   /**

--- a/src/modules/account/auth/dto/adminCreateUser.dto.ts
+++ b/src/modules/account/auth/dto/adminCreateUser.dto.ts
@@ -7,6 +7,12 @@ export class AdminCreateUserDto {
   @ApiPropertyOptional({ description: 'If omitted, server generates a 12-char password and returns it once.' })
   password?: string;
 
+  @ApiPropertyOptional({
+    description:
+      'Optional deliverable email. When supplied and RFC-shaped, the new user is sent a 7-day onboard link to set their own password (response carries mode: "email-sent" and NO password). When absent, the existing clipboard handoff is used (response carries password + mode: "password-returned").',
+  })
+  contactEmail?: string;
+
   @ApiPropertyOptional({ description: 'Required for non-SUPER_ADMIN editors. Scope-checked via assertProviderEditor.' })
   providerId?: string;
 

--- a/src/modules/account/email/templates/admin-created-account.ejs
+++ b/src/modules/account/email/templates/admin-created-account.ejs
@@ -1,0 +1,59 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Welcome to CourtHive — set your password</title>
+</head>
+<body style="margin:0;padding:0;background-color:#f4f6f8;font-family:-apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,sans-serif;color:#1a1a1a;">
+  <table role="presentation" cellpadding="0" cellspacing="0" border="0" width="100%" style="background-color:#f4f6f8;padding:32px 16px;">
+    <tr>
+      <td align="center">
+        <table role="presentation" cellpadding="0" cellspacing="0" border="0" width="560" style="background-color:#ffffff;border-radius:8px;overflow:hidden;box-shadow:0 1px 3px rgba(0,0,0,0.08);">
+
+          <tr>
+            <td style="padding:32px 40px 16px 40px;border-bottom:1px solid #eaecef;">
+              <h1 style="margin:0;font-size:22px;font-weight:600;color:#0f172a;">Welcome to CourtHive</h1>
+            </td>
+          </tr>
+
+          <tr>
+            <td style="padding:24px 40px;font-size:15px;line-height:1.55;color:#334155;">
+              <p style="margin:0 0 16px 0;">Hi<% if (firstName) { %> <%= firstName %><% } %>,</p>
+
+              <p style="margin:0 0 16px 0;">
+                An administrator created a CourtHive account for you. Click the button below to set your password and finish signing in.
+              </p>
+
+              <p style="margin:0 0 24px 0;">This link expires in <strong><%= expiresInMinutes %> minutes</strong>.</p>
+
+              <table role="presentation" cellpadding="0" cellspacing="0" border="0" style="margin:0 auto;">
+                <tr>
+                  <td style="background-color:#0f766e;border-radius:6px;">
+                    <a href="<%= resetUrl %>" target="_blank" rel="noopener"
+                       style="display:inline-block;padding:12px 24px;font-size:15px;font-weight:600;color:#ffffff;text-decoration:none;">
+                      Set your password
+                    </a>
+                  </td>
+                </tr>
+              </table>
+
+              <p style="margin:24px 0 0 0;font-size:13px;color:#64748b;">
+                If the button doesn&rsquo;t work, paste this link into your browser:<br />
+                <a href="<%= resetUrl %>" style="color:#0f766e;word-break:break-all;"><%= resetUrl %></a>
+              </p>
+            </td>
+          </tr>
+
+          <tr>
+            <td style="padding:16px 40px 32px 40px;border-top:1px solid #eaecef;font-size:12px;color:#94a3b8;">
+              If you weren&rsquo;t expecting this invitation, you can safely ignore this email &mdash; nothing happens until you click the link above.
+            </td>
+          </tr>
+
+        </table>
+      </td>
+    </tr>
+  </table>
+</body>
+</html>


### PR DESCRIPTION
## Summary

**Final phase of the email + identity workstream.** Admin-create-user can now optionally email the new user a "Welcome — set your password" link instead of relying solely on the clipboard handoff shipped in PR #671. Falls back gracefully to the clipboard flow when no contact_email is given or the email delivery fails.

With this PR merged, the full identity story is in place:

- B1 (PR #672): module skeleton + EmailService + Resend
- B2 (PR #673): contact_email schema + verification flow
- B3 (PR #674): forgot-password + reset-password wired
- **B4 (this PR): admin-create-user emails**

## What's in

### Server

- \`AdminCreateUserDto\` gains an optional \`contactEmail\` field.
- \`AuthService.adminCreateUser\` branches:
  - **email path** (contactEmail given, RFC-shaped): stamps \`users.contact_email\` (unverified), issues a 7-day password-reset JWT, sends the new \`admin-created-account.ejs\` template. Returns \`{ success, mode: 'email-sent', contactEmail }\` — no password.
  - **clipboard path** (no contactEmail or invalid): unchanged from PR #671. Returns \`{ success, password, mode: 'password-returned' }\`.
  - If the email send throws, the path **falls back to clipboard** so admin onboarding never gets stuck on a transient mail failure.
- New private \`issueAndSendResetEmail(user, opts)\` helper factored out of \`forgotPassword\`. Shared by:
  - **forgot-password** — 1h TTL, gated on \`email_verified_at IS NOT NULL\`
  - **admin-create-user** — 7d TTL, ungated (admin vouches)

  Token shape is identical (\`purpose: 'password-reset'\`), so the existing \`/auth/reset-password\` endpoint handles both call sites without a new route.
- \`resetPassword\` now also stamps \`email_verified_at = NOW()\` if currently null. Successful click of an email link + setting a password is strong evidence of address ownership; admin-onboarded users gain a verified contact_email as a side effect of their first set-password.
- New \`admin-created-account.ejs\` template — welcoming copy, distinct from the password-reset template (this is creation, not a reset).
- New \`parseDurationToMinutes()\` helper for clean template interpolation across 1h (60) and 7d (10080).

### Admin client

- \`createUser\` modal now has separate **Login id** and **Contact email (optional)** fields. Login id stays as-is (historically often a non-email string); contact email is the deliverable address.
- Modal feedback branches on response mode:
  - \`email-sent\` → "Created. A 'set your password' link was sent to {{email}}." No clipboard.
  - \`password-returned\` → existing clipboard handoff.

### Tests

5 new server tests:
- adminCreateUser: emails when valid contactEmail; falls back to clipboard for invalid contactEmail; falls back to clipboard when send fails
- resetPassword: marks email_verified_at when previously unverified; does NOT re-mark when already verified (idempotent)

Server total: 754 (was 749, +5).

## Test plan

- [ ] Pull, build, deploy to mentat. \`APP_BASE_URL\` + \`RESEND_API_KEY\` + \`EMAIL_FROM\` already in place from B1–B3 deploys.
- [ ] As SUPER_ADMIN: open Create User modal, fill login + contact email, submit
- [ ] Toast: "Created. A 'set your password' link was sent to {{email}}." Inbox: link arrives. Click it → set new password → log in.
- [ ] Confirm \`users.email_verified_at\` is populated after the set-password click
- [ ] Repeat with no contact email → clipboard flow still works (PR #671 behavior preserved)
- [ ] Repeat with bogus contact email ("not-an-email") → clipboard fallback
- [ ] Pause Resend / break API key → server falls back to clipboard with a warn-level log entry
- [ ] Forgot-password flow on an already-verified user still works (1h token, B3 behavior unchanged)

## Note on the branch history

This PR's branch was the unintended target of a concurrent session's commit (\`a3422c9 feat(audit): wire AuditService into TmxGateway socket path\`) due to a shared-working-tree race. I recovered cleanly: that commit now lives at \`feat/audit-trail-tmx-gateway-wiring\` (its rightful branch); my B4 branch was soft-reset back to clean main and re-committed with only the B4 changes. PR #674's audit work is unaffected.

## CI matrix

- Server: \`pnpm lint\` ✓ · \`check-types\` ✓ · 751/754 tests ✓ (3 failures are the audit-trail concurrent workstream's WIP, unrelated to B4) · \`build\` ✓
- Admin-client: \`pnpm lint\` ✓ · \`check-types\` ✓ · tests ✓ · \`build\` ✓
- All four templates ship at \`build/src/modules/account/email/templates/\`: email-verification, password-reset-request, password-reset-confirmation, admin-created-account