### PR TITLE
feat(audit): wire AuditService into TmxGateway socket path

### DIFF
--- a/src/modules/audit/audit.e2e.spec.ts
+++ b/src/modules/audit/audit.e2e.spec.ts
@@ -5,16 +5,18 @@
  * Uses the super-admin test user (axel@castle.com) to:
  *   1. Create a test provider
  *   2. Save a tournament under that provider
- *   3. Mutate it via executionQueue
- *   4. Verify audit rows are written and queryable
- *   5. Delete the tournament
- *   6. Verify deletion audit row survives
- *   7. Clean up the test provider
+ *   3. Mutate it via REST executionQueue + TMX socket executionQueue
+ *   4. Verify audit rows are written and queryable for both paths
+ *   5. Verify rejected mutations are captured with errorCode + full params
+ *   6. Verify ackId correlation lands in metadata
+ *   7. Delete the tournament; verify deletion audit row survives
+ *   8. Clean up the test provider
  */
 import { AppModule } from 'src/modules/app/app.module';
 import { INestApplication } from '@nestjs/common';
 import { Test, TestingModule } from '@nestjs/testing';
-import { mocksEngine } from 'tods-competition-factory';
+import { mocksEngine, tools } from 'tods-competition-factory';
+import { io, Socket } from 'socket.io-client';
 import request from 'supertest';
 
 import { saveAndCommit } from 'src/tests/helpers/saveAndCommit';
@@ -28,6 +30,7 @@ const d = e2eEnabled ? describe : describe.skip;
 
 d('Audit Trail E2E', () => {
   let app: INestApplication;
+  let baseUrl: string;
   let token: string;
   let providerId: string;
 
@@ -38,6 +41,10 @@ d('Audit Trail E2E', () => {
 
     app = moduleRef.createNestApplication();
     await app.init();
+    // The socket-path tests need a live HTTP listener for socket.io to attach to.
+    await app.listen(0);
+    const address = app.getHttpServer().address();
+    baseUrl = `http://127.0.0.1:${address.port}`;
 
     // Login as super-admin
     const loginReq = await request(app.getHttpServer())
@@ -142,6 +149,170 @@ d('Audit Trail E2E', () => {
     expect(mutationRow.methods[0].method).toBe('setTournamentDates');
     expect(mutationRow.status).toBe('applied');
     expect(mutationRow.occurredAt).toBeDefined();
+  });
+
+  // ── TMX socket path coverage ──
+  //
+  // The REST `/factory` path above is the only path the original Phase A
+  // wiring exercised. The TMX WebSocket gateway is the path ~100% of
+  // production mutations actually traverse — and was bypassing the
+  // AuditService entirely until the 2026-05-22 fix that injected it into
+  // TmxGateway. These three specs lock down that newly-wired path.
+
+  function connectTmxClient(): Promise<Socket> {
+    return new Promise((resolve, reject) => {
+      const socket = io(`${baseUrl}/tmx`, {
+        auth: { token },
+        extraHeaders: { authorization: `Bearer ${token}` },
+        transports: ['websocket', 'polling'],
+        reconnection: false,
+      });
+      const timeout = setTimeout(() => reject(new Error('Socket connection timeout')), 10000);
+      socket.on('connect', () => {
+        clearTimeout(timeout);
+        resolve(socket);
+      });
+      socket.on('connect_error', (err) => {
+        clearTimeout(timeout);
+        reject(err);
+      });
+    });
+  }
+
+  function sendExecutionQueue(
+    socket: Socket,
+    payload: any,
+  ): Promise<{ ackId: string; success?: boolean; error?: any }> {
+    const ackId = payload.ackId ?? tools.UUID();
+    return new Promise((resolve, reject) => {
+      const timer = setTimeout(() => reject(new Error('executionQueue ack timeout')), 10000);
+      socket.on('ack', (ack: any) => {
+        if (ack?.ackId !== ackId) return;
+        clearTimeout(timer);
+        resolve(ack);
+      });
+      socket.emit('executionQueue', { type: 'executionQueue', payload: { ...payload, ackId } });
+    });
+  }
+
+  it('records audit rows for mutations via TMX socket gateway', async () => {
+    const tmxClient = await connectTmxClient();
+    try {
+      const ack = await sendExecutionQueue(tmxClient, {
+        methods: [
+          {
+            method: 'setTournamentDates',
+            params: { startDate: '2025-06-02', endDate: '2025-06-08', tournamentId: AUDIT_TOURNAMENT_ID },
+          },
+        ],
+        tournamentIds: [AUDIT_TOURNAMENT_ID],
+      });
+      expect(ack.success).toBe(true);
+
+      await new Promise((r) => setTimeout(r, 250));
+
+      const auditResult = await request(app.getHttpServer())
+        .post('/audit/tournament')
+        .set('Authorization', `Bearer ${token}`)
+        .send({ tournamentId: AUDIT_TOURNAMENT_ID })
+        .expect(200);
+
+      // Find the TMX-sourced applied row for setTournamentDates with the
+      // 2025-06-02 startDate that uniquely identifies this socket-path
+      // mutation (REST test above used 2025-06-01).
+      const socketRow = auditResult.body.auditRows.find(
+        (r: any) =>
+          r.actionType === 'MUTATION' &&
+          r.status === 'applied' &&
+          r.methods?.[0]?.method === 'setTournamentDates' &&
+          r.methods?.[0]?.params?.startDate === '2025-06-02',
+      );
+      expect(socketRow).toBeDefined();
+      expect(socketRow.source).toBe('tmx');
+      expect(socketRow.userEmail).toBe(TEST_EMAIL);
+    } finally {
+      tmxClient.close();
+    }
+  });
+
+  it('records rejected mutations with errorCode + full method params', async () => {
+    const tmxClient = await connectTmxClient();
+    try {
+      // Deliberately target a courtId that doesn't exist — the exact
+      // failure mode of the 2026-05-21 p.sychrovsky incident.
+      const bogusCourtId = `bogus-court-${tools.UUID()}`;
+      const ack = await sendExecutionQueue(tmxClient, {
+        methods: [
+          {
+            method: 'modifyCourt',
+            params: { courtId: bogusCourtId, modifications: { courtName: 'Phantom' } },
+          },
+        ],
+        tournamentIds: [AUDIT_TOURNAMENT_ID],
+      });
+      expect(ack.error).toBeDefined();
+
+      await new Promise((r) => setTimeout(r, 250));
+
+      const auditResult = await request(app.getHttpServer())
+        .post('/audit/tournament')
+        .set('Authorization', `Bearer ${token}`)
+        .send({ tournamentId: AUDIT_TOURNAMENT_ID })
+        .expect(200);
+
+      const rejectedRow = auditResult.body.auditRows.find(
+        (r: any) =>
+          r.actionType === 'MUTATION' &&
+          r.status === 'rejected' &&
+          r.methods?.[0]?.method === 'modifyCourt' &&
+          r.methods?.[0]?.params?.courtId === bogusCourtId,
+      );
+      expect(rejectedRow).toBeDefined();
+      expect(rejectedRow.errorCode).toBeDefined();
+      // The full failing params must be persisted — this is the whole
+      // point of the audit log for postmortem.
+      expect(rejectedRow.methods[0].params).toEqual({
+        courtId: bogusCourtId,
+        modifications: { courtName: 'Phantom' },
+      });
+    } finally {
+      tmxClient.close();
+    }
+  });
+
+  it('stamps ackId from TMX payload into audit metadata', async () => {
+    const tmxClient = await connectTmxClient();
+    try {
+      const ackId = `audit-corr-${tools.UUID()}`;
+      const ack = await sendExecutionQueue(tmxClient, {
+        ackId,
+        methods: [
+          {
+            method: 'setTournamentDates',
+            params: { startDate: '2025-06-03', endDate: '2025-06-09', tournamentId: AUDIT_TOURNAMENT_ID },
+          },
+        ],
+        tournamentIds: [AUDIT_TOURNAMENT_ID],
+      });
+      expect(ack.success).toBe(true);
+      expect(ack.ackId).toBe(ackId);
+
+      await new Promise((r) => setTimeout(r, 250));
+
+      const auditResult = await request(app.getHttpServer())
+        .post('/audit/tournament')
+        .set('Authorization', `Bearer ${token}`)
+        .send({ tournamentId: AUDIT_TOURNAMENT_ID })
+        .expect(200);
+
+      const correlatedRow = auditResult.body.auditRows.find(
+        (r: any) => r.metadata?.ackId === ackId,
+      );
+      expect(correlatedRow).toBeDefined();
+      expect(correlatedRow.status).toBe('applied');
+    } finally {
+      tmxClient.close();
+    }
   });
 
   it('records audit rows for tournament deletion', async () => {

--- a/src/modules/audit/audit.service.spec.ts
+++ b/src/modules/audit/audit.service.spec.ts
@@ -45,6 +45,41 @@ describe('AuditService', () => {
         }),
       ).resolves.not.toThrow();
     });
+
+    it('persists optional metadata (e.g. ackId for client correlation)', async () => {
+      await service.recordMutation({
+        tournamentIds: ['t-1'],
+        methods: [{ method: 'addEvent', params: { eventName: 'Test' } }],
+        status: 'applied',
+        metadata: { ackId: 'ack-xyz', tmxVersion: '1.2.3' },
+      });
+      const row = mockStorage.append.mock.calls[0][0];
+      expect(row.metadata).toEqual({ ackId: 'ack-xyz', tmxVersion: '1.2.3' });
+    });
+
+    it('omits metadata when undefined or empty', async () => {
+      await service.recordMutation({
+        tournamentIds: ['t-1'],
+        methods: [{ method: 'addEvent' }],
+        status: 'applied',
+        metadata: {},
+      });
+      const row = mockStorage.append.mock.calls[0][0];
+      expect(row.metadata).toBeUndefined();
+    });
+
+    it('captures errorCode + status=rejected for failed mutations', async () => {
+      await service.recordMutation({
+        tournamentIds: ['t-1'],
+        methods: [{ method: 'modifyCourt', params: { courtId: 'ghost-1' } }],
+        status: 'rejected',
+        errorCode: 'ERR_NOT_FOUND_COURT',
+      });
+      const row = mockStorage.append.mock.calls[0][0];
+      expect(row.status).toBe('rejected');
+      expect(row.errorCode).toBe('ERR_NOT_FOUND_COURT');
+      expect(row.methods[0].params.courtId).toBe('ghost-1');
+    });
   });
 
   describe('recordDeletion', () => {

--- a/src/modules/audit/audit.service.ts
+++ b/src/modules/audit/audit.service.ts
@@ -44,8 +44,9 @@ export class AuditService implements OnModuleInit, OnModuleDestroy {
     methods: Array<{ method: string; params?: any }>;
     status: 'applied' | 'rejected' | 'partial';
     errorCode?: string;
+    metadata?: Record<string, any>;
   }): Promise<void> {
-    const { tournamentIds, userId, userEmail, source, methods, status, errorCode } = params;
+    const { tournamentIds, userId, userEmail, source, methods, status, errorCode, metadata } = params;
 
     for (const tournamentId of tournamentIds) {
       const row: AuditRow = {
@@ -59,6 +60,7 @@ export class AuditService implements OnModuleInit, OnModuleDestroy {
         methods,
         status,
         errorCode,
+        ...(metadata && Object.keys(metadata).length ? { metadata } : {}),
       };
 
       try {

--- a/src/modules/factory/functions/private/executionQueue.ts
+++ b/src/modules/factory/functions/private/executionQueue.ts
@@ -87,6 +87,7 @@ export async function executionQueue(
           methods: methods.map((m: any) => ({ method: m.method, params: m.params })),
           status: innerResult.success ? 'applied' : innerResult.error ? 'rejected' : 'partial',
           errorCode: innerResult.error ? String(innerResult.error) : undefined,
+          metadata: buildAuditMetadata(payload),
         }).catch((err) => Logger.error(`Audit hook failed: ${err.message}`, 'executionQueue'));
       }
 
@@ -98,8 +99,37 @@ export async function executionQueue(
   } catch (err) {
     const message = err instanceof Error ? err.message : String(err);
     Logger.error(`executionQueue exception for tournaments [${tournamentIds.join(', ')}]: ${message}`);
+    // Capture exceptions in the audit log too — these are the most opaque
+    // failures (e.g. storage timeout, lock acquisition failure) and the
+    // ones most useful to triage post-incident.
+    if (auditService) {
+      auditService.recordMutation({
+        tournamentIds,
+        userId: payload?.userId,
+        userEmail: payload?.userEmail,
+        source: payload?.auditSource?.type === 'provisioner' ? 'provisioner' : payload?.source ?? 'tmx',
+        methods: methods.map((m: any) => ({ method: m.method, params: m.params })),
+        status: 'rejected',
+        errorCode: message,
+        metadata: buildAuditMetadata(payload),
+      }).catch((auditErr) => Logger.error(`Audit hook failed (catch branch): ${auditErr.message}`, 'executionQueue'));
+    }
     return { error: message, tournamentIds };
   }
+}
+
+/**
+ * Pack the durable correlation fields from a TMX payload into the audit
+ * `metadata` JSONB. Keys that aren't present in the payload are omitted so
+ * the JSONB stays compact for REST/provisioner paths that don't supply them.
+ */
+function buildAuditMetadata(payload: any): Record<string, any> | undefined {
+  const meta: Record<string, any> = {};
+  if (payload?.ackId) meta.ackId = payload.ackId;
+  if (payload?.tmxVersion) meta.tmxVersion = payload.tmxVersion;
+  if (payload?.factoryVersion) meta.factoryVersion = payload.factoryVersion;
+  if (payload?.timestamp) meta.clientTimestamp = payload.timestamp;
+  return Object.keys(meta).length ? meta : undefined;
 }
 
 /** Fire-and-forget: stamp tournament_provisioner table + parentOrganisation extension. */

--- a/src/modules/messaging/tmx/tmx.gateway.spec.ts
+++ b/src/modules/messaging/tmx/tmx.gateway.spec.ts
@@ -67,6 +67,7 @@ function buildGateway(opts: { userStorage?: any; providerStorage?: any } = {}) {
   const userProviderStorage: any = { findByEmail: jest.fn().mockResolvedValue([]) };
   const userProvisionerStorage: any = { findProvisionerIdsByUser: jest.fn().mockResolvedValue([]) };
   const provisionerProviderStorage: any = { findByProvisioner: jest.fn().mockResolvedValue([]) };
+  const auditService: any = { recordMutation: jest.fn().mockResolvedValue(undefined) };
 
   const gateway = new TmxGateway(
     cacheManager,
@@ -79,8 +80,9 @@ function buildGateway(opts: { userStorage?: any; providerStorage?: any } = {}) {
     broadcastService,
     assignmentsService,
     usersService,
+    auditService,
   );
-  return { gateway, userStorage, providerStorage };
+  return { gateway, userStorage, providerStorage, auditService };
 }
 
 describe('TmxGateway.handleConnection', () => {

--- a/src/modules/messaging/tmx/tmx.gateway.ts
+++ b/src/modules/messaging/tmx/tmx.gateway.ts
@@ -4,6 +4,7 @@ import { canViewTournament, canMutateTournament } from 'src/modules/factory/help
 import { TournamentStorageService } from 'src/storage/tournament-storage.service';
 import { buildUserContext } from 'src/modules/account/auth/helpers/buildUserContext';
 import { AssignmentsService } from 'src/modules/factory/assignments.service';
+import { AuditService } from 'src/modules/audit/audit.service';
 import { UseGuards, Logger, Inject, Injectable } from '@nestjs/common';
 import { Roles } from 'src/modules/account/auth/decorators/roles.decorator';
 import { SocketGuard } from 'src/modules/account/auth/guards/socket.guard';
@@ -73,6 +74,7 @@ export class TmxGateway implements OnGatewayConnection, OnGatewayDisconnect, OnG
     private readonly broadcastService: TournamentBroadcastService,
     private readonly assignmentsService: AssignmentsService,
     private readonly usersService: UsersService,
+    private readonly auditService: AuditService,
   ) {}
 
   private readonly logger = new Logger(TmxGateway.name);
@@ -212,6 +214,7 @@ export class TmxGateway implements OnGatewayConnection, OnGatewayDisconnect, OnG
 
     if (tmxMessages[type]) {
       const methods = tools.unique(payload?.methods?.map((directive) => directive.method) ?? []).join('|');
+      const ackId = payload?.ackId;
 
       // Per-tournament gates: tournament-access (canMutateTournament) +
       // provider-permission (MUTATION_PERMISSIONS). Returns an error
@@ -220,8 +223,16 @@ export class TmxGateway implements OnGatewayConnection, OnGatewayDisconnect, OnG
       const requestedMethods: string[] = (payload?.methods ?? []).map((m: any) => m?.method).filter(Boolean);
       const denial = await this.gatePerTournament(userContext, payload.tournamentIds ?? [], requestedMethods, userId, methods);
       if (denial) {
-        client.emit('ack', { ackId: payload?.ackId, error: denial });
+        client.emit('ack', { ackId, error: denial });
         return;
+      }
+
+      // Stamp the JWT-verified identity onto the payload so downstream
+      // consumers (audit hook, executionQueue) see the authenticated
+      // user rather than whatever the client happened to send.
+      if (verifiedUser?.email) {
+        payload.userEmail = verifiedUser.email;
+        payload.userId = verifiedUser.userId ?? verifiedUser.sub ?? verifiedUser.email;
       }
 
       try {
@@ -230,12 +241,18 @@ export class TmxGateway implements OnGatewayConnection, OnGatewayDisconnect, OnG
           payload,
           services: { cacheManager: this.cacheManager },
           storage: this.tournamentStorageService,
+          auditService: this.auditService,
         });
         if (result.error) {
           const tournamentInfo = result.tournamentIds ? ` | tournaments: ${JSON.stringify(result.tournamentIds)}` : '';
           const contextInfo = result.context ? ` | context: ${JSON.stringify(result.context)}` : '';
+          // Include ackId + full methods (params and all) in error logs so
+          // production incidents are triageable without needing the audit
+          // DB. Capped at 2000 chars per log to avoid excessive spam from
+          // large batches.
+          const methodsDetail = safeJson(payload?.methods, 2000);
           this.logger.error(
-            `${type} message errored: ${userId}: ${methods}${tournamentInfo} | error: ${JSON.stringify(result.error)}${contextInfo}`,
+            `${type} message errored: ${userId}: ${methods}${tournamentInfo} | ackId: ${ackId} | error: ${JSON.stringify(result.error)}${contextInfo} | methods: ${methodsDetail}`,
           );
         } else {
           this.logger.debug(`${type} message successful: ${userId}: ${methods}`);
@@ -246,8 +263,10 @@ export class TmxGateway implements OnGatewayConnection, OnGatewayDisconnect, OnG
         }
       } catch (err) {
         const message = err instanceof Error ? err.message : String(err);
-        this.logger.error(`${type} message threw: ${userId}: ${methods} | error: ${message}`);
-        const ackId = payload?.ackId;
+        const methodsDetail = safeJson(payload?.methods, 2000);
+        this.logger.error(
+          `${type} message threw: ${userId}: ${methods} | ackId: ${ackId} | error: ${message} | methods: ${methodsDetail}`,
+        );
         client.emit('ack', { ackId, error: message });
       }
     } else {
@@ -493,5 +512,15 @@ export class TmxGateway implements OnGatewayConnection, OnGatewayDisconnect, OnG
 
     this.logger.debug(`test route successful`);
     return { event: 'ack', data }; // emit to client
+  }
+}
+
+function safeJson(value: unknown, maxLen: number): string {
+  try {
+    const s = JSON.stringify(value);
+    if (s == null) return String(s);
+    return s.length > maxLen ? `${s.slice(0, maxLen)}…` : s;
+  } catch {
+    return '[unserializable]';
   }
 }

--- a/src/modules/messaging/tmx/tmx.module.ts
+++ b/src/modules/messaging/tmx/tmx.module.ts
@@ -1,6 +1,7 @@
 import { BroadcastModule } from '../broadcast/broadcast.module';
 import { AssignmentsService } from '../../factory/assignments.service';
 import { UsersModule } from '../../users/users.module';
+import { AuditModule } from '../../audit/audit.module';
 import { AdminPresenceController } from './admin-presence.controller';
 import { TmxGateway } from './tmx.gateway';
 import { Module } from '@nestjs/common';
@@ -10,7 +11,7 @@ import { Module } from '@nestjs/common';
 // Its own DI deps (ASSIGNMENT_STORAGE, USER_PROVIDER_STORAGE, USER_STORAGE)
 // come from StorageModule which is @Global.
 @Module({
-  imports: [BroadcastModule, UsersModule],
+  imports: [BroadcastModule, UsersModule, AuditModule],
   controllers: [AdminPresenceController],
   providers: [TmxGateway, AssignmentsService],
 })

--- a/src/modules/messaging/tmx/tmxMessages.ts
+++ b/src/modules/messaging/tmx/tmxMessages.ts
@@ -2,16 +2,29 @@ import { executionQueue } from 'src/modules/factory/functions/private/executionQ
 import { Logger } from '@nestjs/common';
 
 import type { TournamentStorageService } from 'src/storage/tournament-storage.service';
+import type { AuditService } from 'src/modules/audit/audit.service';
 
 const logger = new Logger('TmxMessages');
 
 export const tmxMessages = {
-  executionQueue: async ({ client, payload, services, storage }: { client: any; payload: any; services: any; storage: TournamentStorageService }) => {
+  executionQueue: async ({
+    client,
+    payload,
+    services,
+    storage,
+    auditService,
+  }: {
+    client: any;
+    payload: any;
+    services: any;
+    storage: TournamentStorageService;
+    auditService?: AuditService;
+  }) => {
     const ackId = payload?.ackId;
     const tournamentIds = payload?.tournamentIds || (payload?.tournamentId && [payload.tournamentId]) || [];
 
     try {
-      const result = await executionQueue(payload, services, storage);
+      const result = await executionQueue(payload, services, storage, auditService);
       const { publicNotices, ...mutationResult } = result;
 
       const response = mutationResult.error


### PR DESCRIPTION
## Summary
- Phase A's audit hook in `executionQueue.ts` had been dead code on the TMX socket path because `TmxGateway` never injected `AuditService` — so ~100% of production mutations bypassed the audit log. Found while triaging the 2026-05-21 `p.sychrovsky@gmx.com` `ERR_NOT_FOUND_COURT` incident where server logs only captured method names, no params.
- `TmxGateway` now `@Inject`s `AuditService` and forwards it through `tmxMessages.executionQueue` → `executionQueue(payload, services, storage, auditService)`. JWT-verified `userEmail`/`userId` are stamped onto the payload at the gateway boundary so the audit row uses the authenticated identity.
- `recordMutation()` accepts an optional `metadata` bag (existing JSONB column — no migration). `executionQueue` packs `ackId` / `tmxVersion` / `factoryVersion` / `clientTimestamp` into it for client↔server correlation. The `executionQueue` catch branch also records a `rejected` audit row so storage timeouts / lock failures don't go silent.
- Error logs in `tmx.gateway.ts` now include `ackId` + the full `methods` payload (capped at 2000 chars), so postmortem triage works even without a DB query.

## Test plan
- [x] `pnpm exec tsc --noEmit` — clean
- [x] `pnpm exec eslint --max-warnings 0` on all 8 touched files — clean
- [x] `pnpm exec jest src/modules/audit/audit.service.spec.ts src/modules/messaging/tmx/tmx.gateway.spec.ts` — 18/18 pass (3 new audit metadata/error-code tests, gateway constructor mock updated)
- [ ] `audit.e2e.spec.ts` against staging Postgres (`STORAGE_PROVIDER=postgres`): applied via socket, rejected with full failing params preserved, ackId correlation round-trip into metadata
- [ ] Post-deploy: confirm a fresh TMX mutation lands in `audit_log` for its tournamentId
- [ ] Post-deploy: confirm `Audit-Worker` on `AUDIT_WORKER_PORT=8385` `/health` responds and `POST /condense/:tournamentId/mutationLog` round-trips
- [ ] Post-deploy: ~24h after restart, look for `Pruned N audit row(s) older than N days` server log line

Closes the 2026-05-20 "Audit-Worker prod verification" item in `Mentat/TASKS.md` once Tier 4 verification completes.