### PR TITLE
ci: fix storybook deploy — drop redundant pnpm version pin

### DIFF
--- a/.github/workflows/deploy-storybook.yml
+++ b/.github/workflows/deploy-storybook.yml
@@ -26,8 +26,6 @@ jobs:
       - uses: actions/checkout@v6
 
       - uses: pnpm/action-setup@v6
-        with:
-          version: 11
 
       - uses: actions/setup-node@v6
         with:


### PR DESCRIPTION
The "Deploy Storybook to GitHub Pages" workflow has been failing (last good run 2026-04-21): `pnpm/action-setup@v6` errors when both a `version` input and package.json's `packageManager` field are set. Removing `version: 11` so `packageManager: pnpm@11.2.2` is the single source of truth. Merging re-runs the deploy (path filter includes this workflow file).