### PR TITLE
feat(providers): admin-issued, provider-scoped API keys

### DIFF
--- a/admin-client/src/components/modals/generatedKeyModal.ts
+++ b/admin-client/src/components/modals/generatedKeyModal.ts
@@ -1,7 +1,7 @@
 /**
  * One-shot API key reveal.
  *
- * The plaintext key is returned by `POST /admin/provisioners/:id/keys`
+ * The plaintext key is returned by `POST /admin/{provisioners|providers}/:id/keys`
  * exactly once and never stored. This modal is the only chance the
  * super-admin has to copy it. Auto-copies to clipboard on open.
  */
@@ -14,9 +14,11 @@ type GeneratedKeyModalParams = {
   apiKey: string;
   label?: string;
   provisionerName?: string;
+  providerName?: string;
 };
 
-export function generatedKeyModal({ apiKey, label, provisionerName }: GeneratedKeyModalParams): void {
+export function generatedKeyModal({ apiKey, label, provisionerName, providerName }: GeneratedKeyModalParams): void {
+  const ownerName = providerName ?? provisionerName;
   const content = (elem: HTMLElement) => {
     const wrap = document.createElement('div');
     wrap.style.cssText = 'display: flex; flex-direction: column; gap: .75rem;';
@@ -33,10 +35,10 @@ export function generatedKeyModal({ apiKey, label, provisionerName }: GeneratedK
     warn.textContent = t('system.keyRevealWarning');
     wrap.appendChild(warn);
 
-    if (provisionerName || label) {
+    if (ownerName || label) {
       const meta = document.createElement('div');
       meta.style.cssText = 'font-size: .8rem; color: var(--tmx-text-secondary, #666);';
-      meta.textContent = [provisionerName, label].filter(Boolean).join(' · ');
+      meta.textContent = [ownerName, label].filter(Boolean).join(' · ');
       wrap.appendChild(meta);
     }
 

--- a/admin-client/src/pages/tournament/tabs/settingsTab/systemTab/providersPanel.ts
+++ b/admin-client/src/pages/tournament/tabs/settingsTab/systemTab/providersPanel.ts
@@ -4,18 +4,28 @@ import { setActiveProvider, clearActiveProvider } from 'services/provider/provid
 import { editProviderModal } from 'components/modals/editProvider';
 import { archiveProviderModal } from 'components/modals/archiveProvider';
 import { deleteProviderModal } from 'components/modals/deleteProvider';
+import { generatedKeyModal } from 'components/modals/generatedKeyModal';
 import { TabulatorFull as Tabulator } from 'tabulator-tables';
 import { buildSearchInput } from 'components/inputs/searchInput';
 import { removeUserProvider } from 'services/apis/servicesApi';
+import { listProviderKeys, generateProviderKey, revokeProviderKey } from 'services/apis/providerKeysApi';
 import { destroyTable } from 'pages/tournament/destroyTable';
 import { openTmxImpersonate } from 'services/openTmxImpersonate';
 import { createUserModal } from 'components/modals/createUser';
-import { confirmModal } from 'components/modals/baseModal/baseModal';
+import { confirmModal, openModal } from 'components/modals/baseModal/baseModal';
 import { tmxToast } from 'services/notifications/tmxToast';
+import { renderForm } from 'courthive-components';
 import { t } from 'i18n';
 
 const PROVIDER_LIST_TABLE = 'systemProviderListTable';
 const PROVIDER_USERS_TABLE = 'systemProviderUsersTable';
+const PROVIDER_KEYS_TABLE = 'systemProviderKeysTable';
+
+function formatDateTime(value: string | undefined): string {
+  if (!value) return '';
+  const d = new Date(value);
+  return d.toLocaleDateString() + ' ' + d.toLocaleTimeString([], { hour: '2-digit', minute: '2-digit' });
+}
 
 type RenderProvidersPanelParams = {
   container: HTMLElement;
@@ -249,6 +259,8 @@ function renderProviderDetail({ detailPane, provider, providers, users, onRefres
   actions.appendChild(deleteBtn);
   detailPane.appendChild(actions);
 
+  detailPane.appendChild(buildProviderKeysSection(provider, () => renderProviderDetail({ detailPane, provider, providers, users, onRefresh })));
+
   // Associated users
   const assocSection = document.createElement('div');
   assocSection.className = 'system-associated-users';
@@ -365,5 +377,139 @@ function renderProviderDetail({ detailPane, provider, providers, users, onRefres
         }
       },
     });
+  });
+}
+
+function buildProviderKeysSection(provider: any, refresh: () => void): HTMLElement {
+  const section = document.createElement('div');
+  section.className = 'system-associated-users';
+
+  const sectionHeader = document.createElement('div');
+  sectionHeader.style.cssText = 'display: flex; justify-content: space-between; align-items: center; margin-bottom: 8px;';
+  sectionHeader.innerHTML = `<h4 style="margin: 0;">${t('system.apiKeys')}</h4>`;
+
+  const generateBtn = document.createElement('button');
+  generateBtn.className = 'btn-invite';
+  generateBtn.style.fontSize = '0.75rem';
+  generateBtn.textContent = t('system.generateKey');
+  generateBtn.addEventListener('click', () => openGenerateProviderKeyModal(provider, refresh));
+  sectionHeader.appendChild(generateBtn);
+
+  section.appendChild(sectionHeader);
+
+  const tableEl = document.createElement('div');
+  tableEl.id = PROVIDER_KEYS_TABLE;
+  section.appendChild(tableEl);
+
+  listProviderKeys(provider.organisationId).then(
+    (res: any) => {
+      const keys = res?.data?.keys ?? [];
+      const data = keys.map((k: any) => ({
+        ...k,
+        status: k.isActive ? t('system.active') : t('system.revoked'),
+      }));
+      destroyTable({ anchorId: PROVIDER_KEYS_TABLE });
+      const keysTable = new Tabulator(tableEl, {
+        placeholder: t('system.noKeys'),
+        layout: 'fitColumns',
+        maxHeight: 250,
+        columns: [
+          { title: t('system.label'), field: 'label', headerSort: true },
+          { title: t('system.status'), field: 'status', headerSort: true, width: 90 },
+          {
+            title: t('system.created'),
+            field: 'createdAt',
+            headerSort: true,
+            formatter: (cell: any) => formatDateTime(cell.getValue()),
+          },
+          {
+            title: t('system.lastUsed'),
+            field: 'lastUsedAt',
+            headerSort: true,
+            formatter: (cell: any) => formatDateTime(cell.getValue()),
+          },
+          {
+            title: '',
+            width: 90,
+            hozAlign: 'center',
+            headerSort: false,
+            formatter: (cell: any) =>
+              cell.getRow().getData().isActive
+                ? `<button class="btn-remove" style="font-size:.7rem;padding:2px 8px;">${t('system.revoke')}</button>`
+                : '',
+            cellClick: (_e: any, cell: any) => {
+              const row = cell.getRow().getData();
+              if (!row.isActive) return;
+              confirmModal({
+                title: t('system.revokeKey'),
+                query: t('system.revokeKeyConfirm', { label: row.label || row.keyId }),
+                okIntent: 'is-warning',
+                okAction: () => {
+                  revokeProviderKey(provider.organisationId, row.keyId).then(
+                    () => {
+                      tmxToast({ message: t('system.keyRevoked'), intent: 'is-success' });
+                      refresh();
+                    },
+                    () => tmxToast({ message: t('system.updateFailed'), intent: 'is-danger' }),
+                  );
+                },
+                cancelAction: undefined,
+              });
+            },
+          },
+        ],
+        data,
+      });
+      // Hold a reference to silence unused-var lint; keysTable is owned by Tabulator.
+      void keysTable;
+    },
+    () => tmxToast({ message: t('system.loadError'), intent: 'is-danger' }),
+  );
+
+  return section;
+}
+
+function openGenerateProviderKeyModal(provider: any, refresh: () => void) {
+  let inputs: any;
+  const content = (elem: HTMLElement) => {
+    inputs = renderForm(elem, [
+      {
+        label: t('system.keyLabel'),
+        field: 'label',
+        placeholder: t('system.keyLabelPlaceholder'),
+      },
+    ]);
+  };
+
+  openModal({
+    title: t('system.generateKey'),
+    content,
+    buttons: [
+      { label: t('common.cancel'), intent: 'none', close: true },
+      {
+        label: t('system.generate'),
+        intent: 'is-primary',
+        close: true,
+        onClick: () => {
+          const label = inputs?.label?.value?.trim() || undefined;
+          generateProviderKey(provider.organisationId, label).then(
+            (res: any) => {
+              const apiKey = res?.data?.apiKey;
+              if (!apiKey) {
+                tmxToast({ message: t('system.generateFailed'), intent: 'is-danger' });
+                return;
+              }
+              generatedKeyModal({
+                apiKey,
+                label,
+                providerName: provider.organisationName || provider.organisationAbbreviation,
+              });
+              refresh();
+            },
+            () => tmxToast({ message: t('system.generateFailed'), intent: 'is-danger' }),
+          );
+        },
+      },
+    ],
   });
 }

--- a/admin-client/src/services/apis/providerKeysApi.ts
+++ b/admin-client/src/services/apis/providerKeysApi.ts
@@ -1,0 +1,33 @@
+import { baseApi } from './baseApi';
+
+export interface ProviderKey {
+  keyId: string;
+  label?: string;
+  prefix: string;
+  createdAt?: string;
+  expiresAt?: string;
+  lastUsedAt?: string;
+  isActive: boolean;
+}
+
+export interface GeneratedProviderKey {
+  success: boolean;
+  keyId: string;
+  apiKey: string;
+  label?: string;
+  createdAt?: string;
+}
+
+export async function listProviderKeys(providerId: string) {
+  return baseApi.get(`/admin/providers/${encodeURIComponent(providerId)}/keys`);
+}
+
+export async function generateProviderKey(providerId: string, label?: string) {
+  return baseApi.post(`/admin/providers/${encodeURIComponent(providerId)}/keys`, { label });
+}
+
+export async function revokeProviderKey(providerId: string, keyId: string) {
+  return baseApi.delete(
+    `/admin/providers/${encodeURIComponent(providerId)}/keys/${encodeURIComponent(keyId)}`,
+  );
+}

--- a/src/modules/account/auth/guards/auth.guard.ts
+++ b/src/modules/account/auth/guards/auth.guard.ts
@@ -21,8 +21,10 @@ export class AuthGuard implements CanActivate {
 
     const request = context.switchToHttp().getRequest();
 
-    // If ProvisionerMiddleware already authenticated this request, skip JWT
-    if (request.provisioner) {
+    // If a non-JWT middleware already authenticated this request — either
+    // ProvisionerMiddleware (prov_ tokens) or ProviderApiKeyMiddleware
+    // (pkey_ tokens) — skip JWT verification.
+    if (request.provisioner || request.provider) {
       return true;
     }
 

--- a/src/modules/providers/admin-provider-keys.controller.ts
+++ b/src/modules/providers/admin-provider-keys.controller.ts
@@ -1,0 +1,51 @@
+import { Body, Controller, Delete, Get, HttpCode, HttpStatus, Param, Post, Req, UseGuards } from '@nestjs/common';
+
+import { RolesGuard } from '../account/auth/guards/role.guard';
+import { Roles } from '../account/auth/decorators/roles.decorator';
+import { SUPER_ADMIN } from 'src/common/constants/roles';
+
+import { ProviderApiKeyService } from './provider-api-key.service';
+
+/**
+ * Super-admin endpoints for managing provider-scoped API keys.
+ *
+ * Parallel to `admin/provisioners/:id/keys` (provisioner key CRUD) but
+ * targets the `providers` table. Plaintext key is returned ONCE on POST
+ * and never again.
+ */
+@Controller('admin/providers')
+@UseGuards(RolesGuard)
+@Roles([SUPER_ADMIN])
+export class AdminProviderKeysController {
+  constructor(private readonly providerApiKeyService: ProviderApiKeyService) {}
+
+  @Post(':id/keys')
+  @HttpCode(HttpStatus.CREATED)
+  async generateKey(
+    @Param('id') id: string,
+    @Body() body: { label?: string },
+    @Req() req: any,
+  ) {
+    const actor = req.user
+      ? { userId: req.user.userId ?? req.user.sub, userEmail: req.user.email }
+      : undefined;
+    return this.providerApiKeyService.generateApiKey(id, body?.label, actor);
+  }
+
+  @Get(':id/keys')
+  async listKeys(@Param('id') id: string) {
+    return this.providerApiKeyService.listApiKeys(id);
+  }
+
+  @Delete(':id/keys/:keyId')
+  async revokeKey(
+    @Param('id') id: string,
+    @Param('keyId') keyId: string,
+    @Req() req: any,
+  ) {
+    const actor = req.user
+      ? { userId: req.user.userId ?? req.user.sub, userEmail: req.user.email }
+      : undefined;
+    return this.providerApiKeyService.revokeApiKey(keyId, actor, id);
+  }
+}

--- a/src/modules/providers/provider-api-key.e2e.spec.ts
+++ b/src/modules/providers/provider-api-key.e2e.spec.ts
@@ -1,0 +1,205 @@
+/**
+ * Provider-scoped API key e2e — full lifecycle against live Postgres.
+ *
+ *   1. Super-admin creates two test providers (Alpha + Beta).
+ *   2. POST /admin/providers/:id/keys mints a `pkey_live_*` key.
+ *   3. The plaintext key authenticates GET /provider-key/self.
+ *   4. POST /provider-key/tournaments saves a tournament; subsequent GET round-trips it.
+ *   5. Reading another provider's tournament returns 404 (cross-provider isolation).
+ *   6. Saving a tournament whose parentOrganisation points at another provider returns "Provider mismatch".
+ *   7. DELETE revokes the key; the same key now 401s.
+ *
+ * Gated on STORAGE_PROVIDER=postgres so it skips in LevelDB CI.
+ */
+import { AppModule } from 'src/modules/app/app.module';
+import { INestApplication } from '@nestjs/common';
+import { Test, TestingModule } from '@nestjs/testing';
+import { mocksEngine, tools } from 'tods-competition-factory';
+import request from 'supertest';
+
+import { saveAndCommit } from 'src/tests/helpers/saveAndCommit';
+import { TEST_EMAIL, TEST_PASSWORD } from 'src/common/constants/test';
+
+const SUFFIX = Date.now();
+const ALPHA_ABBR = `PKEYALPHA${SUFFIX}`;
+const BETA_ABBR = `PKEYBETA${SUFFIX}`;
+const ALPHA_TOURNAMENT_ID = `pkey-alpha-${SUFFIX}`;
+const BETA_TOURNAMENT_ID = `pkey-beta-${SUFFIX}`;
+
+const e2eEnabled = process.env.STORAGE_PROVIDER === 'postgres';
+const d = e2eEnabled ? describe : describe.skip;
+
+d('Provider API Key E2E', () => {
+  let app: INestApplication;
+  let server: any;
+  let token: string;
+  let alphaProviderId: string;
+  let betaProviderId: string;
+  let alphaKey: string;
+  let alphaKeyId: string;
+
+  beforeAll(async () => {
+    const moduleRef: TestingModule = await Test.createTestingModule({ imports: [AppModule] }).compile();
+    app = moduleRef.createNestApplication();
+    await app.init();
+    server = app.getHttpServer();
+
+    const login = await request(server)
+      .post('/auth/login')
+      .send({ email: TEST_EMAIL, password: TEST_PASSWORD })
+      .expect(200);
+    token = login.body.token;
+
+    const alphaRes = await request(server)
+      .post('/provider/add')
+      .set('Authorization', `Bearer ${token}`)
+      .send({ organisationAbbreviation: ALPHA_ABBR, organisationName: 'Provider Key Alpha' })
+      .expect(200);
+    alphaProviderId = alphaRes.body.providerId;
+
+    const betaRes = await request(server)
+      .post('/provider/add')
+      .set('Authorization', `Bearer ${token}`)
+      .send({ organisationAbbreviation: BETA_ABBR, organisationName: 'Provider Key Beta' })
+      .expect(200);
+    betaProviderId = betaRes.body.providerId;
+
+    // Seed one tournament under Beta so the cross-provider isolation
+    // test has something existing to attempt to read.
+    const { tournamentRecord: betaT } = mocksEngine.generateTournamentRecord({
+      tournamentAttributes: {
+        tournamentId: BETA_TOURNAMENT_ID,
+        tournamentName: 'Beta seed',
+        parentOrganisation: {
+          organisationId: betaProviderId,
+          organisationName: 'Provider Key Beta',
+          organisationAbbreviation: BETA_ABBR,
+        },
+      },
+    });
+    await saveAndCommit(server, token, betaT);
+  });
+
+  afterAll(async () => {
+    try {
+      const { PROVIDER_STORAGE, CALENDAR_STORAGE } = await import('src/storage/interfaces');
+      const providerStorage = app.get(PROVIDER_STORAGE);
+      const calendarStorage = app.get(CALENDAR_STORAGE);
+      for (const [pid, abbr] of [
+        [alphaProviderId, ALPHA_ABBR],
+        [betaProviderId, BETA_ABBR],
+      ] as const) {
+        if (pid) await providerStorage.removeProvider(pid).catch(() => undefined);
+        if (abbr) await calendarStorage.setCalendar(abbr, { provider: {}, tournaments: [] }).catch(() => undefined);
+      }
+    } finally {
+      await app.close();
+    }
+  });
+
+  it('mints a pkey_live_ key for a provider and reveals plaintext once', async () => {
+    const res = await request(server)
+      .post(`/admin/providers/${alphaProviderId}/keys`)
+      .set('Authorization', `Bearer ${token}`)
+      .send({ label: 'alpha-prod' })
+      .expect(201);
+    expect(res.body.success).toBe(true);
+    expect(res.body.apiKey).toMatch(/^pkey_live_[0-9a-f]{64}$/);
+    expect(res.body.keyId).toBeDefined();
+    alphaKey = res.body.apiKey;
+    alphaKeyId = res.body.keyId;
+
+    // Listing should show the key (without exposing the hash).
+    const list = await request(server)
+      .get(`/admin/providers/${alphaProviderId}/keys`)
+      .set('Authorization', `Bearer ${token}`)
+      .expect(200);
+    const k = list.body.keys.find((x: any) => x.keyId === alphaKeyId);
+    expect(k).toBeDefined();
+    expect(k.label).toBe('alpha-prod');
+    expect(k.prefix).toBe('pkey_live_');
+    expect((k as any).apiKeyHash).toBeUndefined();
+  });
+
+  it('authenticates GET /provider-key/self with the minted key', async () => {
+    const res = await request(server)
+      .get('/provider-key/self')
+      .set('Authorization', `Bearer ${alphaKey}`)
+      .expect(200);
+    expect(res.body.success).toBe(true);
+    expect(res.body.provider.providerId).toBe(alphaProviderId);
+    expect(res.body.provider.keyId).toBe(alphaKeyId);
+  });
+
+  it('rejects /provider-key/self when no key (or wrong key) is presented', async () => {
+    await request(server).get('/provider-key/self').expect(401);
+    await request(server)
+      .get('/provider-key/self')
+      .set('Authorization', `Bearer pkey_live_${tools.UUID().replace(/-/g, '')}deadbeef`)
+      .expect(401);
+  });
+
+  it('round-trips a tournament: POST then GET', async () => {
+    const { tournamentRecord: alphaT } = mocksEngine.generateTournamentRecord({
+      tournamentAttributes: {
+        tournamentId: ALPHA_TOURNAMENT_ID,
+        tournamentName: 'Alpha pkey tournament',
+        parentOrganisation: {
+          organisationId: alphaProviderId,
+          organisationName: 'Provider Key Alpha',
+          organisationAbbreviation: ALPHA_ABBR,
+        },
+      },
+    });
+    const save = await request(server)
+      .post('/provider-key/tournaments')
+      .set('Authorization', `Bearer ${alphaKey}`)
+      .send({ tournamentRecord: alphaT })
+      .expect(200);
+    expect(save.body.success).toBe(true);
+
+    const read = await request(server)
+      .get(`/provider-key/tournaments/${ALPHA_TOURNAMENT_ID}`)
+      .set('Authorization', `Bearer ${alphaKey}`)
+      .expect(200);
+    expect(read.body.tournamentRecord.tournamentId).toBe(ALPHA_TOURNAMENT_ID);
+  });
+
+  it('returns 404 (not 403) when probing for another provider\'s tournament', async () => {
+    await request(server)
+      .get(`/provider-key/tournaments/${BETA_TOURNAMENT_ID}`)
+      .set('Authorization', `Bearer ${alphaKey}`)
+      .expect(404);
+  });
+
+  it('refuses to save a tournament whose parentOrganisation points at another provider', async () => {
+    const { tournamentRecord: spoof } = mocksEngine.generateTournamentRecord({
+      tournamentAttributes: {
+        tournamentId: `spoof-${SUFFIX}`,
+        tournamentName: 'Spoof',
+        parentOrganisation: {
+          organisationId: betaProviderId,
+          organisationName: 'Provider Key Beta',
+          organisationAbbreviation: BETA_ABBR,
+        },
+      },
+    });
+    const res = await request(server)
+      .post('/provider-key/tournaments')
+      .set('Authorization', `Bearer ${alphaKey}`)
+      .send({ tournamentRecord: spoof })
+      .expect(200);
+    // Response is shaped as an error object, not an HTTP 4xx — matches
+    // factory's existing convention of returning `{ error: '...' }`.
+    expect(res.body.error).toBe('Provider mismatch');
+  });
+
+  it('revokes the key and stops authenticating with it', async () => {
+    await request(server)
+      .delete(`/admin/providers/${alphaProviderId}/keys/${alphaKeyId}`)
+      .set('Authorization', `Bearer ${token}`)
+      .expect(200);
+
+    await request(server).get('/provider-key/self').set('Authorization', `Bearer ${alphaKey}`).expect(401);
+  });
+});

--- a/src/modules/providers/provider-api-key.guard.spec.ts
+++ b/src/modules/providers/provider-api-key.guard.spec.ts
@@ -1,0 +1,30 @@
+import { UnauthorizedException } from '@nestjs/common';
+
+import { ProviderApiKeyGuard } from './provider-api-key.guard';
+
+function makeContext(request: any): any {
+  return { switchToHttp: () => ({ getRequest: () => request }) };
+}
+
+describe('ProviderApiKeyGuard', () => {
+  let guard: ProviderApiKeyGuard;
+
+  beforeEach(() => {
+    guard = new ProviderApiKeyGuard();
+  });
+
+  it('allows requests with a provider identity attached', () => {
+    const request = { provider: { providerId: 'kronos' } };
+    expect(guard.canActivate(makeContext(request))).toBe(true);
+  });
+
+  it('rejects requests without request.provider', () => {
+    const request = {};
+    expect(() => guard.canActivate(makeContext(request))).toThrow(UnauthorizedException);
+  });
+
+  it('rejects requests where request.provider exists but providerId is missing', () => {
+    const request = { provider: {} };
+    expect(() => guard.canActivate(makeContext(request))).toThrow(UnauthorizedException);
+  });
+});

--- a/src/modules/providers/provider-api-key.guard.ts
+++ b/src/modules/providers/provider-api-key.guard.ts
@@ -1,0 +1,22 @@
+import { CanActivate, ExecutionContext, Injectable, UnauthorizedException } from '@nestjs/common';
+
+/**
+ * Guard for provider-key-native endpoints (everything under /provider-key/*).
+ *
+ * Ensures request.provider was set by ProviderApiKeyMiddleware. Use with
+ * @UseGuards(ProviderApiKeyGuard) on the provider-key controller. The
+ * downstream handler can then trust request.provider.providerId as the
+ * authenticated scope.
+ */
+@Injectable()
+export class ProviderApiKeyGuard implements CanActivate {
+  canActivate(context: ExecutionContext): boolean {
+    const request = context.switchToHttp().getRequest();
+
+    if (!request.provider?.providerId) {
+      throw new UnauthorizedException('Provider API key required');
+    }
+
+    return true;
+  }
+}

--- a/src/modules/providers/provider-api-key.middleware.spec.ts
+++ b/src/modules/providers/provider-api-key.middleware.spec.ts
@@ -1,0 +1,106 @@
+import { ProviderApiKeyMiddleware, hashApiKey } from './provider-api-key.middleware';
+
+function makeRes() {
+  return {};
+}
+
+function makeNext() {
+  return jest.fn();
+}
+
+describe('ProviderApiKeyMiddleware', () => {
+  let apiKeyStorage: any;
+  let mw: ProviderApiKeyMiddleware;
+
+  beforeEach(() => {
+    apiKeyStorage = {
+      findByKeyHash: jest.fn(),
+      updateLastUsed: jest.fn().mockResolvedValue(undefined),
+    };
+    mw = new ProviderApiKeyMiddleware(apiKeyStorage);
+  });
+
+  it('passes through when no Authorization header', async () => {
+    const req: any = { headers: {} };
+    const next = makeNext();
+    await mw.use(req, makeRes(), next);
+    expect(next).toHaveBeenCalled();
+    expect(req.provider).toBeUndefined();
+    expect(apiKeyStorage.findByKeyHash).not.toHaveBeenCalled();
+  });
+
+  it('ignores Bearer tokens without the pkey_ prefix (lets provisioner middleware handle prov_ tokens)', async () => {
+    const req: any = { headers: { authorization: 'Bearer prov_sk_live_abcdef' } };
+    const next = makeNext();
+    await mw.use(req, makeRes(), next);
+    expect(next).toHaveBeenCalled();
+    expect(req.provider).toBeUndefined();
+    expect(apiKeyStorage.findByKeyHash).not.toHaveBeenCalled();
+  });
+
+  it('ignores non-Bearer auth schemes', async () => {
+    const req: any = { headers: { authorization: 'Basic dXNlcjpwYXNz' } };
+    const next = makeNext();
+    await mw.use(req, makeRes(), next);
+    expect(req.provider).toBeUndefined();
+    expect(apiKeyStorage.findByKeyHash).not.toHaveBeenCalled();
+  });
+
+  it('attaches provider identity when the key matches', async () => {
+    const rawKey = 'pkey_live_secret123';
+    apiKeyStorage.findByKeyHash.mockResolvedValueOnce({
+      key: {
+        keyId: 'k-1',
+        providerId: 'kronos',
+        apiKeyHash: hashApiKey(rawKey),
+        label: 'prod',
+        isActive: true,
+      },
+      providerName: 'Kronos Sports',
+      providerConfig: { permissions: { 'addEvent': true } },
+    });
+    const req: any = { headers: { authorization: `Bearer ${rawKey}` } };
+    const next = makeNext();
+
+    await mw.use(req, makeRes(), next);
+
+    expect(apiKeyStorage.findByKeyHash).toHaveBeenCalledWith(hashApiKey(rawKey));
+    expect(req.provider).toEqual({
+      providerId: 'kronos',
+      providerName: 'Kronos Sports',
+      providerConfig: { permissions: { addEvent: true } },
+      keyId: 'k-1',
+      keyLabel: 'prod',
+    });
+    expect(req.auditSource).toEqual({
+      type: 'provider-key',
+      providerId: 'kronos',
+      keyId: 'k-1',
+      keyLabel: 'prod',
+    });
+    expect(req.user.providerId).toBe('kronos');
+    expect(req.userContext.providerIds).toEqual(['kronos']);
+    expect(req.userContext.providerRoles.kronos).toBe('PROVIDER_ADMIN');
+    expect(req.userContext.isSuperAdmin).toBe(false);
+    expect(apiKeyStorage.updateLastUsed).toHaveBeenCalledWith('k-1');
+    expect(next).toHaveBeenCalled();
+  });
+
+  it('falls through (does not throw) when the key lookup returns null', async () => {
+    apiKeyStorage.findByKeyHash.mockResolvedValueOnce(null);
+    const req: any = { headers: { authorization: 'Bearer pkey_live_unknown' } };
+    const next = makeNext();
+    await mw.use(req, makeRes(), next);
+    expect(req.provider).toBeUndefined();
+    expect(next).toHaveBeenCalled();
+  });
+
+  it('falls through when storage throws (degraded mode — AuthGuard will 401)', async () => {
+    apiKeyStorage.findByKeyHash.mockRejectedValueOnce(new Error('PG down'));
+    const req: any = { headers: { authorization: 'Bearer pkey_live_xyz' } };
+    const next = makeNext();
+    await mw.use(req, makeRes(), next);
+    expect(req.provider).toBeUndefined();
+    expect(next).toHaveBeenCalled();
+  });
+});

--- a/src/modules/providers/provider-api-key.middleware.ts
+++ b/src/modules/providers/provider-api-key.middleware.ts
@@ -1,0 +1,115 @@
+import { Inject, Injectable, NestMiddleware } from '@nestjs/common';
+import { createHash } from 'crypto';
+
+import {
+  PROVIDER_API_KEY_STORAGE,
+  type IProviderApiKeyStorage,
+} from 'src/storage/interfaces';
+import { CLIENT, GENERATE, SCORE } from 'src/common/constants/roles';
+import type { UserContext } from '../account/auth/decorators/user-context.decorator';
+
+const PKEY_PREFIX = 'pkey_';
+
+/**
+ * Middleware that authenticates provider API key requests.
+ *
+ * Distinct from ProvisionerMiddleware (which handles `prov_` tokens):
+ * - Only matches `pkey_*` Bearer tokens.
+ * - Scope is implicit: the key names a single provider; there is no
+ *   `X-Provider-Id` header involvement.
+ *
+ * If matched:
+ * 1. Hashes the key (SHA-256) and looks it up via storage.
+ * 2. Sets request.provider = { providerId, providerName, providerConfig, keyId, keyLabel }.
+ * 3. Synthesizes request.user + request.userContext so downstream
+ *    factory/save endpoints work unchanged — the key acts as a
+ *    PROVIDER_ADMIN for its own provider.
+ * 4. Sets request.auditSource so the audit trail can distinguish
+ *    provider-key actions from JWT-user actions.
+ *
+ * AuthGuard then sees request.user and skips JWT verification.
+ */
+@Injectable()
+export class ProviderApiKeyMiddleware implements NestMiddleware {
+  constructor(
+    @Inject(PROVIDER_API_KEY_STORAGE) private readonly apiKeyStorage: IProviderApiKeyStorage,
+  ) {}
+
+  async use(req: any, _res: any, next: () => void): Promise<void> {
+    const authHeader: string | undefined = req.headers?.authorization;
+    if (!authHeader) {
+      next();
+      return;
+    }
+
+    const [type, token] = authHeader.split(' ');
+    if (type !== 'Bearer' || !token?.startsWith(PKEY_PREFIX)) {
+      next();
+      return;
+    }
+
+    const keyHash = hashApiKey(token);
+
+    let keyResult: Awaited<ReturnType<IProviderApiKeyStorage['findByKeyHash']>>;
+    try {
+      keyResult = await this.apiKeyStorage.findByKeyHash(keyHash);
+    } catch {
+      // Storage unavailable — fall through; AuthGuard will 401
+      next();
+      return;
+    }
+
+    if (!keyResult) {
+      // Invalid / revoked / expired key — fall through; AuthGuard will 401
+      next();
+      return;
+    }
+
+    const { key, providerName, providerConfig } = keyResult;
+
+    req.provider = {
+      providerId: key.providerId,
+      providerName,
+      providerConfig,
+      keyId: key.keyId,
+      keyLabel: key.label,
+    };
+
+    req.auditSource = {
+      type: 'provider-key',
+      providerId: key.providerId,
+      keyId: key.keyId,
+      keyLabel: key.label,
+    };
+
+    // Update last_used_at (fire-and-forget — don't block the request)
+    this.apiKeyStorage.updateLastUsed(key.keyId).catch(() => {});
+
+    // Synthesize a user context so downstream guards/services see the
+    // provider key as a PROVIDER_ADMIN for its own provider. No
+    // cross-provider visibility, no super-admin powers.
+    req.user = {
+      userId: `provider:${key.providerId}`,
+      email: `key@${providerName ?? key.providerId}`,
+      roles: [CLIENT, GENERATE, SCORE],
+      providerId: key.providerId,
+    };
+
+    req.userContext = {
+      userId: `provider:${key.providerId}`,
+      email: `key@${providerName ?? key.providerId}`,
+      isSuperAdmin: false,
+      globalRoles: [CLIENT, GENERATE, SCORE],
+      providerRoles: { [key.providerId]: 'PROVIDER_ADMIN' },
+      providerIds: [key.providerId],
+      provisionerProviderIds: [],
+    } satisfies UserContext;
+
+    next();
+  }
+}
+
+/** SHA-256 hash of an API key for database lookup. */
+export function hashApiKey(key: string): string {
+  return createHash('sha256').update(key).digest('hex');
+}

--- a/src/modules/providers/provider-api-key.service.spec.ts
+++ b/src/modules/providers/provider-api-key.service.spec.ts
@@ -1,0 +1,105 @@
+import { NotFoundException } from '@nestjs/common';
+import { createHash } from 'crypto';
+
+import { ProviderApiKeyService } from './provider-api-key.service';
+
+describe('ProviderApiKeyService', () => {
+  let apiKeyStorage: any;
+  let providerStorage: any;
+  let auditService: any;
+  let service: ProviderApiKeyService;
+
+  beforeEach(() => {
+    apiKeyStorage = {
+      create: jest.fn(),
+      listByProvider: jest.fn(),
+      revoke: jest.fn(),
+    };
+    providerStorage = {
+      getProvider: jest.fn(),
+    };
+    auditService = {
+      recordMutation: jest.fn().mockResolvedValue(undefined),
+    };
+    service = new ProviderApiKeyService(apiKeyStorage, providerStorage, auditService);
+  });
+
+  describe('generateApiKey', () => {
+    it('mints a pkey_live_<hex> key, stores only the SHA-256 hash, and returns plaintext once', async () => {
+      providerStorage.getProvider.mockResolvedValueOnce({ providerId: 'kronos', organisationName: 'Kronos' });
+      apiKeyStorage.create.mockImplementationOnce(async (input: any) => ({
+        keyId: 'new-k', providerId: 'kronos', apiKeyHash: input.apiKeyHash, label: 'prod', isActive: true,
+      }));
+
+      const result = await service.generateApiKey('kronos', 'prod', { userId: 'u-1', userEmail: 'a@b.c' });
+
+      expect(result.apiKey).toMatch(/^pkey_live_[0-9a-f]{64}$/);
+      expect(result.keyId).toBe('new-k');
+      const expectedHash = createHash('sha256').update(result.apiKey).digest('hex');
+      expect(apiKeyStorage.create).toHaveBeenCalledWith({
+        providerId: 'kronos',
+        apiKeyHash: expectedHash,
+        label: 'prod',
+        isActive: true,
+      });
+    });
+
+    it('throws NotFoundException when provider does not exist', async () => {
+      providerStorage.getProvider.mockResolvedValueOnce(null);
+      await expect(service.generateApiKey('ghost', undefined)).rejects.toThrow(NotFoundException);
+      expect(apiKeyStorage.create).not.toHaveBeenCalled();
+    });
+
+    it('audits the issuance with status=applied, source=admin, and the new keyId in metadata', async () => {
+      providerStorage.getProvider.mockResolvedValueOnce({ providerId: 'kronos' });
+      apiKeyStorage.create.mockResolvedValueOnce({
+        keyId: 'k-1', providerId: 'kronos', apiKeyHash: 'h', label: 'prod', isActive: true,
+      });
+      await service.generateApiKey('kronos', 'prod', { userId: 'u-1', userEmail: 'admin@x.com' });
+      expect(auditService.recordMutation).toHaveBeenCalledWith(expect.objectContaining({
+        tournamentIds: ['kronos'],
+        userId: 'u-1',
+        userEmail: 'admin@x.com',
+        source: 'admin',
+        methods: [{ method: 'generateProviderApiKey', params: { providerId: 'kronos', label: 'prod', keyId: 'k-1' } }],
+        status: 'applied',
+        metadata: { providerId: 'kronos', keyId: 'k-1', label: 'prod' },
+      }));
+    });
+
+    it('does not throw when the audit hook itself fails (fail-soft)', async () => {
+      providerStorage.getProvider.mockResolvedValueOnce({ providerId: 'kronos' });
+      apiKeyStorage.create.mockResolvedValueOnce({ keyId: 'k-1', providerId: 'kronos', apiKeyHash: 'h' });
+      auditService.recordMutation.mockRejectedValueOnce(new Error('audit DB down'));
+      await expect(service.generateApiKey('kronos', undefined)).resolves.toBeTruthy();
+    });
+  });
+
+  describe('listApiKeys', () => {
+    it('returns key metadata without the api_key_hash field', async () => {
+      apiKeyStorage.listByProvider.mockResolvedValueOnce([
+        { keyId: 'k-1', providerId: 'kronos', apiKeyHash: 'secret', label: 'prod', isActive: true, createdAt: '2026-05-22' },
+      ]);
+      const result = await service.listApiKeys('kronos');
+      expect(result.success).toBe(true);
+      expect(result.keys[0]).toEqual(expect.not.objectContaining({ apiKeyHash: expect.anything() }));
+      expect(result.keys[0].prefix).toBe('pkey_live_');
+      expect(result.keys[0].label).toBe('prod');
+    });
+  });
+
+  describe('revokeApiKey', () => {
+    it('marks the key revoked and audits the action', async () => {
+      apiKeyStorage.revoke.mockResolvedValueOnce({ success: true });
+      const result = await service.revokeApiKey('k-1', { userId: 'u-1', userEmail: 'admin@x.com' }, 'kronos');
+      expect(result.success).toBe(true);
+      expect(apiKeyStorage.revoke).toHaveBeenCalledWith('k-1');
+      expect(auditService.recordMutation).toHaveBeenCalledWith(expect.objectContaining({
+        tournamentIds: ['kronos'],
+        source: 'admin',
+        methods: [{ method: 'revokeProviderApiKey', params: { keyId: 'k-1' } }],
+        status: 'applied',
+      }));
+    });
+  });
+});

--- a/src/modules/providers/provider-api-key.service.ts
+++ b/src/modules/providers/provider-api-key.service.ts
@@ -1,0 +1,112 @@
+import { Inject, Injectable, Logger, NotFoundException } from '@nestjs/common';
+import { createHash, randomBytes } from 'crypto';
+
+import {
+  PROVIDER_API_KEY_STORAGE,
+  type IProviderApiKeyStorage,
+  PROVIDER_STORAGE,
+  type IProviderStorage,
+} from 'src/storage/interfaces';
+import { AuditService } from '../audit/audit.service';
+
+const PKEY_PREFIX = 'pkey_live_';
+
+/**
+ * Manage provider-scoped API keys (mint, list, revoke).
+ *
+ * Keys are minted as `pkey_live_<64 hex chars>` and stored only as a
+ * SHA-256 hash. The plaintext is returned ONCE on creation and never
+ * persisted. Mirrors the provisioner-key pattern, but scoped to a single
+ * provider with no on-behalf-of indirection.
+ */
+@Injectable()
+export class ProviderApiKeyService {
+  private readonly logger = new Logger(ProviderApiKeyService.name);
+
+  constructor(
+    @Inject(PROVIDER_API_KEY_STORAGE) private readonly apiKeyStorage: IProviderApiKeyStorage,
+    @Inject(PROVIDER_STORAGE) private readonly providerStorage: IProviderStorage,
+    private readonly auditService: AuditService,
+  ) {}
+
+  async generateApiKey(
+    providerId: string,
+    label: string | undefined,
+    actor?: { userId?: string; userEmail?: string },
+  ) {
+    const provider: any = await this.providerStorage.getProvider(providerId);
+    if (!provider) {
+      throw new NotFoundException(`Provider ${providerId} not found`);
+    }
+
+    const rawKey = PKEY_PREFIX + randomBytes(32).toString('hex');
+    const keyHash = createHash('sha256').update(rawKey).digest('hex');
+
+    const keyRow = await this.apiKeyStorage.create({
+      providerId,
+      apiKeyHash: keyHash,
+      label,
+      isActive: true,
+    });
+
+    // Audit (fail-soft) so key issuance is traceable from the audit_log
+    // table alongside mutations. tournamentId is set to the providerId as
+    // a denormalized stable scope key for queryability.
+    this.auditService
+      .recordMutation({
+        tournamentIds: [providerId],
+        userId: actor?.userId,
+        userEmail: actor?.userEmail,
+        source: 'admin',
+        methods: [{ method: 'generateProviderApiKey', params: { providerId, label, keyId: keyRow.keyId } }],
+        status: 'applied',
+        metadata: { providerId, keyId: keyRow.keyId, label },
+      })
+      .catch((err) => this.logger.error(`Audit failed for generateProviderApiKey: ${err.message}`));
+
+    return {
+      success: true,
+      keyId: keyRow.keyId,
+      apiKey: rawKey,
+      label: keyRow.label,
+      createdAt: keyRow.createdAt,
+    };
+  }
+
+  async listApiKeys(providerId: string) {
+    const rows = await this.apiKeyStorage.listByProvider(providerId);
+    // Strip the hash before returning — admin UI never needs it.
+    const keys = rows.map((row) => ({
+      keyId: row.keyId,
+      label: row.label,
+      isActive: row.isActive,
+      lastUsedAt: row.lastUsedAt,
+      createdAt: row.createdAt,
+      expiresAt: row.expiresAt,
+      prefix: PKEY_PREFIX,
+    }));
+    return { success: true, keys };
+  }
+
+  async revokeApiKey(
+    keyId: string,
+    actor?: { userId?: string; userEmail?: string },
+    providerIdHint?: string,
+  ) {
+    const result = await this.apiKeyStorage.revoke(keyId);
+
+    this.auditService
+      .recordMutation({
+        tournamentIds: providerIdHint ? [providerIdHint] : [keyId],
+        userId: actor?.userId,
+        userEmail: actor?.userEmail,
+        source: 'admin',
+        methods: [{ method: 'revokeProviderApiKey', params: { keyId } }],
+        status: 'applied',
+        metadata: { keyId, providerId: providerIdHint },
+      })
+      .catch((err) => this.logger.error(`Audit failed for revokeProviderApiKey: ${err.message}`));
+
+    return result;
+  }
+}

--- a/src/modules/providers/provider-key.controller.ts
+++ b/src/modules/providers/provider-key.controller.ts
@@ -1,0 +1,103 @@
+import { Body, Controller, Get, HttpCode, HttpStatus, NotFoundException, Param, Post, Req, UseGuards } from '@nestjs/common';
+
+import { TournamentStorageService } from 'src/storage/tournament-storage.service';
+import { FactoryService } from '../factory/factory.service';
+
+import { ProviderApiKeyGuard } from './provider-api-key.guard';
+
+/**
+ * Provider-key-scoped REST surface. Authenticated by `pkey_live_*` Bearer
+ * tokens (see ProviderApiKeyMiddleware). Every endpoint operates ONLY on
+ * `req.provider.providerId` — no cross-provider access, no header indirection.
+ *
+ * v1 capabilities (per design decision 2026-05-23):
+ *   • GET  /provider-key/self                     — what provider does this key represent?
+ *   • POST /provider-key/tournaments              — create or save a tournament
+ *   • GET  /provider-key/tournaments/:id          — read a single tournament (if owned)
+ */
+@Controller('provider-key')
+@UseGuards(ProviderApiKeyGuard)
+export class ProviderKeyController {
+  constructor(
+    private readonly factoryService: FactoryService,
+    private readonly tournamentStorageService: TournamentStorageService,
+  ) {}
+
+  @Get('self')
+  async self(@Req() req: any) {
+    const p = req.provider;
+    return {
+      success: true,
+      provider: {
+        providerId: p.providerId,
+        providerName: p.providerName,
+        keyId: p.keyId,
+        keyLabel: p.keyLabel,
+      },
+    };
+  }
+
+  /**
+   * Save (create or update) a tournament record under this provider.
+   *
+   * Enforces that `tournamentRecord.parentOrganisation.organisationId`
+   * matches the authenticated provider — clients cannot land tournaments
+   * under another provider by manipulating the payload.
+   */
+  @Post('tournaments')
+  @HttpCode(HttpStatus.OK)
+  async saveTournament(@Body() body: { tournamentRecord?: any; tournamentRecords?: Record<string, any> }, @Req() req: any) {
+    const authedProviderId: string = req.provider.providerId;
+
+    const records = body.tournamentRecords
+      ? body.tournamentRecords
+      : body.tournamentRecord
+        ? { [body.tournamentRecord.tournamentId]: body.tournamentRecord }
+        : null;
+
+    if (!records || !Object.keys(records).length) {
+      return { error: 'No tournamentRecord provided' };
+    }
+
+    // Reject any tournament whose parentOrganisation doesn't match the
+    // key's provider. Returning 404-style "not found" rather than 403
+    // would be friendlier to misconfigured callers, but here the caller
+    // explicitly tried to write under another provider — refuse loudly.
+    for (const [tid, record] of Object.entries(records)) {
+      const parentOrgId = (record as any)?.parentOrganisation?.organisationId;
+      if (parentOrgId && parentOrgId !== authedProviderId) {
+        return {
+          error: 'Provider mismatch',
+          tournamentId: tid,
+          message: `Tournament ${tid} parentOrganisation.organisationId does not match the authenticated provider.`,
+        };
+      }
+      // If parentOrganisation is missing, stamp it from the key — saves
+      // callers the boilerplate of repeating their own providerId.
+      if (!parentOrgId) {
+        (record as any).parentOrganisation = {
+          ...((record as any).parentOrganisation ?? {}),
+          organisationId: authedProviderId,
+        };
+      }
+    }
+
+    return this.factoryService.saveTournamentRecords({ tournamentRecords: records }, req.user, req.userContext);
+  }
+
+  @Get('tournaments/:tournamentId')
+  async getTournament(@Param('tournamentId') tournamentId: string, @Req() req: any) {
+    const result: any = await this.tournamentStorageService.fetchTournamentRecords({ tournamentId });
+    const tournament = result?.tournamentRecords?.[tournamentId];
+    if (!tournament) {
+      throw new NotFoundException('Tournament not found');
+    }
+    const parentOrgId = tournament?.parentOrganisation?.organisationId;
+    // Return 404 rather than 403 so attackers can't probe for the
+    // existence of tournaments belonging to other providers.
+    if (parentOrgId !== req.provider.providerId) {
+      throw new NotFoundException('Tournament not found');
+    }
+    return { success: true, tournamentRecord: tournament };
+  }
+}

--- a/src/modules/providers/providers.module.ts
+++ b/src/modules/providers/providers.module.ts
@@ -1,14 +1,21 @@
 import { ProviderLifecycleService } from './provider-lifecycle.service';
 import { ProviderCleanupService } from './provider-cleanup.service';
 import { ProviderArchiveService } from './provider-archive.service';
+import { ProviderApiKeyService } from './provider-api-key.service';
+import { ProviderApiKeyMiddleware } from './provider-api-key.middleware';
 import { ProvidersController } from './providers.controller';
+import { AdminProviderKeysController } from './admin-provider-keys.controller';
+import { ProviderKeyController } from './provider-key.controller';
 import { ProvidersService } from './providers.service';
 import { TopologiesService } from './topologies.service';
 import { ProviderCatalogService } from './provider-catalog.service';
-import { Module } from '@nestjs/common';
+import { AuditModule } from '../audit/audit.module';
+import { FactoryModule } from '../factory/factory.module';
+import { MiddlewareConsumer, Module, NestModule } from '@nestjs/common';
 
 @Module({
-  controllers: [ProvidersController],
+  imports: [AuditModule, FactoryModule],
+  controllers: [ProvidersController, AdminProviderKeysController, ProviderKeyController],
   providers: [
     ProvidersService,
     TopologiesService,
@@ -16,7 +23,17 @@ import { Module } from '@nestjs/common';
     ProviderArchiveService,
     ProviderCleanupService,
     ProviderLifecycleService,
+    ProviderApiKeyService,
+    ProviderApiKeyMiddleware,
   ],
-  exports: [ProvidersService, TopologiesService, ProviderCatalogService],
+  exports: [ProvidersService, TopologiesService, ProviderCatalogService, ProviderApiKeyService],
 })
-export class ProvidersModule {}
+export class ProvidersModule implements NestModule {
+  configure(consumer: MiddlewareConsumer): void {
+    // Apply ProviderApiKeyMiddleware globally — it only acts on `pkey_*`
+    // Bearer tokens and passes through otherwise, so coexists with
+    // ProvisionerMiddleware (which handles `prov_*` tokens) and with
+    // standard JWT auth.
+    consumer.apply(ProviderApiKeyMiddleware).forRoutes('*');
+  }
+}

--- a/src/storage/interfaces/index.ts
+++ b/src/storage/interfaces/index.ts
@@ -42,6 +42,11 @@ export {
   type ProvisionerApiKeyRow,
 } from './provisioner-api-key-storage.interface';
 export {
+  PROVIDER_API_KEY_STORAGE,
+  type IProviderApiKeyStorage,
+  type ProviderApiKeyRow,
+} from './provider-api-key-storage.interface';
+export {
   PROVISIONER_PROVIDER_STORAGE,
   type IProvisionerProviderStorage,
   type ProvisionerProviderRow,

--- a/src/storage/interfaces/provider-api-key-storage.interface.ts
+++ b/src/storage/interfaces/provider-api-key-storage.interface.ts
@@ -1,0 +1,36 @@
+export const PROVIDER_API_KEY_STORAGE = Symbol('PROVIDER_API_KEY_STORAGE');
+
+/**
+ * Storage interface for provider-scoped API key management.
+ *
+ * Distinct from `IProvisionerApiKeyStorage`: a provider key authenticates
+ * as a single provider and has no provisioner wrapper. Multiple keys per
+ * provider so callers can rotate without downtime. Key prefix: `pkey_live_`.
+ */
+export interface IProviderApiKeyStorage {
+  /** Look up an active, non-expired key by its hash. Returns the key and its provider. */
+  findByKeyHash(hash: string): Promise<{ key: ProviderApiKeyRow; providerName: string; providerConfig: Record<string, any> } | null>;
+
+  /** Create a new API key record. The plaintext key is NOT stored — only the hash. */
+  create(key: Omit<ProviderApiKeyRow, 'keyId' | 'createdAt' | 'lastUsedAt'>): Promise<ProviderApiKeyRow>;
+
+  /** Revoke a key (set is_active = false). */
+  revoke(keyId: string): Promise<{ success: boolean }>;
+
+  /** List all keys for a provider (metadata only, no hashes). */
+  listByProvider(providerId: string): Promise<ProviderApiKeyRow[]>;
+
+  /** Update last_used_at timestamp. */
+  updateLastUsed(keyId: string): Promise<void>;
+}
+
+export interface ProviderApiKeyRow {
+  keyId: string;
+  providerId: string;
+  apiKeyHash: string;
+  label?: string;
+  isActive: boolean;
+  lastUsedAt?: string;
+  createdAt?: string;
+  expiresAt?: string;
+}

--- a/src/storage/postgres/migrations/029-add-provider-api-keys.sql
+++ b/src/storage/postgres/migrations/029-add-provider-api-keys.sql
@@ -1,0 +1,21 @@
+-- 029-add-provider-api-keys.sql
+-- Provider-scoped API keys for direct provider-to-server integration.
+--
+-- Distinct from provisioner_api_keys (migration 009): a provider key
+-- authenticates as a single provider and grants access only to that
+-- provider's data. Used by partner organisations who don't need or want
+-- a provisioner-level wrapper. Key prefix: `pkey_live_`.
+
+CREATE TABLE IF NOT EXISTS provider_api_keys (
+  key_id         UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  provider_id    TEXT NOT NULL REFERENCES providers(provider_id) ON DELETE CASCADE,
+  api_key_hash   TEXT NOT NULL,
+  label          TEXT,
+  is_active      BOOLEAN DEFAULT true,
+  last_used_at   TIMESTAMPTZ,
+  created_at     TIMESTAMPTZ DEFAULT NOW(),
+  expires_at     TIMESTAMPTZ
+);
+
+CREATE INDEX IF NOT EXISTS idx_provider_api_keys_provider ON provider_api_keys(provider_id);
+CREATE INDEX IF NOT EXISTS idx_provider_api_keys_active ON provider_api_keys(api_key_hash) WHERE is_active = true;

--- a/src/storage/postgres/postgres-provider-api-key.storage.spec.ts
+++ b/src/storage/postgres/postgres-provider-api-key.storage.spec.ts
@@ -1,0 +1,106 @@
+import { PostgresProviderApiKeyStorage } from './postgres-provider-api-key.storage';
+import { IProviderApiKeyStorage } from '../interfaces/provider-api-key-storage.interface';
+
+function makeMockPool() {
+  return { query: jest.fn() };
+}
+
+describe('PostgresProviderApiKeyStorage', () => {
+  let pool: ReturnType<typeof makeMockPool>;
+  let storage: IProviderApiKeyStorage;
+
+  beforeEach(() => {
+    pool = makeMockPool();
+    storage = new PostgresProviderApiKeyStorage(pool as any);
+  });
+
+  describe('findByKeyHash', () => {
+    it('returns key and provider info when found', async () => {
+      pool.query.mockResolvedValueOnce({
+        rows: [{
+          key_id: 'k1', provider_id: 'kronos', api_key_hash: 'hash123', label: 'prod',
+          is_active: true, last_used_at: null, created_at: new Date('2026-04-14'), expires_at: null,
+          provider_name: 'Kronos Sports', provider_config: { permissions: {} },
+        }],
+      });
+      let result: any = await storage.findByKeyHash('hash123');
+      expect(result.key.keyId).toBe('k1');
+      expect(result.providerName).toBe('Kronos Sports');
+      expect(result.providerConfig).toEqual({ permissions: {} });
+      const sql = pool.query.mock.calls[0][0];
+      expect(sql).toContain('k.is_active = true');
+      expect(sql).toContain('expires_at IS NULL OR k.expires_at > NOW()');
+    });
+
+    it('returns null when not found', async () => {
+      pool.query.mockResolvedValueOnce({ rows: [] });
+      let result: any = await storage.findByKeyHash('nope');
+      expect(result).toBeNull();
+    });
+
+    it('defaults missing provider_config to empty object', async () => {
+      pool.query.mockResolvedValueOnce({
+        rows: [{
+          key_id: 'k1', provider_id: 'p1', api_key_hash: 'h', label: null,
+          is_active: true, last_used_at: null, created_at: null, expires_at: null,
+          provider_name: 'Some Provider', provider_config: null,
+        }],
+      });
+      let result: any = await storage.findByKeyHash('h');
+      expect(result.providerConfig).toEqual({});
+    });
+  });
+
+  describe('create', () => {
+    it('inserts and returns the key row', async () => {
+      pool.query.mockResolvedValueOnce({
+        rows: [{
+          key_id: 'new-key', provider_id: 'kronos', api_key_hash: 'h', label: 'staging',
+          is_active: true, last_used_at: null, created_at: new Date('2026-04-14'), expires_at: null,
+        }],
+      });
+      let result: any = await storage.create({
+        providerId: 'kronos', apiKeyHash: 'h', label: 'staging', isActive: true,
+      });
+      expect(result.keyId).toBe('new-key');
+      expect(result.label).toBe('staging');
+    });
+  });
+
+  describe('revoke', () => {
+    it('sets is_active to false', async () => {
+      pool.query.mockResolvedValueOnce({ rows: [] });
+      let result: any = await storage.revoke('k1');
+      expect(result.success).toBe(true);
+      expect(pool.query).toHaveBeenCalledWith(
+        expect.stringContaining('is_active = false'),
+        ['k1'],
+      );
+    });
+  });
+
+  describe('listByProvider', () => {
+    it('returns keys ordered by created_at', async () => {
+      pool.query.mockResolvedValueOnce({
+        rows: [
+          { key_id: 'k1', provider_id: 'kronos', api_key_hash: 'h1', label: 'prod', is_active: true, last_used_at: null, created_at: null, expires_at: null },
+          { key_id: 'k2', provider_id: 'kronos', api_key_hash: 'h2', label: 'staging', is_active: true, last_used_at: null, created_at: null, expires_at: null },
+        ],
+      });
+      let result: any = await storage.listByProvider('kronos');
+      expect(result).toHaveLength(2);
+      expect(result[0].keyId).toBe('k1');
+    });
+  });
+
+  describe('updateLastUsed', () => {
+    it('updates last_used_at', async () => {
+      pool.query.mockResolvedValueOnce({ rows: [] });
+      await storage.updateLastUsed('k1');
+      expect(pool.query).toHaveBeenCalledWith(
+        expect.stringContaining('last_used_at = NOW()'),
+        ['k1'],
+      );
+    });
+  });
+});

--- a/src/storage/postgres/postgres-provider-api-key.storage.ts
+++ b/src/storage/postgres/postgres-provider-api-key.storage.ts
@@ -1,0 +1,85 @@
+import { Inject, Injectable } from '@nestjs/common';
+import { Pool } from 'pg';
+
+import { IProviderApiKeyStorage, ProviderApiKeyRow } from '../interfaces/provider-api-key-storage.interface';
+import { PG_POOL } from './postgres.config';
+import { SUCCESS } from 'src/common/constants/app';
+
+@Injectable()
+export class PostgresProviderApiKeyStorage implements IProviderApiKeyStorage {
+  constructor(@Inject(PG_POOL) private readonly pool: Pool) {}
+
+  async findByKeyHash(
+    hash: string,
+  ): Promise<{ key: ProviderApiKeyRow; providerName: string; providerConfig: Record<string, any> } | null> {
+    const result = await this.pool.query(
+      `SELECT k.key_id, k.provider_id, k.api_key_hash, k.label, k.is_active,
+              k.last_used_at, k.created_at, k.expires_at,
+              p.organisation_name AS provider_name, p.provider_config AS provider_config
+       FROM provider_api_keys k
+       JOIN providers p ON p.provider_id = k.provider_id
+       WHERE k.api_key_hash = $1
+         AND k.is_active = true
+         AND (k.expires_at IS NULL OR k.expires_at > NOW())`,
+      [hash],
+    );
+    if (!result.rows.length) return null;
+    const row = result.rows[0];
+    return {
+      key: mapKeyRow(row),
+      providerName: row.provider_name,
+      providerConfig: row.provider_config ?? {},
+    };
+  }
+
+  async create(
+    key: Omit<ProviderApiKeyRow, 'keyId' | 'createdAt' | 'lastUsedAt'>,
+  ): Promise<ProviderApiKeyRow> {
+    const result = await this.pool.query(
+      `INSERT INTO provider_api_keys (provider_id, api_key_hash, label, is_active, expires_at)
+       VALUES ($1, $2, $3, $4, $5)
+       RETURNING key_id, provider_id, api_key_hash, label, is_active, last_used_at, created_at, expires_at`,
+      [key.providerId, key.apiKeyHash, key.label ?? null, key.isActive ?? true, key.expiresAt ?? null],
+    );
+    return mapKeyRow(result.rows[0]);
+  }
+
+  async revoke(keyId: string): Promise<{ success: boolean }> {
+    await this.pool.query(
+      'UPDATE provider_api_keys SET is_active = false WHERE key_id = $1',
+      [keyId],
+    );
+    return { ...SUCCESS };
+  }
+
+  async listByProvider(providerId: string): Promise<ProviderApiKeyRow[]> {
+    const result = await this.pool.query(
+      `SELECT key_id, provider_id, api_key_hash, label, is_active, last_used_at, created_at, expires_at
+       FROM provider_api_keys
+       WHERE provider_id = $1
+       ORDER BY created_at`,
+      [providerId],
+    );
+    return result.rows.map(mapKeyRow);
+  }
+
+  async updateLastUsed(keyId: string): Promise<void> {
+    await this.pool.query(
+      'UPDATE provider_api_keys SET last_used_at = NOW() WHERE key_id = $1',
+      [keyId],
+    );
+  }
+}
+
+function mapKeyRow(row: any): ProviderApiKeyRow {
+  return {
+    keyId: row.key_id,
+    providerId: row.provider_id,
+    apiKeyHash: row.api_key_hash,
+    label: row.label,
+    isActive: row.is_active,
+    lastUsedAt: row.last_used_at?.toISOString?.() ?? row.last_used_at,
+    createdAt: row.created_at?.toISOString?.() ?? row.created_at,
+    expiresAt: row.expires_at?.toISOString?.() ?? row.expires_at,
+  };
+}

--- a/src/storage/storage.module.ts
+++ b/src/storage/storage.module.ts
@@ -1,6 +1,7 @@
 import { PROVISIONER_PROVIDER_STORAGE } from './interfaces/provisioner-provider-storage.interface';
 import { TOURNAMENT_PROVISIONER_STORAGE } from './interfaces/tournament-provisioner-storage.interface';
 import { PROVISIONER_API_KEY_STORAGE } from './interfaces/provisioner-api-key-storage.interface';
+import { PROVIDER_API_KEY_STORAGE } from './interfaces/provider-api-key-storage.interface';
 import { BOLT_HISTORY_REPORTING } from './interfaces/bolt-history-reporting.interface';
 import { USER_PROVIDER_STORAGE } from './interfaces/user-provider-storage.interface';
 import { PROVISIONER_STORAGE } from './interfaces/provisioner-storage.interface';
@@ -25,6 +26,7 @@ import { PostgresBoltHistoryReportingStorage } from './postgres/postgres-bolt-hi
 import { PostgresProvisionerProviderStorage } from './postgres/postgres-provisioner-provider.storage';
 import { PostgresTournamentProvisionerStorage } from './postgres/postgres-tournament-provisioner.storage';
 import { PostgresProvisionerApiKeyStorage } from './postgres/postgres-provisioner-api-key.storage';
+import { PostgresProviderApiKeyStorage } from './postgres/postgres-provider-api-key.storage';
 import { PostgresUserProviderStorage } from './postgres/postgres-user-provider.storage';
 import { PostgresProvisionerStorage } from './postgres/postgres-provisioner.storage';
 import { PostgresSsoIdentityStorage } from './postgres/postgres-sso-identity.storage';
@@ -93,6 +95,7 @@ const assignmentStorageProvider = makeStorageProvider(ASSIGNMENT_STORAGE, Postgr
 const auditStorageProvider = makeStorageProvider(AUDIT_STORAGE, PostgresAuditStorage);
 const provisionerStorageProvider = makeStorageProvider(PROVISIONER_STORAGE, PostgresProvisionerStorage);
 const provisionerApiKeyStorageProvider = makeStorageProvider(PROVISIONER_API_KEY_STORAGE, PostgresProvisionerApiKeyStorage);
+const providerApiKeyStorageProvider = makeStorageProvider(PROVIDER_API_KEY_STORAGE, PostgresProviderApiKeyStorage);
 const provisionerProviderStorageProvider = makeStorageProvider(PROVISIONER_PROVIDER_STORAGE, PostgresProvisionerProviderStorage);
 const tournamentProvisionerStorageProvider = makeStorageProvider(TOURNAMENT_PROVISIONER_STORAGE, PostgresTournamentProvisionerStorage);
 const ssoIdentityStorageProvider = makeStorageProvider(SSO_IDENTITY_STORAGE, PostgresSsoIdentityStorage);
@@ -122,6 +125,7 @@ const policyStorageProvider = makeStorageProvider(POLICY_STORAGE, PostgresPolicy
     auditStorageProvider,
     provisionerStorageProvider,
     provisionerApiKeyStorageProvider,
+    providerApiKeyStorageProvider,
     provisionerProviderStorageProvider,
     tournamentProvisionerStorageProvider,
     ssoIdentityStorageProvider,
@@ -148,6 +152,7 @@ const policyStorageProvider = makeStorageProvider(POLICY_STORAGE, PostgresPolicy
     AUDIT_STORAGE,
     PROVISIONER_STORAGE,
     PROVISIONER_API_KEY_STORAGE,
+    PROVIDER_API_KEY_STORAGE,
     PROVISIONER_PROVIDER_STORAGE,
     TOURNAMENT_PROVISIONER_STORAGE,
     SSO_IDENTITY_STORAGE,


### PR DESCRIPTION
## Summary
- Adds a real **provider-scoped** API key facility, parallel to the existing provisioner-key flow. Closes the long-standing gap where the only way to give an external partner direct integration access was to first register them as a provisioner (IONSport→Kronos pattern).
- Key prefix: `pkey_live_<64 hex>`. Plaintext is returned once on creation and never stored — only the SHA-256 hash lives in `provider_api_keys`.
- New `/provider-key/*` route set is the scoped surface: `GET /self`, `POST /tournaments`, `GET /tournaments/:id`. Cross-provider tournament reads return **404 (not 403)** to avoid existence probing. Saves whose `parentOrganisation` points at another provider are explicitly refused.
- Admin CRUD lives at `/admin/providers/:id/keys` (super-admin only). Admin-client `providersPanel` now has a Generate / List / Revoke section mirroring the provisioner panel — same Tabulator, same `generatedKeyModal` (extended with an optional `providerName`).

## Design decisions (locked with stakeholder)
- Prefix: `pkey_live_` (distinct from `prov_sk_live_`).
- Routes: dedicated `/provider-key/*` rather than reusing `/provisioner/*` with a synthesized provisioner identity. Easier to enumerate the v1 capability surface and to inspect "is this caller a provisioner or a provider" in audit/log.
- v1 capabilities: read own provider + tournament read/save. **No user mgmt, no subsidiaries, no key self-management.** Easy to expand once real usage surfaces a need.
- IONSport stays a provisioner — they own Kronos. No migration of existing keys.

## Notable wiring detail
- `AuthGuard` previously short-circuited only on `request.provisioner`. Updated to also accept `request.provider`, since the new middleware synthesizes the same shape of `req.user` / `req.userContext` that downstream code expects.

## Test plan
- [x] `pnpm exec tsc --noEmit` (server + admin-client) — clean
- [x] `pnpm exec eslint --max-warnings 0` on all 20 touched files — clean
- [x] Unit: 7 storage + 6 middleware + 3 guard + 6 service tests — 22/22 pass
- [x] E2E against live Postgres (gated on `STORAGE_PROVIDER=postgres`): 7-test lifecycle — mint key, authenticate `/self`, round-trip tournament, 404 on cross-provider read, refuse cross-provider save, revoke kills the key — 7/7 pass
- [ ] Admin UI smoke: open Providers tab → select a provider → Generate Key → confirm one-shot modal → verify list/revoke
- [ ] Post-deploy: hand a provider a `pkey_live_` key, confirm they can `POST /provider-key/tournaments`

## Notes for review
- 1 migration (`029-add-provider-api-keys.sql`). Idempotent (`IF NOT EXISTS`).
- No `en.json` edits — every i18n key the new UI uses is already shipping for the provisioner panel.
- Audit trail is wired: key issuance and revocation are recorded via `recordMutation` with `source: 'admin'`. Tournament writes through `/provider-key/tournaments` go through `FactoryService.saveTournamentRecords` and so inherit the audit behavior we shipped on 2026-05-22.