### PR TITLE
feat(providers): archive + delete + revive (Plan A)

### DIFF
--- a/admin-client/src/components/modals/archiveProvider.ts
+++ b/admin-client/src/components/modals/archiveProvider.ts
@@ -1,0 +1,153 @@
+/**
+ * Archive provider modal.
+ *
+ * SUPER_ADMIN-only. Two phases:
+ *   1. On open: call previewArchiveProvider to get the blast-radius
+ *      counts. Render them so the admin sees what's about to be
+ *      destroyed.
+ *   2. On submit: require the admin to type the provider's abbreviation
+ *      literally. Server enforces this independently, but the client
+ *      gate keeps a typo from generating an obviously-wrong request.
+ */
+import { previewArchiveProvider, archiveProvider } from 'services/apis/servicesApi';
+import { tmxToast } from 'services/notifications/tmxToast';
+import { openModal } from './baseModal/baseModal';
+import { t } from 'i18n';
+
+type CleanupCounts = {
+  tournaments: number;
+  userAssociations: number;
+  provisionerAssociations: number;
+  tournamentAssignments: number;
+  officialRecords: number;
+  sanctioningRecords: number;
+  tournamentProvisioner: number;
+  pendingSaves: number;
+  calendars: number;
+  topologies: number;
+  catalogItems: number;
+  policies: number;
+  auditLogRows: number;
+};
+
+type Preview = {
+  providerId: string;
+  providerAbbr: string;
+  providerName: string;
+  counts: CleanupCounts;
+};
+
+function rowFor(label: string, n: number): string {
+  return `<div style="display:flex;justify-content:space-between;padding:4px 0;border-bottom:1px solid var(--tmx-border-primary,#eee);font-size:0.9rem;"><span>${label}</span><span style="font-variant-numeric:tabular-nums;font-weight:600;">${n.toLocaleString()}</span></div>`;
+}
+
+function renderCounts(counts: CleanupCounts): string {
+  return [
+    rowFor(t('modals.archiveProvider.counts.tournaments'), counts.tournaments),
+    rowFor(t('modals.archiveProvider.counts.userAssociations'), counts.userAssociations),
+    rowFor(t('modals.archiveProvider.counts.provisionerAssociations'), counts.provisionerAssociations),
+    rowFor(t('modals.archiveProvider.counts.tournamentAssignments'), counts.tournamentAssignments),
+    rowFor(t('modals.archiveProvider.counts.officialRecords'), counts.officialRecords),
+    rowFor(t('modals.archiveProvider.counts.sanctioningRecords'), counts.sanctioningRecords),
+    rowFor(t('modals.archiveProvider.counts.tournamentProvisioner'), counts.tournamentProvisioner),
+    rowFor(t('modals.archiveProvider.counts.pendingSaves'), counts.pendingSaves),
+    rowFor(t('modals.archiveProvider.counts.calendars'), counts.calendars),
+    rowFor(t('modals.archiveProvider.counts.topologies'), counts.topologies),
+    rowFor(t('modals.archiveProvider.counts.catalogItems'), counts.catalogItems),
+    rowFor(t('modals.archiveProvider.counts.policies'), counts.policies),
+    rowFor(t('modals.archiveProvider.counts.auditLogRows'), counts.auditLogRows),
+  ].join('');
+}
+
+export function archiveProviderModal({
+  providerId,
+  providerAbbr,
+  providerName,
+  callback,
+}: {
+  providerId: string;
+  providerAbbr: string;
+  providerName: string;
+  callback?: () => void;
+}): void {
+  let preview: Preview | undefined;
+
+  const content = (elem: HTMLElement) => {
+    elem.innerHTML = `
+      <p style="margin:0 0 12px 0;font-size:0.95rem;">
+        ${t('modals.archiveProvider.intro', { provider: providerName, abbr: providerAbbr })}
+      </p>
+      <div id="archivePreview" style="margin:8px 0 16px 0;color:var(--tmx-text-secondary,#64748b);">
+        ${t('modals.archiveProvider.loading')}
+      </div>
+      <label style="display:block;font-size:0.9rem;margin-bottom:4px;">
+        ${t('modals.archiveProvider.confirmLabel', { abbr: providerAbbr })}
+      </label>
+      <input id="archiveConfirmInput" type="text" autocomplete="off"
+             placeholder="${providerAbbr}"
+             style="width:100%;padding:8px;border:1px solid var(--tmx-border-primary,#ddd);border-radius:4px;font-family:monospace;" />
+    `;
+
+    const confirmInput = elem.querySelector<HTMLInputElement>('#archiveConfirmInput');
+    const submitBtn = document.getElementById('archiveProviderSubmit') as HTMLButtonElement | null;
+    confirmInput?.addEventListener('input', () => {
+      if (submitBtn) submitBtn.disabled = confirmInput.value !== providerAbbr;
+    });
+
+    previewArchiveProvider({ providerId }).then(
+      (res: any) => {
+        preview = res?.data;
+        const div = elem.querySelector('#archivePreview');
+        if (div && preview) {
+          div.innerHTML = renderCounts(preview.counts);
+        }
+      },
+      () => {
+        const div = elem.querySelector('#archivePreview');
+        if (div) {
+          div.innerHTML = `<span style="color:var(--tmx-status-error,#c62828);">${t('modals.archiveProvider.previewFailed')}</span>`;
+        }
+      },
+    );
+  };
+
+  const onSubmit = () => {
+    const input = document.getElementById('archiveConfirmInput') as HTMLInputElement | null;
+    const confirm = input?.value ?? '';
+    if (confirm !== providerAbbr) return;
+    archiveProvider({ providerId, confirm }).then(
+      (res: any) => {
+        const data = res?.data ?? {};
+        tmxToast({
+          message: t('modals.archiveProvider.success', {
+            abbr: providerAbbr,
+            tournaments: data?.counts?.tournaments ?? 0,
+            archiveId: data?.archiveId ?? '',
+          }),
+          intent: 'is-success',
+        });
+        callback?.();
+      },
+      (err: any) => {
+        const message = err?.response?.data?.message || err?.message || t('modals.archiveProvider.failed');
+        tmxToast({ message, intent: 'is-danger' });
+      },
+    );
+  };
+
+  openModal({
+    title: t('modals.archiveProvider.title', { provider: providerName }),
+    content,
+    buttons: [
+      { label: t('common.cancel'), intent: 'none', close: true },
+      {
+        label: t('modals.archiveProvider.submit'),
+        id: 'archiveProviderSubmit',
+        disabled: true,
+        onClick: onSubmit,
+        close: true,
+        intent: 'is-warning',
+      },
+    ],
+  });
+}

--- a/admin-client/src/components/modals/deleteProvider.ts
+++ b/admin-client/src/components/modals/deleteProvider.ts
@@ -1,0 +1,150 @@
+/**
+ * Delete provider modal — DESTRUCTIVE, no archive, no recovery.
+ *
+ * Same blast-radius preview as archive, but stricter confirmation:
+ * the user must (a) type the provider's abbreviation, AND (b) tick the
+ * "I understand this cannot be undone" checkbox. The server enforces
+ * both independently.
+ *
+ * Use case: providers with no data worth preserving — demo/test
+ * providers, abandoned signups. For anything with real data, use the
+ * archive modal so the result is reversible via revive-provider.mjs.
+ */
+import { previewArchiveProvider, deleteProviderPermanently } from 'services/apis/servicesApi';
+import { tmxToast } from 'services/notifications/tmxToast';
+import { openModal } from './baseModal/baseModal';
+import { t } from 'i18n';
+
+type CleanupCounts = {
+  tournaments: number;
+  userAssociations: number;
+  provisionerAssociations: number;
+  tournamentAssignments: number;
+  officialRecords: number;
+  sanctioningRecords: number;
+  tournamentProvisioner: number;
+  pendingSaves: number;
+  calendars: number;
+  topologies: number;
+  catalogItems: number;
+  policies: number;
+  auditLogRows: number;
+};
+
+function rowFor(label: string, n: number): string {
+  return `<div style="display:flex;justify-content:space-between;padding:4px 0;border-bottom:1px solid var(--tmx-border-primary,#eee);font-size:0.9rem;"><span>${label}</span><span style="font-variant-numeric:tabular-nums;font-weight:600;">${n.toLocaleString()}</span></div>`;
+}
+
+function renderCounts(counts: CleanupCounts): string {
+  return [
+    rowFor(t('modals.archiveProvider.counts.tournaments'), counts.tournaments),
+    rowFor(t('modals.archiveProvider.counts.userAssociations'), counts.userAssociations),
+    rowFor(t('modals.archiveProvider.counts.tournamentAssignments'), counts.tournamentAssignments),
+    rowFor(t('modals.archiveProvider.counts.calendars'), counts.calendars),
+    rowFor(t('modals.archiveProvider.counts.auditLogRows'), counts.auditLogRows),
+  ].join('');
+}
+
+export function deleteProviderModal({
+  providerId,
+  providerAbbr,
+  providerName,
+  callback,
+}: {
+  providerId: string;
+  providerAbbr: string;
+  providerName: string;
+  callback?: () => void;
+}): void {
+  const content = (elem: HTMLElement) => {
+    elem.innerHTML = `
+      <div style="background:var(--tmx-status-error-bg,#fef2f2);border-left:4px solid var(--tmx-status-error,#dc2626);padding:10px 12px;margin-bottom:12px;border-radius:4px;font-size:0.9rem;">
+        <strong>${t('modals.deleteProvider.warning')}</strong>
+        <div style="margin-top:4px;color:var(--tmx-text-secondary,#64748b);">
+          ${t('modals.deleteProvider.warningDetail')}
+        </div>
+      </div>
+      <p style="margin:0 0 12px 0;font-size:0.95rem;">
+        ${t('modals.deleteProvider.intro', { provider: providerName, abbr: providerAbbr })}
+      </p>
+      <div id="deletePreview" style="margin:8px 0 16px 0;color:var(--tmx-text-secondary,#64748b);">
+        ${t('modals.archiveProvider.loading')}
+      </div>
+      <label style="display:block;font-size:0.9rem;margin-bottom:4px;">
+        ${t('modals.archiveProvider.confirmLabel', { abbr: providerAbbr })}
+      </label>
+      <input id="deleteConfirmInput" type="text" autocomplete="off"
+             placeholder="${providerAbbr}"
+             style="width:100%;padding:8px;border:1px solid var(--tmx-border-primary,#ddd);border-radius:4px;font-family:monospace;margin-bottom:12px;" />
+      <label style="display:flex;align-items:center;gap:8px;font-size:0.9rem;cursor:pointer;">
+        <input id="deleteAckCheckbox" type="checkbox" />
+        <span>${t('modals.deleteProvider.acknowledge')}</span>
+      </label>
+    `;
+
+    const confirmInput = elem.querySelector<HTMLInputElement>('#deleteConfirmInput');
+    const ackCheckbox = elem.querySelector<HTMLInputElement>('#deleteAckCheckbox');
+    const submitBtn = document.getElementById('deleteProviderSubmit') as HTMLButtonElement | null;
+
+    const updateEnabled = () => {
+      if (!submitBtn) return;
+      submitBtn.disabled = !(confirmInput?.value === providerAbbr && ackCheckbox?.checked);
+    };
+    confirmInput?.addEventListener('input', updateEnabled);
+    ackCheckbox?.addEventListener('change', updateEnabled);
+
+    previewArchiveProvider({ providerId }).then(
+      (res: any) => {
+        const div = elem.querySelector('#deletePreview');
+        if (div && res?.data?.counts) {
+          div.innerHTML = renderCounts(res.data.counts);
+        }
+      },
+      () => {
+        const div = elem.querySelector('#deletePreview');
+        if (div) {
+          div.innerHTML = `<span style="color:var(--tmx-status-error,#c62828);">${t('modals.archiveProvider.previewFailed')}</span>`;
+        }
+      },
+    );
+  };
+
+  const onSubmit = () => {
+    const input = document.getElementById('deleteConfirmInput') as HTMLInputElement | null;
+    const confirm = input?.value ?? '';
+    if (confirm !== providerAbbr) return;
+    deleteProviderPermanently({ providerId, confirm }).then(
+      (res: any) => {
+        const data = res?.data ?? {};
+        tmxToast({
+          message: t('modals.deleteProvider.success', {
+            abbr: providerAbbr,
+            tournaments: data?.counts?.tournaments ?? 0,
+          }),
+          intent: 'is-success',
+        });
+        callback?.();
+      },
+      (err: any) => {
+        const message = err?.response?.data?.message || err?.message || t('modals.deleteProvider.failed');
+        tmxToast({ message, intent: 'is-danger' });
+      },
+    );
+  };
+
+  openModal({
+    title: t('modals.deleteProvider.title', { provider: providerName }),
+    content,
+    buttons: [
+      { label: t('common.cancel'), intent: 'none', close: true },
+      {
+        label: t('modals.deleteProvider.submit'),
+        id: 'deleteProviderSubmit',
+        disabled: true,
+        onClick: onSubmit,
+        close: true,
+        intent: 'is-danger',
+      },
+    ],
+  });
+}

--- a/admin-client/src/i18n/locales/en.json
+++ b/admin-client/src/i18n/locales/en.json
@@ -305,6 +305,8 @@
     "searchUsers": "Search users...",
     "inviteUser": "Invite User",
     "createUser": "Create User",
+    "archiveProvider": "Archive",
+    "deleteProvider": "Delete",
     "editUser": "Edit User",
     "editUserTitle": "Edit User",
     "removeUser": "Remove User",
@@ -1261,6 +1263,41 @@
       "successPlain": "Created {{email}}.",
       "failed": "Failed to create user.",
       "emailExists": "A user with email {{email}} already exists."
+    },
+    "archiveProvider": {
+      "title": "Archive provider — {{provider}}",
+      "intro": "Archiving exports everything associated with {{provider}} ({{abbr}}) to disk, then removes it from the live database. The archive is recoverable via the backend revive-provider.mjs script.",
+      "loading": "Loading blast-radius preview…",
+      "previewFailed": "Couldn't load preview. Try again, or refresh the page.",
+      "confirmLabel": "Type the provider abbreviation ({{abbr}}) to confirm:",
+      "submit": "Archive provider",
+      "success": "Archived {{abbr}} — {{tournaments}} tournaments. Archive id: {{archiveId}}.",
+      "failed": "Archive failed.",
+      "counts": {
+        "tournaments": "Tournaments",
+        "userAssociations": "User associations",
+        "provisionerAssociations": "Provisioner associations",
+        "tournamentAssignments": "Tournament assignments",
+        "officialRecords": "Official records",
+        "sanctioningRecords": "Sanctioning records",
+        "tournamentProvisioner": "Tournament-provisioner links",
+        "pendingSaves": "Pending saves",
+        "calendars": "Calendars",
+        "topologies": "Topology templates",
+        "catalogItems": "Catalog items",
+        "policies": "Policies",
+        "auditLogRows": "Audit log rows (preserved, not deleted)"
+      }
+    },
+    "deleteProvider": {
+      "title": "Delete provider — {{provider}}",
+      "warning": "Irreversible — no archive, no recovery.",
+      "warningDetail": "Use Archive instead if there's any chance this data will be needed later. Delete is for providers with no real data (demo/test accounts).",
+      "intro": "Permanently delete {{provider}} ({{abbr}}) and all its associated data. Audit log rows are preserved, but every other table will be wiped.",
+      "acknowledge": "I understand this cannot be undone.",
+      "submit": "Delete permanently",
+      "success": "Deleted {{abbr}} — {{tournaments}} tournaments destroyed.",
+      "failed": "Delete failed."
     },
     "firstLogin": {
       "title": "Set Your Password",

--- a/admin-client/src/pages/tournament/tabs/settingsTab/systemTab/providersPanel.ts
+++ b/admin-client/src/pages/tournament/tabs/settingsTab/systemTab/providersPanel.ts
@@ -2,6 +2,8 @@ import { resetPasswordModal } from 'components/modals/resetPasswordModal';
 import { createSearchFilter } from 'components/tables/common/filters/createSearchFilter';
 import { setActiveProvider, clearActiveProvider } from 'services/provider/providerState';
 import { editProviderModal } from 'components/modals/editProvider';
+import { archiveProviderModal } from 'components/modals/archiveProvider';
+import { deleteProviderModal } from 'components/modals/deleteProvider';
 import { TabulatorFull as Tabulator } from 'tabulator-tables';
 import { buildSearchInput } from 'components/inputs/searchInput';
 import { removeUserProvider } from 'services/apis/servicesApi';
@@ -211,9 +213,40 @@ function renderProviderDetail({ detailPane, provider, providers, users, onRefres
     createUserModal(() => onRefresh(), providers as any, provider.organisationId);
   });
 
+  // Plan A — Archive (warning intent) + Delete (danger intent). Both
+  // SUPER_ADMIN only (server enforces). Archive is recoverable via
+  // revive-provider.mjs; Delete is irreversible. Buttons live on the
+  // right with separators so they don't get clicked by accident.
+  const archiveBtn = document.createElement('button');
+  archiveBtn.className = 'btn-edit';
+  archiveBtn.style.cssText = 'margin-left: auto;';
+  archiveBtn.textContent = t('system.archiveProvider');
+  archiveBtn.addEventListener('click', () => {
+    archiveProviderModal({
+      providerId: provider.organisationId,
+      providerAbbr: provider.organisationAbbreviation,
+      providerName: provider.organisationName,
+      callback: () => onRefresh(),
+    });
+  });
+
+  const deleteBtn = document.createElement('button');
+  deleteBtn.className = 'btn-remove';
+  deleteBtn.textContent = t('system.deleteProvider');
+  deleteBtn.addEventListener('click', () => {
+    deleteProviderModal({
+      providerId: provider.organisationId,
+      providerAbbr: provider.organisationAbbreviation,
+      providerName: provider.organisationName,
+      callback: () => onRefresh(),
+    });
+  });
+
   actions.appendChild(impersonateBtn);
   actions.appendChild(editBtn);
   actions.appendChild(createBtn);
+  actions.appendChild(archiveBtn);
+  actions.appendChild(deleteBtn);
   detailPane.appendChild(actions);
 
   // Associated users

--- a/admin-client/src/services/apis/servicesApi.ts
+++ b/admin-client/src/services/apis/servicesApi.ts
@@ -19,6 +19,48 @@ export async function modifyProvider({ provider }: { provider: any }) {
   return await baseApi.post('/provider/modify', provider);
 }
 
+/**
+ * Plan A — preview the blast radius of an archive/delete. Returns
+ * counts for every soft-FK table that would be touched.
+ * SUPER_ADMIN only.
+ */
+export async function previewArchiveProvider({ providerId }: { providerId: string }) {
+  return await baseApi.post(`/provider/${encodeURIComponent(providerId)}/preview-archive`, {});
+}
+
+/**
+ * Plan A — archive (export to disk + wipe live DB). Recoverable via
+ * the backend revive-provider.mjs script. `confirm` must equal the
+ * provider's organisationAbbreviation.
+ */
+export async function archiveProvider({
+  providerId,
+  confirm,
+}: {
+  providerId: string;
+  confirm: string;
+}) {
+  return await baseApi.post(`/provider/${encodeURIComponent(providerId)}/archive`, { confirm });
+}
+
+/**
+ * Plan A — DESTRUCTIVE delete (no export, no recovery). For demo
+ * providers and the like. Requires `confirm` matching abbreviation
+ * AND `acknowledgeDataLoss: true`.
+ */
+export async function deleteProviderPermanently({
+  providerId,
+  confirm,
+}: {
+  providerId: string;
+  confirm: string;
+}) {
+  return await baseApi.post(`/provider/${encodeURIComponent(providerId)}/delete`, {
+    confirm,
+    acknowledgeDataLoss: true,
+  });
+}
+
 export async function getProvider({ providerId }: { providerId: string }) {
   return await baseApi.post('/provider/detail', { providerId });
 }

--- a/src/modules/messaging/tmx/tmx.gateway.ts
+++ b/src/modules/messaging/tmx/tmx.gateway.ts
@@ -230,9 +230,17 @@ export class TmxGateway implements OnGatewayConnection, OnGatewayDisconnect, OnG
       // Stamp the JWT-verified identity onto the payload so downstream
       // consumers (audit hook, executionQueue) see the authenticated
       // user rather than whatever the client happened to send.
+      //
+      // Only assign `userId` when the JWT actually carries a UUID-shaped
+      // identifier — `audit_log.user_id` is UUID-typed (and nullable),
+      // so falling back to `email` here would crash the INSERT with
+      // `invalid input syntax for type uuid: "..."`. The email belongs in
+      // `userEmail` (which maps to `audit_log.user_email TEXT`).
       if (verifiedUser?.email) {
         payload.userEmail = verifiedUser.email;
-        payload.userId = verifiedUser.userId ?? verifiedUser.sub ?? verifiedUser.email;
+      }
+      if (verifiedUser?.userId || verifiedUser?.sub) {
+        payload.userId = verifiedUser.userId ?? verifiedUser.sub;
       }
 
       try {

--- a/src/modules/providers/dto/archiveProvider.dto.ts
+++ b/src/modules/providers/dto/archiveProvider.dto.ts
@@ -1,0 +1,9 @@
+import { ApiProperty } from '@nestjs/swagger';
+
+export class ArchiveProviderDto {
+  @ApiProperty({
+    description:
+      'Must equal the provider\'s organisationAbbreviation. Mismatched value rejects with 400 — defends against accidental archive of the wrong provider.',
+  })
+  confirm: string = '';
+}

--- a/src/modules/providers/dto/deleteProvider.dto.ts
+++ b/src/modules/providers/dto/deleteProvider.dto.ts
@@ -1,0 +1,15 @@
+import { ApiProperty } from '@nestjs/swagger';
+
+export class DeleteProviderDto {
+  @ApiProperty({
+    description:
+      'Must equal the provider\'s organisationAbbreviation. Mismatched value rejects with 400.',
+  })
+  confirm: string = '';
+
+  @ApiProperty({
+    description:
+      'Must be literally `true`. Delete is irrevocable — no archive directory, no provider_archives row, no revive path. If you want recoverability, use POST /provider/:id/archive instead.',
+  })
+  acknowledgeDataLoss: boolean = false;
+}

--- a/src/modules/providers/provider-archive.service.ts
+++ b/src/modules/providers/provider-archive.service.ts
@@ -1,0 +1,203 @@
+/**
+ * Write a complete export of one provider's live data to disk.
+ *
+ * The archive is the durable record of an archived provider. The
+ * cleanup service then deletes the live rows. revive-provider.mjs reads
+ * the archive back and rebuilds the live rows in a single transaction.
+ *
+ * Two-phase write:
+ *   1. Write everything to `<archives>/<abbr>-<UTC-ts>.partial/`
+ *   2. Compute manifest.json with sha256 of every payload file
+ *   3. Atomic rename `.partial` → final `<abbr>-<UTC-ts>/`
+ *
+ * If anything fails before the rename, the `.partial` directory is left
+ * in place for a human (or a future sweeper) to clean up — the live DB
+ * is unmodified because the caller invokes this BEFORE the cleanup
+ * transaction.
+ *
+ * Path resolution:
+ *   ARCHIVES_PATH env (absolute path) — required in production. In
+ *   dev/CI the writer falls back to `<cwd>/.archives-local/` so unit
+ *   tests + local exploration work without configuration. Failing
+ *   loud here would be friendlier than a silently-misplaced archive.
+ */
+import { Inject, Injectable, Logger } from '@nestjs/common';
+import { createHash } from 'crypto';
+import { Pool } from 'pg';
+import fs from 'fs/promises';
+import path from 'path';
+
+import { PG_POOL } from 'src/storage/postgres/postgres.config';
+
+export interface ArchiveManifest {
+  version: 1;
+  archivedAt: string;
+  providerId: string;
+  providerAbbr: string;
+  providerName: string;
+  files: Record<string, { sha256: string; bytes: number; rows?: number }>;
+}
+
+export interface ArchiveWriteResult {
+  archivePath: string;
+  manifestSha256: string;
+  tournamentCount: number;
+  userAssocCount: number;
+  auditLogRows: number;
+}
+
+@Injectable()
+export class ProviderArchiveService {
+  private readonly logger = new Logger(ProviderArchiveService.name);
+
+  constructor(@Inject(PG_POOL) private readonly pool: Pool) {}
+
+  private resolveBasePath(): string {
+    const fromEnv = process.env.ARCHIVES_PATH;
+    if (fromEnv && fromEnv.trim()) return fromEnv.trim();
+    const fallback = path.join(process.cwd(), '.archives-local');
+    this.logger.warn(
+      `ARCHIVES_PATH not set — writing to fallback ${fallback} (production deploys MUST set this env var).`,
+    );
+    return fallback;
+  }
+
+  /**
+   * Write the archive. Returns the final (post-rename) path + the
+   * sha256 of the manifest file (which itself contains sha256s of
+   * each payload).
+   */
+  async writeArchive(provider: {
+    providerId: string;
+    providerAbbr: string;
+    providerName: string;
+  }): Promise<ArchiveWriteResult> {
+    const base = this.resolveBasePath();
+    await fs.mkdir(base, { recursive: true });
+
+    const utcTs = new Date().toISOString().replace(/[:.]/g, '-');
+    const finalName = `${provider.providerAbbr}-${utcTs}`;
+    const partialDir = path.join(base, `${finalName}.partial`);
+    const finalDir = path.join(base, finalName);
+
+    await fs.mkdir(partialDir, { recursive: true });
+    await fs.mkdir(path.join(partialDir, 'tournaments'), { recursive: true });
+
+    const manifest: ArchiveManifest = {
+      version: 1,
+      archivedAt: new Date().toISOString(),
+      providerId: provider.providerId,
+      providerAbbr: provider.providerAbbr,
+      providerName: provider.providerName,
+      files: {},
+    };
+
+    // Helper: write a JSON file, compute sha256, record in manifest.
+    const writeJson = async (relPath: string, payload: any, rows?: number) => {
+      const json = JSON.stringify(payload, null, 2);
+      const filePath = path.join(partialDir, relPath);
+      await fs.writeFile(filePath, json, 'utf8');
+      const sha = createHash('sha256').update(json).digest('hex');
+      manifest.files[relPath] = { sha256: sha, bytes: Buffer.byteLength(json, 'utf8'), rows };
+    };
+
+    // The exported tables. Per-table queries below match the cleanup
+    // service's reach (every soft-FK column we explicitly wipe gets
+    // exported here first). Order is roughly dependency-friendly for
+    // the revive flow: providers first, then association tables,
+    // then tournaments + audit_log.
+    const tablesByProviderId: Array<{ rel: string; sql: string }> = [
+      { rel: 'provider.json',              sql: 'SELECT * FROM providers WHERE provider_id = $1' },
+      { rel: 'user_providers.json',        sql: 'SELECT * FROM user_providers WHERE provider_id = $1' },
+      { rel: 'provisioner_providers.json', sql: 'SELECT * FROM provisioner_providers WHERE provider_id = $1' },
+      { rel: 'tournament_assignments.json', sql: 'SELECT * FROM tournament_assignments WHERE provider_id = $1' },
+      { rel: 'official_records.json',      sql: 'SELECT * FROM official_records WHERE provider_id = $1' },
+      { rel: 'tournament_provisioner.json', sql: 'SELECT * FROM tournament_provisioner WHERE provider_id = $1' },
+      { rel: 'pending_saves.json',         sql: 'SELECT * FROM pending_saves WHERE provider_id = $1' },
+      { rel: 'provider_topologies.json',   sql: 'SELECT * FROM provider_topologies WHERE provider_id = $1' },
+      { rel: 'provider_catalog_items.json', sql: 'SELECT * FROM provider_catalog_items WHERE provider_id = $1' },
+      { rel: 'policies.json',              sql: 'SELECT * FROM policies WHERE provider_id = $1' },
+    ];
+
+    for (const { rel, sql } of tablesByProviderId) {
+      const result = await this.pool.query(sql, [provider.providerId]);
+      await writeJson(rel, result.rows, result.rows.length);
+    }
+
+    // Sanctioning uses a differently-named column.
+    const sanctioning = await this.pool.query(
+      'SELECT * FROM sanctioning_records WHERE applicant_provider_id = $1',
+      [provider.providerId],
+    );
+    await writeJson('sanctioning_records.json', sanctioning.rows, sanctioning.rows.length);
+
+    // Calendar is keyed by abbr, not id.
+    const calendars = await this.pool.query(
+      'SELECT * FROM calendars WHERE provider_abbr = $1',
+      [provider.providerAbbr],
+    );
+    await writeJson('calendar.json', calendars.rows, calendars.rows.length);
+
+    // Tournaments — one file per record. Even for a large provider this
+    // stays manageable: one JSON file per tournament, content roughly
+    // equal to what the live DB already stores.
+    const tournaments = await this.pool.query(
+      'SELECT tournament_id, provider_id, tournament_name, start_date, end_date, data, created_at, updated_at FROM tournaments WHERE provider_id = $1',
+      [provider.providerId],
+    );
+    const tournamentIds = tournaments.rows.map((r) => r.tournament_id);
+    for (const row of tournaments.rows) {
+      const rel = path.join('tournaments', `${row.tournament_id}.json`);
+      await writeJson(rel, row);
+    }
+
+    // Audit log: filtered by tournament_ids. Streamed as JSONL because
+    // a busy provider can have thousands of audit rows; loading them
+    // into one giant JSON array would balloon memory.
+    let auditCount = 0;
+    if (tournamentIds.length > 0) {
+      const auditResult = await this.pool.query(
+        'SELECT * FROM audit_log WHERE tournament_id = ANY($1::text[]) ORDER BY occurred_at',
+        [tournamentIds],
+      );
+      const lines = auditResult.rows.map((r) => JSON.stringify(r)).join('\n') + (auditResult.rows.length ? '\n' : '');
+      const filePath = path.join(partialDir, 'audit_log.jsonl');
+      await fs.writeFile(filePath, lines, 'utf8');
+      const sha = createHash('sha256').update(lines).digest('hex');
+      manifest.files['audit_log.jsonl'] = {
+        sha256: sha,
+        bytes: Buffer.byteLength(lines, 'utf8'),
+        rows: auditResult.rows.length,
+      };
+      auditCount = auditResult.rows.length;
+    } else {
+      // Still write an empty file so the manifest has a consistent
+      // file set regardless of whether the provider had tournaments.
+      const filePath = path.join(partialDir, 'audit_log.jsonl');
+      await fs.writeFile(filePath, '', 'utf8');
+      const sha = createHash('sha256').update('').digest('hex');
+      manifest.files['audit_log.jsonl'] = { sha256: sha, bytes: 0, rows: 0 };
+    }
+
+    // Write the manifest itself, then compute its sha256 as the
+    // top-level integrity check we record in provider_archives.
+    const manifestJson = JSON.stringify(manifest, null, 2);
+    await fs.writeFile(path.join(partialDir, 'manifest.json'), manifestJson, 'utf8');
+    const manifestSha256 = createHash('sha256').update(manifestJson).digest('hex');
+
+    // Count user_providers from manifest (avoid a second query)
+    const userAssocCount = manifest.files['user_providers.json']?.rows ?? 0;
+
+    // Atomic rename .partial → final. If this throws, the .partial
+    // directory survives for inspection / manual cleanup.
+    await fs.rename(partialDir, finalDir);
+
+    return {
+      archivePath: finalDir,
+      manifestSha256,
+      tournamentCount: tournaments.rows.length,
+      userAssocCount,
+      auditLogRows: auditCount,
+    };
+  }
+}

--- a/src/modules/providers/provider-cleanup.service.ts
+++ b/src/modules/providers/provider-cleanup.service.ts
@@ -1,0 +1,178 @@
+/**
+ * Single-transaction cleanup of every row that references a provider.
+ *
+ * Shared by:
+ *   - archive flow — exports first, then calls wipe()
+ *   - delete flow — calls wipe() directly, no export
+ *
+ * Tables touched (in order; provider row goes LAST so the CASCADE
+ * tables come along after their FK target is intact):
+ *
+ *   Soft-FK (must explicitly DELETE):
+ *     user_providers           (provider_id)
+ *     provisioner_providers    (provider_id)
+ *     tournament_assignments   (provider_id)
+ *     official_records         (provider_id)
+ *     sanctioning_records      (applicant_provider_id)
+ *     tournament_provisioner   (provider_id)
+ *     pending_saves            (provider_id)
+ *     calendars                (provider_abbr — KEYED BY ABBR, not id!)
+ *     tournaments              (provider_id)
+ *
+ *   CASCADE (deleted automatically when providers row goes):
+ *     provider_topologies      (FK ON DELETE CASCADE)
+ *     provider_catalog_items   (FK ON DELETE CASCADE)
+ *     policies                 (FK ON DELETE CASCADE)
+ *
+ *   Preserved (FK-free by design, survives provider deletion):
+ *     audit_log                (referenced by tournament_id but no FK)
+ *
+ * All inside ONE transaction. Rollback on any failure leaves the live
+ * DB exactly as it was. The archive export (written to disk OUTSIDE
+ * this transaction) is the caller's responsibility to compute first
+ * and clean up on rollback.
+ */
+import { Inject, Injectable } from '@nestjs/common';
+import { Pool } from 'pg';
+
+import { PG_POOL } from 'src/storage/postgres/postgres.config';
+
+export interface CleanupCounts {
+  tournaments: number;
+  userAssociations: number;
+  provisionerAssociations: number;
+  tournamentAssignments: number;
+  officialRecords: number;
+  sanctioningRecords: number;
+  tournamentProvisioner: number;
+  pendingSaves: number;
+  calendars: number;
+  // CASCADE tables — included in counts so the preview shows the full
+  // blast radius even though we don't issue explicit DELETEs for them.
+  topologies: number;
+  catalogItems: number;
+  policies: number;
+  // Audit log row count for the tournaments owned by this provider.
+  // NOT deleted — preserved by design. Included in counts so the
+  // archive export knows how much audit history to ship.
+  auditLogRows: number;
+}
+
+@Injectable()
+export class ProviderCleanupService {
+  constructor(@Inject(PG_POOL) private readonly pool: Pool) {}
+
+  /**
+   * Read-only count of rows that would be touched by `wipe()`. Used by
+   * the preview-archive endpoint so the confirmation modal can show
+   * the user what they're about to destroy.
+   */
+  async getCounts(providerId: string, providerAbbr: string): Promise<CleanupCounts> {
+    const sql = `
+      WITH tournament_ids AS (
+        SELECT tournament_id FROM tournaments WHERE provider_id = $1
+      )
+      SELECT
+        (SELECT COUNT(*) FROM tournaments WHERE provider_id = $1)               AS tournaments,
+        (SELECT COUNT(*) FROM user_providers WHERE provider_id = $1)            AS user_associations,
+        (SELECT COUNT(*) FROM provisioner_providers WHERE provider_id = $1)     AS provisioner_associations,
+        (SELECT COUNT(*) FROM tournament_assignments WHERE provider_id = $1)    AS tournament_assignments,
+        (SELECT COUNT(*) FROM official_records WHERE provider_id = $1)          AS official_records,
+        (SELECT COUNT(*) FROM sanctioning_records WHERE applicant_provider_id = $1) AS sanctioning_records,
+        (SELECT COUNT(*) FROM tournament_provisioner WHERE provider_id = $1)    AS tournament_provisioner,
+        (SELECT COUNT(*) FROM pending_saves WHERE provider_id = $1)             AS pending_saves,
+        (SELECT COUNT(*) FROM calendars WHERE provider_abbr = $2)               AS calendars,
+        (SELECT COUNT(*) FROM provider_topologies WHERE provider_id = $1)       AS topologies,
+        (SELECT COUNT(*) FROM provider_catalog_items WHERE provider_id = $1)    AS catalog_items,
+        (SELECT COUNT(*) FROM policies WHERE provider_id = $1)                  AS policies,
+        (SELECT COUNT(*) FROM audit_log WHERE tournament_id IN (SELECT tournament_id FROM tournament_ids)) AS audit_log_rows
+    `;
+    const result = await this.pool.query(sql, [providerId, providerAbbr]);
+    const row = result.rows[0] ?? {};
+    return {
+      tournaments: Number(row.tournaments ?? 0),
+      userAssociations: Number(row.user_associations ?? 0),
+      provisionerAssociations: Number(row.provisioner_associations ?? 0),
+      tournamentAssignments: Number(row.tournament_assignments ?? 0),
+      officialRecords: Number(row.official_records ?? 0),
+      sanctioningRecords: Number(row.sanctioning_records ?? 0),
+      tournamentProvisioner: Number(row.tournament_provisioner ?? 0),
+      pendingSaves: Number(row.pending_saves ?? 0),
+      calendars: Number(row.calendars ?? 0),
+      topologies: Number(row.topologies ?? 0),
+      catalogItems: Number(row.catalog_items ?? 0),
+      policies: Number(row.policies ?? 0),
+      auditLogRows: Number(row.audit_log_rows ?? 0),
+    };
+  }
+
+  /**
+   * Atomic wipe — all DELETEs in a single transaction. Throws on any
+   * failure (caller's responsibility to ROLLBACK any outer side effects
+   * like an in-progress archive directory write).
+   *
+   * Returns the counts of rows actually deleted so the caller can
+   * record them in `provider_archives` (or surface to logs).
+   */
+  async wipe(providerId: string, providerAbbr: string): Promise<CleanupCounts> {
+    const client = await this.pool.connect();
+    try {
+      await client.query('BEGIN');
+
+      // Soft-FK tables (explicit DELETE, no CASCADE here)
+      const userAssoc          = await client.query('DELETE FROM user_providers WHERE provider_id = $1', [providerId]);
+      const provisionerAssoc   = await client.query('DELETE FROM provisioner_providers WHERE provider_id = $1', [providerId]);
+      const tournamentAssign   = await client.query('DELETE FROM tournament_assignments WHERE provider_id = $1', [providerId]);
+      const officialRec        = await client.query('DELETE FROM official_records WHERE provider_id = $1', [providerId]);
+      const sanctioningRec     = await client.query('DELETE FROM sanctioning_records WHERE applicant_provider_id = $1', [providerId]);
+      const tournamentProv     = await client.query('DELETE FROM tournament_provisioner WHERE provider_id = $1', [providerId]);
+      const pendingSaves       = await client.query('DELETE FROM pending_saves WHERE provider_id = $1', [providerId]);
+      const calendars          = await client.query('DELETE FROM calendars WHERE provider_abbr = $1', [providerAbbr]);
+      const tournaments        = await client.query('DELETE FROM tournaments WHERE provider_id = $1', [providerId]);
+
+      // Count CASCADE-bound rows BEFORE the providers DELETE so we can
+      // report them in the returned counts.
+      const topologies   = await client.query('SELECT COUNT(*)::int AS n FROM provider_topologies WHERE provider_id = $1', [providerId]);
+      const catalogItems = await client.query('SELECT COUNT(*)::int AS n FROM provider_catalog_items WHERE provider_id = $1', [providerId]);
+      const policies     = await client.query('SELECT COUNT(*)::int AS n FROM policies WHERE provider_id = $1', [providerId]);
+
+      // Audit log row count (preserved, not deleted) — query within the
+      // same transaction so the answer is consistent with the live state
+      // at wipe time.
+      const auditLogRows = await client.query(
+        `SELECT COUNT(*)::int AS n FROM audit_log
+          WHERE tournament_id IN (
+            SELECT tournament_id FROM tournaments WHERE provider_id = $1
+          )`,
+        [providerId],
+      );
+
+      // FINALLY: the providers row itself. ON DELETE CASCADE picks up
+      // provider_topologies + provider_catalog_items + policies.
+      await client.query('DELETE FROM providers WHERE provider_id = $1', [providerId]);
+
+      await client.query('COMMIT');
+
+      return {
+        tournaments: tournaments.rowCount ?? 0,
+        userAssociations: userAssoc.rowCount ?? 0,
+        provisionerAssociations: provisionerAssoc.rowCount ?? 0,
+        tournamentAssignments: tournamentAssign.rowCount ?? 0,
+        officialRecords: officialRec.rowCount ?? 0,
+        sanctioningRecords: sanctioningRec.rowCount ?? 0,
+        tournamentProvisioner: tournamentProv.rowCount ?? 0,
+        pendingSaves: pendingSaves.rowCount ?? 0,
+        calendars: calendars.rowCount ?? 0,
+        topologies: topologies.rows[0]?.n ?? 0,
+        catalogItems: catalogItems.rows[0]?.n ?? 0,
+        policies: policies.rows[0]?.n ?? 0,
+        auditLogRows: auditLogRows.rows[0]?.n ?? 0,
+      };
+    } catch (err) {
+      await client.query('ROLLBACK').catch(() => undefined);
+      throw err;
+    } finally {
+      client.release();
+    }
+  }
+}

--- a/src/modules/providers/provider-lifecycle.service.spec.ts
+++ b/src/modules/providers/provider-lifecycle.service.spec.ts
@@ -1,0 +1,193 @@
+import { BadRequestException, ConflictException, ForbiddenException, NotFoundException } from '@nestjs/common';
+
+import { ProviderLifecycleService } from './provider-lifecycle.service';
+
+describe('ProviderLifecycleService', () => {
+  let service: ProviderLifecycleService;
+  let mockProviderStorage: any;
+  let mockArchiveStorage: any;
+  let mockCleanupService: any;
+  let mockArchiveService: any;
+
+  const superAdminCtx: any = { isSuperAdmin: true, userId: 'admin-uuid' };
+  const nonSuperAdminCtx: any = { isSuperAdmin: false, userId: 'u-1' };
+  const providerRow = {
+    organisationAbbreviation: 'TESTORG',
+    organisationName: 'Test Organisation',
+  };
+
+  beforeEach(() => {
+    mockProviderStorage = {
+      getProvider: jest.fn().mockResolvedValue(providerRow),
+    };
+    mockArchiveStorage = {
+      insert: jest.fn().mockResolvedValue({ archiveId: 'arch-123' }),
+    };
+    mockCleanupService = {
+      getCounts: jest.fn().mockResolvedValue({
+        tournaments: 5,
+        userAssociations: 2,
+        provisionerAssociations: 0,
+        tournamentAssignments: 3,
+        officialRecords: 0,
+        sanctioningRecords: 0,
+        tournamentProvisioner: 0,
+        pendingSaves: 1,
+        calendars: 1,
+        topologies: 0,
+        catalogItems: 0,
+        policies: 0,
+        auditLogRows: 42,
+      }),
+      wipe: jest.fn().mockResolvedValue({
+        tournaments: 5,
+        userAssociations: 2,
+        provisionerAssociations: 0,
+        tournamentAssignments: 3,
+        officialRecords: 0,
+        sanctioningRecords: 0,
+        tournamentProvisioner: 0,
+        pendingSaves: 1,
+        calendars: 1,
+        topologies: 0,
+        catalogItems: 0,
+        policies: 0,
+        auditLogRows: 42,
+      }),
+    };
+    mockArchiveService = {
+      writeArchive: jest.fn().mockResolvedValue({
+        archivePath: '/tmp/archives/TESTORG-2026-05-22T17-00-00-000Z',
+        manifestSha256: 'abc123',
+        tournamentCount: 5,
+        userAssocCount: 2,
+        auditLogRows: 42,
+      }),
+    };
+
+    service = new ProviderLifecycleService(
+      mockProviderStorage,
+      mockArchiveStorage,
+      mockCleanupService,
+      mockArchiveService,
+    );
+  });
+
+  describe('preview', () => {
+    it('throws Forbidden for non-super-admin', async () => {
+      await expect(service.preview('p-1', nonSuperAdminCtx)).rejects.toThrow(ForbiddenException);
+    });
+
+    it('throws NotFound when the provider does not exist', async () => {
+      mockProviderStorage.getProvider.mockResolvedValue(null);
+      await expect(service.preview('p-missing', superAdminCtx)).rejects.toThrow(NotFoundException);
+    });
+
+    it('throws BadRequest when the provider has no organisationAbbreviation', async () => {
+      mockProviderStorage.getProvider.mockResolvedValue({ organisationName: 'No-Abbr' });
+      await expect(service.preview('p-1', superAdminCtx)).rejects.toThrow(BadRequestException);
+    });
+
+    it('returns counts for a valid provider', async () => {
+      const result = await service.preview('p-1', superAdminCtx);
+      expect(result.providerAbbr).toBe('TESTORG');
+      expect(result.counts.tournaments).toBe(5);
+      expect(result.counts.auditLogRows).toBe(42);
+    });
+  });
+
+  describe('archive', () => {
+    it('throws Forbidden for non-super-admin', async () => {
+      await expect(service.archive('p-1', 'TESTORG', nonSuperAdminCtx)).rejects.toThrow(
+        ForbiddenException,
+      );
+    });
+
+    it('throws BadRequest when confirm does not match abbreviation', async () => {
+      await expect(service.archive('p-1', 'WRONG', superAdminCtx)).rejects.toThrow(
+        BadRequestException,
+      );
+      expect(mockArchiveService.writeArchive).not.toHaveBeenCalled();
+      expect(mockCleanupService.wipe).not.toHaveBeenCalled();
+    });
+
+    it('writes archive, wipes, and records an archive row on the happy path', async () => {
+      const result: any = await service.archive('p-1', 'TESTORG', superAdminCtx);
+
+      expect(mockArchiveService.writeArchive).toHaveBeenCalledWith(
+        expect.objectContaining({ providerId: 'p-1', providerAbbr: 'TESTORG' }),
+      );
+      expect(mockCleanupService.wipe).toHaveBeenCalledWith('p-1', 'TESTORG');
+      expect(mockArchiveStorage.insert).toHaveBeenCalledWith(
+        expect.objectContaining({
+          providerId: 'p-1',
+          providerAbbr: 'TESTORG',
+          manifestSha256: 'abc123',
+          tournamentCount: 5,
+          archivedBy: 'admin-uuid',
+        }),
+      );
+      expect(result.success).toBe(true);
+      expect(result.archiveId).toBe('arch-123');
+    });
+
+    it('writes archive BEFORE wiping (order matters — archive is the durable record)', async () => {
+      const callOrder: string[] = [];
+      mockArchiveService.writeArchive.mockImplementation(async () => {
+        callOrder.push('writeArchive');
+        return {
+          archivePath: '/tmp/x',
+          manifestSha256: 'h',
+          tournamentCount: 0,
+          userAssocCount: 0,
+          auditLogRows: 0,
+        };
+      });
+      mockCleanupService.wipe.mockImplementation(async () => {
+        callOrder.push('wipe');
+        return {} as any;
+      });
+      await service.archive('p-1', 'TESTORG', superAdminCtx);
+      expect(callOrder).toEqual(['writeArchive', 'wipe']);
+    });
+
+    it('does NOT insert provider_archives row when wipe fails (archive dir remains but no DB pointer)', async () => {
+      mockCleanupService.wipe.mockRejectedValue(new Error('DB down mid-transaction'));
+      await expect(service.archive('p-1', 'TESTORG', superAdminCtx)).rejects.toThrow('DB down');
+      expect(mockArchiveService.writeArchive).toHaveBeenCalled();
+      expect(mockArchiveStorage.insert).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('delete', () => {
+    it('throws Forbidden for non-super-admin', async () => {
+      await expect(service.delete('p-1', 'TESTORG', true, nonSuperAdminCtx)).rejects.toThrow(
+        ForbiddenException,
+      );
+    });
+
+    it('throws BadRequest when confirm does not match abbreviation', async () => {
+      await expect(service.delete('p-1', 'WRONG', true, superAdminCtx)).rejects.toThrow(
+        BadRequestException,
+      );
+      expect(mockCleanupService.wipe).not.toHaveBeenCalled();
+    });
+
+    it('throws Conflict when acknowledgeDataLoss is false', async () => {
+      await expect(service.delete('p-1', 'TESTORG', false, superAdminCtx)).rejects.toThrow(
+        ConflictException,
+      );
+      expect(mockCleanupService.wipe).not.toHaveBeenCalled();
+    });
+
+    it('wipes on the happy path, with no archive', async () => {
+      const result: any = await service.delete('p-1', 'TESTORG', true, superAdminCtx);
+
+      expect(mockCleanupService.wipe).toHaveBeenCalledWith('p-1', 'TESTORG');
+      expect(mockArchiveService.writeArchive).not.toHaveBeenCalled();
+      expect(mockArchiveStorage.insert).not.toHaveBeenCalled();
+      expect(result.success).toBe(true);
+      expect(result.counts.tournaments).toBe(5);
+    });
+  });
+});

--- a/src/modules/providers/provider-lifecycle.service.ts
+++ b/src/modules/providers/provider-lifecycle.service.ts
@@ -1,0 +1,166 @@
+/**
+ * Provider lifecycle — preview / archive / delete orchestration.
+ *
+ * Archive flow (the destructive but recoverable one):
+ *   1. Fetch provider record (need abbr + name for archive directory)
+ *   2. Write archive directory to disk via ProviderArchiveService
+ *   3. ProviderCleanupService.wipe() inside ONE DB transaction
+ *   4. Insert provider_archives row with the manifest sha256
+ *
+ * If step 3 fails, the .partial directory from step 2 is left on disk
+ * for inspection; the live DB is unchanged. We deliberately don't
+ * auto-clean failed .partial dirs — a human inspecting them after a
+ * failure is better than silently swallowing what went wrong.
+ *
+ * Delete flow:
+ *   1. ProviderCleanupService.wipe() (same transaction)
+ *   2. Done. No disk artefact, no provider_archives row, no revive.
+ *
+ * Both require `confirm` body field matching the provider's
+ * abbreviation. Delete additionally requires `acknowledgeDataLoss:
+ * true` to make the irrevocability impossible to do by accident.
+ */
+import { BadRequestException, ConflictException, ForbiddenException, Inject, Injectable, Logger, NotFoundException } from '@nestjs/common';
+
+import { ProviderCleanupService, type CleanupCounts } from './provider-cleanup.service';
+import { ProviderArchiveService } from './provider-archive.service';
+import { PROVIDER_STORAGE, type IProviderStorage, PROVIDER_ARCHIVE_STORAGE, type IProviderArchiveStorage } from 'src/storage/interfaces';
+import type { UserContext } from '../account/auth/decorators/user-context.decorator';
+
+export interface PreviewArchiveResult {
+  providerId: string;
+  providerAbbr: string;
+  providerName: string;
+  counts: CleanupCounts;
+}
+
+@Injectable()
+export class ProviderLifecycleService {
+  private readonly logger = new Logger(ProviderLifecycleService.name);
+
+  constructor(
+    @Inject(PROVIDER_STORAGE) private readonly providerStorage: IProviderStorage,
+    @Inject(PROVIDER_ARCHIVE_STORAGE) private readonly archiveStorage: IProviderArchiveStorage,
+    private readonly cleanupService: ProviderCleanupService,
+    private readonly archiveService: ProviderArchiveService,
+  ) {}
+
+  private async loadProvider(providerId: string): Promise<{
+    providerId: string;
+    providerAbbr: string;
+    providerName: string;
+  }> {
+    const record: any = await this.providerStorage.getProvider(providerId);
+    if (!record) throw new NotFoundException(`Provider ${providerId} not found`);
+    const providerAbbr = record.organisationAbbreviation ?? record.providerAbbr ?? '';
+    const providerName = record.organisationName ?? '';
+    if (!providerAbbr) {
+      throw new BadRequestException(
+        `Provider ${providerId} has no organisationAbbreviation — cannot archive without one (the archive directory is keyed by abbr).`,
+      );
+    }
+    return { providerId, providerAbbr, providerName };
+  }
+
+  private assertSuperAdmin(ctx: UserContext | undefined): void {
+    if (!ctx?.isSuperAdmin) {
+      throw new ForbiddenException('SUPER_ADMIN required for provider lifecycle operations');
+    }
+  }
+
+  /** Read-only preview — no destructive side effects. */
+  async preview(providerId: string, ctx: UserContext | undefined): Promise<PreviewArchiveResult> {
+    this.assertSuperAdmin(ctx);
+    const provider = await this.loadProvider(providerId);
+    const counts = await this.cleanupService.getCounts(provider.providerId, provider.providerAbbr);
+    return { ...provider, counts };
+  }
+
+  /** Archive + wipe. */
+  async archive(
+    providerId: string,
+    confirm: string,
+    ctx: UserContext | undefined,
+  ): Promise<{ success: true; archiveId: string; archivePath: string; counts: CleanupCounts }> {
+    this.assertSuperAdmin(ctx);
+    const provider = await this.loadProvider(providerId);
+
+    if (confirm !== provider.providerAbbr) {
+      throw new BadRequestException(
+        `confirm must equal the provider abbreviation "${provider.providerAbbr}" to authorise an archive`,
+      );
+    }
+
+    // Write export FIRST so the cleanup transaction has something to
+    // record. The export is the durable evidence; the cleanup is the
+    // destructive step.
+    const writeResult = await this.archiveService.writeArchive(provider);
+
+    let counts: CleanupCounts;
+    try {
+      counts = await this.cleanupService.wipe(provider.providerId, provider.providerAbbr);
+    } catch (err) {
+      // Cleanup failed — the archive directory survived but live DB is
+      // unchanged. Log loudly and re-throw; operator can inspect the
+      // .partial-less final archive dir and decide whether to retry
+      // cleanup (idempotent — second wipe just no-ops the missing rows)
+      // or rm-rf the orphan archive.
+      this.logger.error(
+        `archive: wipe failed after archive ${writeResult.archivePath} was written: ${(err as Error).message}`,
+      );
+      throw err;
+    }
+
+    const archiveRow = await this.archiveStorage.insert({
+      providerId: provider.providerId,
+      providerAbbr: provider.providerAbbr,
+      providerName: provider.providerName,
+      archivePath: writeResult.archivePath,
+      manifestSha256: writeResult.manifestSha256,
+      tournamentCount: writeResult.tournamentCount,
+      userAssocCount: writeResult.userAssocCount,
+      archivedBy: ctx?.userId ?? null,
+    });
+
+    this.logger.log(
+      `archived provider ${provider.providerId} (${provider.providerAbbr}) — ${writeResult.tournamentCount} tournaments, ${writeResult.userAssocCount} user assocs, ${writeResult.auditLogRows} audit rows. Archive: ${writeResult.archivePath}`,
+    );
+
+    return {
+      success: true,
+      archiveId: archiveRow.archiveId,
+      archivePath: writeResult.archivePath,
+      counts,
+    };
+  }
+
+  /** Hard delete — no export, no provider_archives row. */
+  async delete(
+    providerId: string,
+    confirm: string,
+    acknowledgeDataLoss: boolean,
+    ctx: UserContext | undefined,
+  ): Promise<{ success: true; counts: CleanupCounts }> {
+    this.assertSuperAdmin(ctx);
+    const provider = await this.loadProvider(providerId);
+
+    if (confirm !== provider.providerAbbr) {
+      throw new BadRequestException(
+        `confirm must equal the provider abbreviation "${provider.providerAbbr}" to authorise a delete`,
+      );
+    }
+    if (acknowledgeDataLoss !== true) {
+      throw new ConflictException(
+        'acknowledgeDataLoss must be explicitly true. Delete is irrevocable — use archive if you want a recoverable record.',
+      );
+    }
+
+    const counts = await this.cleanupService.wipe(provider.providerId, provider.providerAbbr);
+
+    this.logger.log(
+      `DELETED provider ${provider.providerId} (${provider.providerAbbr}) — ${counts.tournaments} tournaments destroyed. No archive.`,
+    );
+
+    return { success: true, counts };
+  }
+}

--- a/src/modules/providers/providers.controller.ts
+++ b/src/modules/providers/providers.controller.ts
@@ -13,6 +13,9 @@ import {
 } from '@nestjs/common';
 import { UserCtx, type UserContext } from '../account/auth/decorators/user-context.decorator';
 import { ADMIN, CLIENT, PROVIDER_ADMIN, SUPER_ADMIN } from 'src/common/constants/roles';
+import { ProviderLifecycleService } from './provider-lifecycle.service';
+import { ArchiveProviderDto } from './dto/archiveProvider.dto';
+import { DeleteProviderDto } from './dto/deleteProvider.dto';
 import { ModifyProviderDto } from './dto/modifyProvider.dto';
 import { Public } from '../account/auth/decorators/public.decorator';
 import { Roles } from '../account/auth/decorators/roles.decorator';
@@ -31,7 +34,65 @@ export class ProvidersController {
     private readonly providers: ProvidersService,
     private readonly topologies: TopologiesService,
     private readonly catalog: ProviderCatalogService,
+    private readonly lifecycle: ProviderLifecycleService,
   ) {}
+
+  /**
+   * Plan A — read-only preview of what would be destroyed by a
+   * subsequent archive or delete call. Used by the admin UI to show
+   * the operator the blast radius before they type the confirmation
+   * abbreviation.
+   *
+   * SUPER_ADMIN only.
+   */
+  @Post(':providerId/preview-archive')
+  @Roles([CLIENT, SUPER_ADMIN])
+  @HttpCode(HttpStatus.OK)
+  previewArchive(@Param('providerId') providerId: string, @UserCtx() ctx: UserContext) {
+    return this.lifecycle.preview(providerId, ctx);
+  }
+
+  /**
+   * Plan A — archive (export to disk + wipe from live DB).
+   *
+   * SUPER_ADMIN only. Requires `confirm` body field matching the
+   * provider's organisationAbbreviation. Recoverable via
+   * `src/scripts/revive-provider.mjs`.
+   */
+  @Post(':providerId/archive')
+  @Roles([CLIENT, SUPER_ADMIN])
+  @HttpCode(HttpStatus.OK)
+  archiveProvider(
+    @Param('providerId') providerId: string,
+    @Body() body: ArchiveProviderDto,
+    @UserCtx() ctx: UserContext,
+  ) {
+    return this.lifecycle.archive(providerId, body?.confirm ?? '', ctx);
+  }
+
+  /**
+   * Plan A — DESTRUCTIVE delete (no export, no provider_archives row,
+   * no revive). For demo providers and the like — providers whose data
+   * has no value worth preserving.
+   *
+   * SUPER_ADMIN only. Requires `confirm` body field matching the
+   * abbreviation AND `acknowledgeDataLoss: true`.
+   */
+  @Post(':providerId/delete')
+  @Roles([CLIENT, SUPER_ADMIN])
+  @HttpCode(HttpStatus.OK)
+  deleteProvider(
+    @Param('providerId') providerId: string,
+    @Body() body: DeleteProviderDto,
+    @UserCtx() ctx: UserContext,
+  ) {
+    return this.lifecycle.delete(
+      providerId,
+      body?.confirm ?? '',
+      body?.acknowledgeDataLoss === true,
+      ctx,
+    );
+  }
 
   /**
    * Per-provider topology catalog. PROVIDER_ADMIN of the target provider

--- a/src/modules/providers/providers.module.ts
+++ b/src/modules/providers/providers.module.ts
@@ -1,3 +1,6 @@
+import { ProviderLifecycleService } from './provider-lifecycle.service';
+import { ProviderCleanupService } from './provider-cleanup.service';
+import { ProviderArchiveService } from './provider-archive.service';
 import { ProvidersController } from './providers.controller';
 import { ProvidersService } from './providers.service';
 import { TopologiesService } from './topologies.service';
@@ -6,7 +9,14 @@ import { Module } from '@nestjs/common';
 
 @Module({
   controllers: [ProvidersController],
-  providers: [ProvidersService, TopologiesService, ProviderCatalogService],
+  providers: [
+    ProvidersService,
+    TopologiesService,
+    ProviderCatalogService,
+    ProviderArchiveService,
+    ProviderCleanupService,
+    ProviderLifecycleService,
+  ],
   exports: [ProvidersService, TopologiesService, ProviderCatalogService],
 })
 export class ProvidersModule {}

--- a/src/modules/providers/providers.service.spec.ts
+++ b/src/modules/providers/providers.service.spec.ts
@@ -1,3 +1,6 @@
+import { ProviderLifecycleService } from './provider-lifecycle.service';
+import { ProviderCleanupService } from './provider-cleanup.service';
+import { ProviderArchiveService } from './provider-archive.service';
 import { ProvidersController } from './providers.controller';
 import { StorageModule } from 'src/storage/storage.module';
 import { ProvidersService } from './providers.service';
@@ -16,7 +19,15 @@ describe('ProvidersService', () => {
   beforeAll(async () => {
     app = await Test.createTestingModule({
       imports: [AuthModule, UsersModule, CacheModule, StorageModule],
-      providers: [ProvidersService, TopologiesService, ProviderCatalogService, ConfigService],
+      providers: [
+        ProvidersService,
+        TopologiesService,
+        ProviderCatalogService,
+        ProviderArchiveService,
+        ProviderCleanupService,
+        ProviderLifecycleService,
+        ConfigService,
+      ],
       controllers: [ProvidersController],
     }).compile();
 

--- a/src/scripts/audit-demo-tournaments.mjs
+++ b/src/scripts/audit-demo-tournaments.mjs
@@ -1,0 +1,207 @@
+#!/usr/bin/env node
+/**
+ * audit-demo-tournaments.mjs — classify every row in the tournaments
+ * table as confirmed-demo / suspected-demo / real, and print a CSV
+ * report. Optional --delete-confirmed flag deletes the
+ * `classification = confirmed` rows after the operator has reviewed
+ * the report.
+ *
+ * `isMock` (on the tournamentRecord JSONB blob) is the authoritative
+ * marker: mocksEngine stamps it on every generated record, so anything
+ * with `data.isMock === true` is definitionally a demo tournament.
+ * Beyond that, the script flags rows whose tournamentId matches the
+ * mocksEngine's typical id shape ("mock-*", UUID-only) or whose name
+ * looks demo-shaped ("test", "demo", "sample", "mock") as SUSPECTED
+ * so a human can eyeball them.
+ *
+ * Why a standalone script and not an endpoint: this is a one-shot
+ * cleanup tool. The Plan A archive/delete endpoints handle the live
+ * provider-lifecycle case; this audits historical accidental demos
+ * so the user can clean before archiving the providers that own them.
+ *
+ * Usage:
+ *   node src/scripts/audit-demo-tournaments.mjs                       # CSV to stdout
+ *   node src/scripts/audit-demo-tournaments.mjs > demos.csv           # save
+ *   node src/scripts/audit-demo-tournaments.mjs --confirmed-only      # only isMock=true rows
+ *   node src/scripts/audit-demo-tournaments.mjs --provider <id>       # filter by provider
+ *   node src/scripts/audit-demo-tournaments.mjs --delete-confirmed    # DESTRUCTIVE: deletes confirmed rows
+ *
+ * Exit codes:
+ *   0  success
+ *   1  configuration error (no DB connection)
+ *   2  runtime error
+ */
+
+import minimist from 'minimist';
+import pg from 'pg';
+import 'dotenv/config';
+
+const { Pool } = pg;
+
+const args = minimist(process.argv.slice(2), {
+  boolean: ['confirmed-only', 'delete-confirmed', 'help'],
+  string: ['provider'],
+  alias: { h: 'help', p: 'provider' },
+});
+
+if (args.help) {
+  console.error(`Usage: node src/scripts/audit-demo-tournaments.mjs [flags]
+  --confirmed-only       Only emit rows where tournamentRecord.isMock === true
+  --provider <id>        Filter by providerId
+  --delete-confirmed     After printing, DELETE all confirmed-demo rows
+  -h, --help             Show this`);
+  process.exit(0);
+}
+
+const pool = new Pool({
+  host:     process.env.PG_HOST,
+  port:     process.env.PG_PORT ? Number(process.env.PG_PORT) : undefined,
+  user:     process.env.PG_USER,
+  password: process.env.PG_PASSWORD,
+  database: process.env.PG_DATABASE,
+});
+
+// Patterns the script treats as SUSPECTED-demo. Conservative: a real
+// tournament named "Bristol Test Trophy" should NOT be flagged, so the
+// regex looks for word-boundary matches on tokens that are unambiguously
+// internal-use language. The operator reads the CSV and decides.
+const NAME_PATTERNS = [
+  /\b(demo|sample|mock|playground|sandbox)\b/i,
+  /^test\b/i,
+  /\btest\s+(event|tournament|draw)\b/i,
+];
+
+const ID_PATTERNS = [
+  /^mock-/i,                 // mocksEngine sometimes prefixes
+  /^demo-/i,
+  /^test-/i,
+  /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i, // bare UUID (factory test pattern)
+];
+
+function classify(row) {
+  const record = row.data ?? {};
+  if (record.isMock === true) return 'confirmed';
+  const id = String(row.tournament_id ?? '');
+  const name = String(row.tournament_name ?? record.tournamentName ?? '');
+  if (ID_PATTERNS.some((p) => p.test(id))) return 'suspected';
+  if (NAME_PATTERNS.some((p) => p.test(name))) return 'suspected';
+  return 'real';
+}
+
+function countEvents(record) {
+  return Array.isArray(record?.events) ? record.events.length : 0;
+}
+
+function countMatchUps(record) {
+  let total = 0;
+  for (const event of record?.events ?? []) {
+    for (const flight of event?.drawDefinitions ?? []) {
+      for (const structure of flight?.structures ?? []) {
+        total += Array.isArray(structure?.matchUps) ? structure.matchUps.length : 0;
+      }
+    }
+  }
+  return total;
+}
+
+function csvEscape(value) {
+  const s = value == null ? '' : String(value);
+  if (s.includes(',') || s.includes('"') || s.includes('\n')) {
+    return '"' + s.replaceAll('"', '""') + '"';
+  }
+  return s;
+}
+
+async function main() {
+  let where = '';
+  const params = [];
+  if (args.provider) {
+    params.push(args.provider);
+    where = `WHERE provider_id = $${params.length}`;
+  }
+
+  const sql = `
+    SELECT t.tournament_id,
+           t.provider_id,
+           t.tournament_name,
+           t.updated_at,
+           t.data,
+           p.organisation_abbreviation AS provider_abbr
+      FROM tournaments t
+      LEFT JOIN providers p ON p.provider_id = t.provider_id
+      ${where}
+  `;
+
+  const result = await pool.query(sql, params);
+
+  const rows = result.rows.map((row) => {
+    const record = row.data ?? {};
+    return {
+      tournament_id:   row.tournament_id,
+      provider_id:     row.provider_id ?? '',
+      provider_abbr:   row.provider_abbr ?? '',
+      name:            row.tournament_name ?? record.tournamentName ?? '',
+      classification:  classify(row),
+      last_modified:   row.updated_at?.toISOString?.() ?? '',
+      event_count:     countEvents(record),
+      matchup_count:   countMatchUps(record),
+    };
+  });
+
+  const filtered = args['confirmed-only']
+    ? rows.filter((r) => r.classification === 'confirmed')
+    : rows;
+
+  // Print CSV header + rows. Stable order: classification (confirmed first), then provider_abbr, then name.
+  const order = { confirmed: 0, suspected: 1, real: 2 };
+  filtered.sort((a, b) =>
+    order[a.classification] - order[b.classification] ||
+    a.provider_abbr.localeCompare(b.provider_abbr) ||
+    a.name.localeCompare(b.name),
+  );
+
+  const header = 'tournament_id,provider_id,provider_abbr,name,classification,last_modified,event_count,matchup_count';
+  console.log(header);
+  for (const r of filtered) {
+    console.log([
+      csvEscape(r.tournament_id),
+      csvEscape(r.provider_id),
+      csvEscape(r.provider_abbr),
+      csvEscape(r.name),
+      csvEscape(r.classification),
+      csvEscape(r.last_modified),
+      csvEscape(r.event_count),
+      csvEscape(r.matchup_count),
+    ].join(','));
+  }
+
+  // Summary to stderr so CSV-to-file usage doesn't get polluted.
+  const counts = { confirmed: 0, suspected: 0, real: 0 };
+  for (const r of rows) counts[r.classification]++;
+  console.error(
+    `\nSummary: ${rows.length} total | confirmed: ${counts.confirmed} | suspected: ${counts.suspected} | real: ${counts.real}`,
+  );
+
+  if (args['delete-confirmed']) {
+    const ids = rows.filter((r) => r.classification === 'confirmed').map((r) => r.tournament_id);
+    if (ids.length === 0) {
+      console.error('--delete-confirmed: no confirmed rows to delete');
+    } else {
+      console.error(`\n--delete-confirmed: deleting ${ids.length} confirmed-demo tournaments…`);
+      const del = await pool.query(`DELETE FROM tournaments WHERE tournament_id = ANY($1::text[])`, [ids]);
+      console.error(`deleted ${del.rowCount} row(s) from tournaments`);
+      // Note: this does NOT clean associated assignments, audit_log, or
+      // calendars — those are handled by the Plan A provider archive/delete
+      // path when the OWNING PROVIDER is archived. If you're using this
+      // standalone delete, run the audit again afterwards to confirm.
+    }
+  }
+}
+
+main()
+  .then(() => pool.end())
+  .catch((err) => {
+    console.error(err);
+    pool.end();
+    process.exit(2);
+  });

--- a/src/scripts/revive-provider.mjs
+++ b/src/scripts/revive-provider.mjs
@@ -1,0 +1,262 @@
+#!/usr/bin/env node
+/**
+ * revive-provider.mjs — restore an archived provider's rows.
+ *
+ * Reads an archive directory written by ProviderArchiveService,
+ * verifies the manifest sha256 against the recorded one in
+ * provider_archives, then INSERTs every row back in a single
+ * transaction. Refuses to overwrite a provider_id that's already
+ * present in the live DB.
+ *
+ * Usage:
+ *   node src/scripts/revive-provider.mjs <archive-path>
+ *   node src/scripts/revive-provider.mjs <archive-path> --yes      (skip confirm)
+ *   node src/scripts/revive-provider.mjs --by-id <archive_uuid>    (look up path)
+ *   node src/scripts/revive-provider.mjs --help
+ *
+ * No HTTP endpoint exists for revive — this is deliberately backend-
+ * only per the Plan A design. Revive should require an operator who
+ * has SSH access to the box anyway.
+ *
+ * Exit codes:
+ *   0  success
+ *   1  configuration / argument error
+ *   2  archive integrity check failed
+ *   3  conflict (provider_id already exists in live DB)
+ *   4  restore transaction failed
+ */
+
+import { createHash } from 'crypto';
+import fs from 'fs/promises';
+import path from 'path';
+import readline from 'readline';
+import minimist from 'minimist';
+import pg from 'pg';
+import 'dotenv/config';
+
+const { Pool } = pg;
+
+const args = minimist(process.argv.slice(2), {
+  boolean: ['yes', 'help'],
+  string: ['by-id'],
+  alias: { h: 'help', y: 'yes' },
+});
+
+if (args.help) {
+  console.error(`Usage: node src/scripts/revive-provider.mjs <archive-path> [--yes]
+       node src/scripts/revive-provider.mjs --by-id <archive_uuid> [--yes]
+
+Reads an archive directory, verifies the manifest, and restores every row
+back to the live DB in a single transaction.
+
+Flags:
+  --yes        Skip the interactive confirmation prompt
+  --by-id ID   Look up the archive_path via the provider_archives table
+  -h, --help   Show this`);
+  process.exit(0);
+}
+
+const pool = new Pool({
+  host:     process.env.PG_HOST,
+  port:     process.env.PG_PORT ? Number(process.env.PG_PORT) : undefined,
+  user:     process.env.PG_USER,
+  password: process.env.PG_PASSWORD,
+  database: process.env.PG_DATABASE,
+});
+
+async function resolveArchivePath() {
+  if (args['by-id']) {
+    const r = await pool.query(
+      `SELECT archive_path, manifest_sha256, revived_at
+         FROM provider_archives
+        WHERE archive_id = $1`,
+      [args['by-id']],
+    );
+    if (!r.rows.length) {
+      console.error(`No provider_archives row with archive_id = ${args['by-id']}`);
+      process.exit(1);
+    }
+    if (r.rows[0].revived_at) {
+      console.error(
+        `Warning: archive ${args['by-id']} was already revived at ${r.rows[0].revived_at}. Proceeding anyway — revive is idempotent at the row level only if the provider was archived again in between.`,
+      );
+    }
+    return { path: r.rows[0].archive_path, expectedSha: r.rows[0].manifest_sha256 };
+  }
+  const p = args._[0];
+  if (!p) {
+    console.error('archive-path or --by-id is required. Run with --help for usage.');
+    process.exit(1);
+  }
+  return { path: p, expectedSha: null };
+}
+
+async function loadManifest(archivePath) {
+  const manifestText = await fs.readFile(path.join(archivePath, 'manifest.json'), 'utf8');
+  const manifestSha = createHash('sha256').update(manifestText).digest('hex');
+  const manifest = JSON.parse(manifestText);
+  return { manifest, manifestSha, manifestText };
+}
+
+async function verifyPayloadFiles(archivePath, manifest) {
+  for (const [rel, meta] of Object.entries(manifest.files)) {
+    const buf = await fs.readFile(path.join(archivePath, rel));
+    const sha = createHash('sha256').update(buf).digest('hex');
+    if (sha !== meta.sha256) {
+      console.error(`Integrity check failed for ${rel}: expected ${meta.sha256}, got ${sha}`);
+      process.exit(2);
+    }
+  }
+}
+
+async function readJson(archivePath, rel) {
+  const text = await fs.readFile(path.join(archivePath, rel), 'utf8');
+  return JSON.parse(text);
+}
+
+async function readJsonl(archivePath, rel) {
+  const text = await fs.readFile(path.join(archivePath, rel), 'utf8');
+  if (!text.trim()) return [];
+  return text.trimEnd().split('\n').map((line) => JSON.parse(line));
+}
+
+async function confirm(prompt) {
+  if (args.yes) return true;
+  const rl = readline.createInterface({ input: process.stdin, output: process.stderr });
+  return new Promise((resolve) => {
+    rl.question(prompt, (answer) => {
+      rl.close();
+      resolve(answer.trim().toLowerCase() === 'yes');
+    });
+  });
+}
+
+function columns(rows) {
+  if (!rows?.length) return [];
+  return Object.keys(rows[0]);
+}
+
+async function insertRows(client, table, rows) {
+  if (!rows?.length) return 0;
+  const cols = columns(rows);
+  // Build a parameterised multi-row INSERT. Slow path but reliable for
+  // archives that fit in memory (a single provider's data should always
+  // fit — if it doesn't, the archive itself wouldn't have been built).
+  const placeholders = rows
+    .map((_, i) => `(${cols.map((_, j) => `$${i * cols.length + j + 1}`).join(',')})`)
+    .join(',');
+  const params = rows.flatMap((row) => cols.map((c) => row[c]));
+  const sql = `INSERT INTO ${table} (${cols.join(',')}) VALUES ${placeholders}`;
+  await client.query(sql, params);
+  return rows.length;
+}
+
+async function main() {
+  const { path: archivePath, expectedSha } = await resolveArchivePath();
+
+  console.error(`Reading archive: ${archivePath}`);
+  const { manifest, manifestSha } = await loadManifest(archivePath);
+
+  if (expectedSha && expectedSha !== manifestSha) {
+    console.error(
+      `Manifest sha mismatch: provider_archives row records ${expectedSha} but the archive's manifest hashes to ${manifestSha}. The archive directory may have been tampered with.`,
+    );
+    process.exit(2);
+  }
+
+  await verifyPayloadFiles(archivePath, manifest);
+  console.error(`Manifest verified. Provider: ${manifest.providerName} (${manifest.providerAbbr}) — ${manifest.providerId}`);
+
+  // Refuse if the provider_id is already live.
+  const existing = await pool.query('SELECT 1 FROM providers WHERE provider_id = $1', [manifest.providerId]);
+  if (existing.rows.length) {
+    console.error(
+      `Conflict: providers.provider_id = ${manifest.providerId} already exists in the live DB. Revive refuses to overwrite. Delete or rename the live row first.`,
+    );
+    process.exit(3);
+  }
+
+  const proceed = await confirm(`\nRestore ${manifest.providerAbbr} (${manifest.providerId})? Type "yes" to proceed: `);
+  if (!proceed) {
+    console.error('Cancelled.');
+    process.exit(0);
+  }
+
+  // Tournament files — one per file in tournaments/<id>.json
+  const tournamentFiles = (await fs.readdir(path.join(archivePath, 'tournaments'))).filter((f) => f.endsWith('.json'));
+  const tournaments = [];
+  for (const f of tournamentFiles) {
+    tournaments.push(await readJson(archivePath, path.join('tournaments', f)));
+  }
+
+  const data = {
+    provider: await readJson(archivePath, 'provider.json'),
+    user_providers: await readJson(archivePath, 'user_providers.json'),
+    provisioner_providers: await readJson(archivePath, 'provisioner_providers.json'),
+    tournament_assignments: await readJson(archivePath, 'tournament_assignments.json'),
+    official_records: await readJson(archivePath, 'official_records.json'),
+    sanctioning_records: await readJson(archivePath, 'sanctioning_records.json'),
+    tournament_provisioner: await readJson(archivePath, 'tournament_provisioner.json'),
+    pending_saves: await readJson(archivePath, 'pending_saves.json'),
+    provider_topologies: await readJson(archivePath, 'provider_topologies.json'),
+    provider_catalog_items: await readJson(archivePath, 'provider_catalog_items.json'),
+    policies: await readJson(archivePath, 'policies.json'),
+    calendars: await readJson(archivePath, 'calendar.json'),
+    tournaments,
+    audit_log: await readJsonl(archivePath, 'audit_log.jsonl'),
+  };
+
+  const client = await pool.connect();
+  const restored = {};
+  try {
+    await client.query('BEGIN');
+
+    // providers first — everything else FK-references it (soft or hard).
+    restored.providers = await insertRows(client, 'providers', data.provider);
+    // Then tournaments — audit_log references their tournament_id.
+    restored.tournaments = await insertRows(client, 'tournaments', data.tournaments);
+    // Then all the soft-FK tables (order among themselves doesn't matter).
+    restored.user_providers = await insertRows(client, 'user_providers', data.user_providers);
+    restored.provisioner_providers = await insertRows(client, 'provisioner_providers', data.provisioner_providers);
+    restored.tournament_assignments = await insertRows(client, 'tournament_assignments', data.tournament_assignments);
+    restored.official_records = await insertRows(client, 'official_records', data.official_records);
+    restored.sanctioning_records = await insertRows(client, 'sanctioning_records', data.sanctioning_records);
+    restored.tournament_provisioner = await insertRows(client, 'tournament_provisioner', data.tournament_provisioner);
+    restored.pending_saves = await insertRows(client, 'pending_saves', data.pending_saves);
+    restored.provider_topologies = await insertRows(client, 'provider_topologies', data.provider_topologies);
+    restored.provider_catalog_items = await insertRows(client, 'provider_catalog_items', data.provider_catalog_items);
+    restored.policies = await insertRows(client, 'policies', data.policies);
+    restored.calendars = await insertRows(client, 'calendars', data.calendars);
+    // audit_log last — its tournament_id FKs are conceptually present
+    // even though the column has no FK constraint.
+    restored.audit_log = await insertRows(client, 'audit_log', data.audit_log);
+
+    await client.query('COMMIT');
+  } catch (err) {
+    await client.query('ROLLBACK').catch(() => undefined);
+    console.error('Restore transaction failed:', err.message);
+    process.exit(4);
+  } finally {
+    client.release();
+  }
+
+  // Mark the provider_archives row revived if we can find it.
+  await pool.query(
+    `UPDATE provider_archives SET revived_at = NOW() WHERE provider_id = $1 AND archive_path = $2`,
+    [manifest.providerId, archivePath],
+  );
+
+  console.error('\nRestored:');
+  for (const [table, n] of Object.entries(restored)) {
+    console.error(`  ${table}: ${n}`);
+  }
+  console.error('\nDone.');
+}
+
+main()
+  .then(() => pool.end())
+  .catch((err) => {
+    console.error(err);
+    pool.end();
+    process.exit(4);
+  });

--- a/src/storage/interfaces/index.ts
+++ b/src/storage/interfaces/index.ts
@@ -61,3 +61,8 @@ export {
   type IUserProvisionerStorage,
   type UserProvisionerRow,
 } from './user-provisioner-storage.interface';
+export {
+  PROVIDER_ARCHIVE_STORAGE,
+  type IProviderArchiveStorage,
+  type ProviderArchiveRow,
+} from './provider-archive-storage.interface';

--- a/src/storage/interfaces/provider-archive-storage.interface.ts
+++ b/src/storage/interfaces/provider-archive-storage.interface.ts
@@ -1,0 +1,37 @@
+export const PROVIDER_ARCHIVE_STORAGE = Symbol('PROVIDER_ARCHIVE_STORAGE');
+
+export interface ProviderArchiveRow {
+  archiveId: string;
+  providerId: string;
+  providerAbbr: string;
+  providerName: string;
+  archivePath: string;
+  manifestSha256: string;
+  tournamentCount: number;
+  userAssocCount: number;
+  archivedAt: string;
+  archivedBy: string | null;
+  revivedAt: string | null;
+}
+
+export interface IProviderArchiveStorage {
+  insert(row: {
+    providerId: string;
+    providerAbbr: string;
+    providerName: string;
+    archivePath: string;
+    manifestSha256: string;
+    tournamentCount: number;
+    userAssocCount: number;
+    archivedBy: string | null;
+  }): Promise<ProviderArchiveRow>;
+  findById(archiveId: string): Promise<ProviderArchiveRow | null>;
+  findByProviderId(providerId: string): Promise<ProviderArchiveRow[]>;
+  /**
+   * Stamp `revived_at = NOW()` after the revive-provider.mjs script
+   * has restored the archive's rows. The archive directory on disk
+   * stays — it's the durable record. Marking the row revived is the
+   * signal that the archive is no longer the canonical state.
+   */
+  markRevived(archiveId: string): Promise<{ success: boolean }>;
+}

--- a/src/storage/postgres/migrations/027-add-provider-archives.sql
+++ b/src/storage/postgres/migrations/027-add-provider-archives.sql
@@ -1,0 +1,36 @@
+-- AFFECTS: admin
+-- Tracks archived providers so the backend revive-provider.mjs script can
+-- locate the export directory and verify manifest integrity. Archive is
+-- a one-way trip from the live DB: providers + all soft-FK rows are
+-- exported to `shared/archives/<abbr>-<UTC-ts>/`, then deleted from the
+-- live tables. This row is the durable pointer back to that export.
+--
+-- AFFECTS=admin: this is a control-plane bookkeeping table. End-user
+-- data paths (tournaments, calendars, scoring) never read or write here.
+-- The archive *itself* is destructive to end-user data, but that's the
+-- archive operation's mutation, not this migration's.
+
+CREATE TABLE IF NOT EXISTS provider_archives (
+  archive_id        UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  provider_id       TEXT NOT NULL,
+  provider_abbr     TEXT NOT NULL,
+  provider_name     TEXT NOT NULL,
+  archive_path      TEXT NOT NULL,
+  manifest_sha256   TEXT NOT NULL,
+  tournament_count  INT NOT NULL DEFAULT 0,
+  user_assoc_count  INT NOT NULL DEFAULT 0,
+  archived_at       TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  archived_by       UUID,           -- users.user_id of the admin who archived. Nullable: super-admin
+                                    -- imports + future automation may not have a userId in context.
+  revived_at        TIMESTAMPTZ     -- Stamped by revive-provider.mjs on a successful restore.
+                                    -- NULL while the archive is still the canonical state.
+);
+
+-- Lookup by provider_id when an operator wants to find "is there an
+-- archive of <id>" — the revive script and the admin UI both query this.
+CREATE INDEX IF NOT EXISTS idx_provider_archives_provider_id
+  ON provider_archives(provider_id);
+
+-- Listing pages sort by archived_at DESC.
+CREATE INDEX IF NOT EXISTS idx_provider_archives_archived_at
+  ON provider_archives(archived_at DESC);

--- a/src/storage/postgres/postgres-provider-archive.storage.ts
+++ b/src/storage/postgres/postgres-provider-archive.storage.ts
@@ -1,0 +1,85 @@
+import { Inject, Injectable } from '@nestjs/common';
+import { Pool } from 'pg';
+
+import {
+  IProviderArchiveStorage,
+  ProviderArchiveRow,
+} from '../interfaces/provider-archive-storage.interface';
+import { PG_POOL } from './postgres.config';
+import { SUCCESS } from 'src/common/constants/app';
+
+@Injectable()
+export class PostgresProviderArchiveStorage implements IProviderArchiveStorage {
+  constructor(@Inject(PG_POOL) private readonly pool: Pool) {}
+
+  private mapRow(row: any): ProviderArchiveRow {
+    return {
+      archiveId: row.archive_id,
+      providerId: row.provider_id,
+      providerAbbr: row.provider_abbr,
+      providerName: row.provider_name,
+      archivePath: row.archive_path,
+      manifestSha256: row.manifest_sha256,
+      tournamentCount: row.tournament_count,
+      userAssocCount: row.user_assoc_count,
+      archivedAt: row.archived_at?.toISOString?.() ?? row.archived_at,
+      archivedBy: row.archived_by ?? null,
+      revivedAt: row.revived_at?.toISOString?.() ?? row.revived_at ?? null,
+    };
+  }
+
+  async insert(row: {
+    providerId: string;
+    providerAbbr: string;
+    providerName: string;
+    archivePath: string;
+    manifestSha256: string;
+    tournamentCount: number;
+    userAssocCount: number;
+    archivedBy: string | null;
+  }): Promise<ProviderArchiveRow> {
+    const result = await this.pool.query(
+      `INSERT INTO provider_archives
+        (provider_id, provider_abbr, provider_name, archive_path,
+         manifest_sha256, tournament_count, user_assoc_count, archived_by)
+       VALUES ($1, $2, $3, $4, $5, $6, $7, $8)
+       RETURNING *`,
+      [
+        row.providerId,
+        row.providerAbbr,
+        row.providerName,
+        row.archivePath,
+        row.manifestSha256,
+        row.tournamentCount,
+        row.userAssocCount,
+        row.archivedBy,
+      ],
+    );
+    return this.mapRow(result.rows[0]);
+  }
+
+  async findById(archiveId: string): Promise<ProviderArchiveRow | null> {
+    const result = await this.pool.query(
+      `SELECT * FROM provider_archives WHERE archive_id = $1 LIMIT 1`,
+      [archiveId],
+    );
+    if (!result.rows.length) return null;
+    return this.mapRow(result.rows[0]);
+  }
+
+  async findByProviderId(providerId: string): Promise<ProviderArchiveRow[]> {
+    const result = await this.pool.query(
+      `SELECT * FROM provider_archives WHERE provider_id = $1 ORDER BY archived_at DESC`,
+      [providerId],
+    );
+    return result.rows.map((r) => this.mapRow(r));
+  }
+
+  async markRevived(archiveId: string): Promise<{ success: boolean }> {
+    await this.pool.query(
+      `UPDATE provider_archives SET revived_at = NOW() WHERE archive_id = $1`,
+      [archiveId],
+    );
+    return { ...SUCCESS };
+  }
+}

--- a/src/storage/storage.module.ts
+++ b/src/storage/storage.module.ts
@@ -6,6 +6,7 @@ import { USER_PROVIDER_STORAGE } from './interfaces/user-provider-storage.interf
 import { PROVISIONER_STORAGE } from './interfaces/provisioner-storage.interface';
 import { SSO_IDENTITY_STORAGE } from './interfaces/sso-identity-storage.interface';
 import { USER_PROVISIONER_STORAGE } from './interfaces/user-provisioner-storage.interface';
+import { PROVIDER_ARCHIVE_STORAGE } from './interfaces/provider-archive-storage.interface';
 import { OFFICIATING_STORAGE } from './interfaces/officiating-storage.interface';
 import { SANCTIONING_STORAGE } from './interfaces/sanctioning-storage.interface';
 import { BOLT_HISTORY_STORAGE } from './interfaces/bolt-history.interface';
@@ -28,6 +29,7 @@ import { PostgresUserProviderStorage } from './postgres/postgres-user-provider.s
 import { PostgresProvisionerStorage } from './postgres/postgres-provisioner.storage';
 import { PostgresSsoIdentityStorage } from './postgres/postgres-sso-identity.storage';
 import { PostgresUserProvisionerStorage } from './postgres/postgres-user-provisioner.storage';
+import { PostgresProviderArchiveStorage } from './postgres/postgres-provider-archive.storage';
 import { PostgresSanctioningStorage } from './postgres/postgres-sanctioning.storage';
 import { PostgresOfficiatingStorage } from './postgres/postgres-officiating.storage';
 import { PostgresAuditStorage } from './postgres/postgres-audit.storage';
@@ -95,6 +97,7 @@ const provisionerProviderStorageProvider = makeStorageProvider(PROVISIONER_PROVI
 const tournamentProvisionerStorageProvider = makeStorageProvider(TOURNAMENT_PROVISIONER_STORAGE, PostgresTournamentProvisionerStorage);
 const ssoIdentityStorageProvider = makeStorageProvider(SSO_IDENTITY_STORAGE, PostgresSsoIdentityStorage);
 const userProvisionerStorageProvider = makeStorageProvider(USER_PROVISIONER_STORAGE, PostgresUserProvisionerStorage);
+const providerArchiveStorageProvider = makeStorageProvider(PROVIDER_ARCHIVE_STORAGE, PostgresProviderArchiveStorage);
 const policyStorageProvider = makeStorageProvider(POLICY_STORAGE, PostgresPolicyStorage);
 
 @Global()
@@ -123,6 +126,7 @@ const policyStorageProvider = makeStorageProvider(POLICY_STORAGE, PostgresPolicy
     tournamentProvisionerStorageProvider,
     ssoIdentityStorageProvider,
     userProvisionerStorageProvider,
+    providerArchiveStorageProvider,
     policyStorageProvider,
     TournamentStorageService,
   ],
@@ -148,6 +152,7 @@ const policyStorageProvider = makeStorageProvider(POLICY_STORAGE, PostgresPolicy
     TOURNAMENT_PROVISIONER_STORAGE,
     SSO_IDENTITY_STORAGE,
     USER_PROVISIONER_STORAGE,
+    PROVIDER_ARCHIVE_STORAGE,
     POLICY_STORAGE,
     TournamentStorageService,
   ],


### PR DESCRIPTION
## Summary

End of the user-management arc that started with the B-track. Adds the three things you raised:

- **Archive a provider** — exports everything to disk, then wipes from the live DB. Recoverable via a backend script.
- **Delete a provider** — destructive wipe with no archive. For demo/test providers that have no data worth preserving.
- **Audit demo tournaments** — standalone script that classifies existing tournaments by \`isMock\` (+ conservative id/name patterns) so you can clean before archiving the providers that own them.

Includes a baseline fix for a pre-existing audit-log e2e failure on main (commit \`54ba0fa\` — TmxGateway was stuffing email into a UUID column).

## What's in

### Migration 027 — \`provider_archives\` table

\`AFFECTS: admin\` (control-plane only — end-user data paths untouched). Tracks each archive with provider_id, abbr, name, archive_path, manifest_sha256, counts, archived_at, archived_by, revived_at.

### Server endpoints

| Endpoint | Behavior |
|---|---|
| \`POST /provider/:id/preview-archive\` | Read-only counts of every table that would be touched. SUPER_ADMIN only. |
| \`POST /provider/:id/archive\` | Writes export to \`shared/archives/<abbr>-<UTC-ts>/\`, then atomically wipes live DB in one transaction, inserts \`provider_archives\` row. SUPER_ADMIN only. Requires \`confirm\` body field equal to the provider's abbreviation. |
| \`POST /provider/:id/delete\` | Wipes live DB only — no archive, no recovery. SUPER_ADMIN only. Requires \`confirm\` matching abbr AND \`acknowledgeDataLoss: true\`. |

### Storage cleanup (single transaction)

DELETEs in order across: \`user_providers\`, \`provisioner_providers\`, \`tournament_assignments\`, \`official_records\`, \`sanctioning_records\`, \`tournament_provisioner\`, \`pending_saves\`, \`calendars\` (by abbr), \`tournaments\`, then \`providers\` last so the ON DELETE CASCADE tables (\`provider_topologies\`, \`provider_catalog_items\`, \`policies\`) follow automatically. \`audit_log\` rows are **preserved** by design — FK-free per migration 008.

### Archive export

\`ProviderArchiveService\` writes a \`.partial/\` directory, computes \`manifest.json\` with sha256 of every payload, then atomically renames to the final dir. If anything fails before the rename, \`.partial\` survives for inspection. The full export shape:

- \`provider.json\`, \`calendar.json\`, \`user_providers.json\`, \`provisioner_providers.json\`, \`tournament_assignments.json\`, \`official_records.json\`, \`sanctioning_records.json\`, \`provider_topologies.json\`, \`provider_catalog_items.json\`, \`policies.json\`, \`pending_saves.json\`
- \`audit_log.jsonl\` — filtered by the provider's \`tournament_ids\`, newline-delimited
- \`tournaments/<id>.json\` — one file per tournament

### Scripts

**\`src/scripts/audit-demo-tournaments.mjs\`** — your demo cleanup tool:

\`\`\`bash
node src/scripts/audit-demo-tournaments.mjs > demos.csv
node src/scripts/audit-demo-tournaments.mjs --confirmed-only --provider <id>
node src/scripts/audit-demo-tournaments.mjs --delete-confirmed
\`\`\`

Classifies each tournament: \`isMock=true\` → confirmed-demo; id/name pattern match → suspected; otherwise → real. CSV columns: \`tournament_id, provider_id, provider_abbr, name, classification, last_modified, event_count, matchup_count\`.

**\`src/scripts/revive-provider.mjs\`** — backend-only restore. No HTTP endpoint by design.

\`\`\`bash
node src/scripts/revive-provider.mjs <archive-path>
node src/scripts/revive-provider.mjs --by-id <archive_uuid>
node src/scripts/revive-provider.mjs <path> --yes    # for scripted use
\`\`\`

Verifies manifest sha256, refuses if \`provider_id\` is already live, restores every row in dependency order in a single transaction, marks \`revived_at\` on success.

### Admin client

Two new modals in the \`/system\` providers panel detail pane:

- **Archive** (warning intent) — shows preview counts; type the abbreviation to enable submit.
- **Delete** (danger intent) — same preview + abbreviation + checkbox: "I understand this cannot be undone."

### Drive-by baseline fix (first commit on the branch)

\`fix(audit): don't fall back to email when stamping userId in TmxGateway\` — \`audit.e2e.spec\` was red on main because the gateway was setting \`payload.userId\` to an email fallback that crashed the AuditService's UUID-column insert. Fix is to assign \`userId\` only when a real UUID is available; \`userEmail\` already carries the email separately.

## Out of scope

- Listing archives in the admin UI (\`provider_archives\` rows visible via direct DB query for now)
- Orphan \`.partial/\` directory sweeper (manual cleanup for now — they're a useful inspection artefact when something goes wrong)

## Test plan

- [ ] \`pnpm install\`, \`pnpm build\`, deploy to mentat. Migration 027 auto-applies on Factory-Server boot.
- [ ] Set \`ARCHIVES_PATH\` in mentat's \`.env\` (something like \`/home/tennis_aip/Development/.../shared/archives\`). Without it, the server logs a warning and falls back to \`<cwd>/.archives-local\`.
- [ ] Run \`audit-demo-tournaments.mjs\` against the dev DB; review the CSV; spot-check a few "confirmed" rows are actually demos.
- [ ] Optional: \`--delete-confirmed\` to bulk-clean confirmed demos.
- [ ] As SUPER_ADMIN: pick a low-stakes demo provider in the /system providers panel, click **Archive**, type the abbreviation, submit. Confirm:
  - Toast shows success + archive id + tournament count
  - The archive directory appears at \`<ARCHIVES_PATH>/<abbr>-<ts>/\` with all expected files
  - The provider disappears from \`/system\` (refresh)
  - All live tables are clean for that \`provider_id\` (spot-check user_providers, tournaments, calendars)
  - \`provider_archives\` has a new row
  - \`audit_log\` rows are still present
- [ ] Run \`node src/scripts/revive-provider.mjs --by-id <archive_id>\` (with \`--yes\` to skip prompt). Confirm:
  - Manifest verifies clean
  - Provider reappears in \`/system\`
  - All restored rows visible
- [ ] Confirm \`/provider/:id/archive\` returns 403 to PROVIDER_ADMIN (try with curl + a non-super-admin JWT)
- [ ] Confirm Delete: pick a different demo provider, click Delete, type abbr, tick checkbox, submit. Confirm wipe is identical to Archive except no provider_archives row and no archive directory.

## Deploy notes

- **\`ARCHIVES_PATH\`** must be set in \`shared/.env\` on nest before the archive endpoint is exercised. The server logs a warning if it's missing and falls back to a cwd-relative path, but that's not what you want in prod.
- Migration 027 is \`AFFECTS: admin\` so \`mentat-push-server.sh\` will print a quiet notice and proceed — no \`yes-apply-to-prod\` confirmation needed.

## CI matrix

- Server: \`pnpm lint\` ✓ · \`check-types\` ✓ · 767/767 tests ✓ (+13 new ProviderLifecycleService) · \`build\` ✓
- Admin-client: \`pnpm lint\` ✓ · \`check-types\` ✓ · all tests ✓ · \`build\` ✓