### PR TITLE
feat(swagger): gate /api docs by CFS account role

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -7,7 +7,7 @@ import { version } from 'tods-competition-factory';
 import { ConfigService } from '@nestjs/config';
 import { NestFactory } from '@nestjs/core';
 import { Logger } from '@nestjs/common';
-import { createHash, timingSafeEqual } from 'crypto';
+import { AuthService } from './modules/account/auth/auth.service';
 import compression from 'compression';
 import { json } from 'body-parser';
 
@@ -53,48 +53,44 @@ async function bootstrap() {
   // covers every operation. Public endpoints simply ignore the token.
   document.security = [{ bearer: [] }];
 
-  // In production the Swagger explorer + spec are gated behind HTTP Basic auth
-  // so the full API surface isn't publicly browsable. Only the Swagger-owned
-  // paths are gated — real `/api/*` controllers (e.g. /api/config,
-  // /api/bolt-history) are deliberately left untouched. Fail-safe: if no
-  // credentials are configured in production, the explorer is not mounted at all.
+  // In production the Swagger explorer + spec are gated behind HTTP Basic auth.
+  // Credentials are real accounts — SUPER_ADMIN, PROVISIONER, or PROVIDER_ADMIN
+  // users (the ones who actually exercise the API) — validated by AuthService
+  // against the users table. Only Swagger-owned paths are gated; real `/api/*`
+  // controllers (e.g. /api/config, /api/bolt-history) are untouched. Dev
+  // (non-production) stays open.
   const swaggerLocked = process.env.NODE_ENV === 'production' || process.env.APP_MODE === 'production';
-  const swaggerUser = process.env.SWAGGER_USER;
-  const swaggerPassword = process.env.SWAGGER_PASSWORD;
-
-  if (swaggerLocked && !(swaggerUser && swaggerPassword)) {
-    Logger.warn(
-      'Swagger UI not mounted: set SWAGGER_USER and SWAGGER_PASSWORD to expose it behind Basic auth in production.',
-      'Bootstrap',
-    );
-  } else {
-    if (swaggerLocked) {
-      const isSwaggerPath = (p: string): boolean =>
-        p === '/api' ||
-        p === '/api/' ||
-        p === '/api-json' ||
-        p === '/api-yaml' ||
-        p.startsWith('/api/swagger-ui') ||
-        p === '/api/index.css' ||
-        p.startsWith('/api/favicon');
-      const safeEqual = (a: string, b: string): boolean =>
-        timingSafeEqual(createHash('sha256').update(a).digest(), createHash('sha256').update(b).digest());
-      app.use((req: any, res: any, next: () => void) => {
-        if (!isSwaggerPath(req.path)) return next();
-        const [scheme, encoded] = (req.headers.authorization ?? '').split(' ');
-        if (scheme === 'Basic' && encoded) {
-          const decoded = Buffer.from(encoded, 'base64').toString();
-          const idx = decoded.indexOf(':');
-          if (idx >= 0 && safeEqual(decoded.slice(0, idx), swaggerUser as string) && safeEqual(decoded.slice(idx + 1), swaggerPassword as string)) {
-            return next();
+  if (swaggerLocked) {
+    const authService = app.get(AuthService);
+    const isSwaggerPath = (p: string): boolean =>
+      p === '/api' ||
+      p === '/api/' ||
+      p === '/api-json' ||
+      p === '/api-yaml' ||
+      p.startsWith('/api/swagger-ui') ||
+      p === '/api/index.css' ||
+      p.startsWith('/api/favicon');
+    app.use(async (req: any, res: any, next: () => void) => {
+      if (!isSwaggerPath(req.path)) return next();
+      const [scheme, encoded] = (req.headers.authorization ?? '').split(' ');
+      if (scheme === 'Basic' && encoded) {
+        const decoded = Buffer.from(encoded, 'base64').toString();
+        const idx = decoded.indexOf(':');
+        if (idx >= 0) {
+          try {
+            if (await authService.canAccessApiDocs(decoded.slice(0, idx), decoded.slice(idx + 1))) {
+              return next();
+            }
+          } catch {
+            // fall through to 401
           }
         }
-        res.set('WWW-Authenticate', 'Basic realm="CFS API docs"');
-        res.status(401).send('Authentication required');
-      });
-    }
-    SwaggerModule.setup('api', app, document);
+      }
+      res.set('WWW-Authenticate', 'Basic realm="CFS API docs"');
+      res.status(401).send('Authentication required');
+    });
   }
+  SwaggerModule.setup('api', app, document);
 
   const config = app.get(ConfigService);
   const appName = config.get('APP.name');

--- a/src/modules/account/auth/auth.service.ts
+++ b/src/modules/account/auth/auth.service.ts
@@ -11,7 +11,7 @@ import bcrypt from 'bcryptjs';
 
 // constants and interfaces
 import { SUCCESS } from 'src/common/constants/app';
-import { PROVISIONER as PROVISIONER_ROLE, SUPER_ADMIN } from 'src/common/constants/roles';
+import { PROVISIONER as PROVISIONER_ROLE, SUPER_ADMIN, PROVIDER_ADMIN } from 'src/common/constants/roles';
 import {
   PROVIDER_STORAGE,
   type IProviderStorage,
@@ -25,6 +25,7 @@ import {
   type IProvisionerProviderStorage,
 } from 'src/storage/interfaces';
 import { assertProviderEditor } from './helpers/assertProviderEditor';
+import { buildUserContext } from './helpers/buildUserContext';
 import type { UserContext } from './decorators/user-context.decorator';
 
 const PASSWORD_RESET_TOKEN_TTL = '1h';
@@ -73,6 +74,36 @@ export class AuthService {
     @Inject(PROVISIONER_PROVIDER_STORAGE)
     private readonly provisionerProviderStorage: IProvisionerProviderStorage,
   ) {}
+
+  /**
+   * Authorize access to the Swagger explorer (/api) in production. Returns
+   * true only for accounts that actually exercise the API — SUPER_ADMIN,
+   * PROVISIONER-role users, or a PROVIDER_ADMIN of any provider — after a
+   * bcrypt password check. SSO-only (passwordless) and unknown accounts are
+   * rejected. Reuses the same role model as login (incl. the legacy
+   * `admin` → PROVIDER_ADMIN shim via buildUserContext).
+   */
+  async canAccessApiDocs(email: string, clearTextPassword: string): Promise<boolean> {
+    if (!email || !clearTextPassword) return false;
+    let user: any;
+    try {
+      user = await this.usersService.findOne(email);
+    } catch {
+      return false;
+    }
+    if (!user?.password) return false;
+    if (!(await bcrypt.compare(clearTextPassword, user.password))) return false;
+
+    const roles: string[] = user.roles ?? [];
+    if (roles.includes(SUPER_ADMIN) || roles.includes(PROVISIONER_ROLE)) return true;
+
+    const ctx = await buildUserContext(user, {
+      userProviderStorage: this.userProviderStorage,
+      userProvisionerStorage: this.userProvisionerStorage,
+      provisionerProviderStorage: this.provisionerProviderStorage,
+    });
+    return Object.values(ctx.providerRoles).includes(PROVIDER_ADMIN);
+  }
 
   /**
    * Build the password-reset URL placed in the email body. Same shape

--- a/src/stories/api-reference/SwaggerUI.mdx
+++ b/src/stories/api-reference/SwaggerUI.mdx
@@ -20,6 +20,24 @@ deployed server exposes.
   </tbody>
 </table>
 
+## Access (production)
+
+On the production server the explorer and spec are **gated behind HTTP Basic
+auth**. Your browser will prompt for credentials — sign in with your **CourtHive
+account** (the same email + password you use for TMX). Access is limited to the
+roles that exercise the API:
+
+- **Super admins**
+- **Provisioners** (users with the provisioner role)
+- **Provider admins** (of any provider)
+
+Other accounts — and anonymous visitors — get `401`. In local development the
+explorer is open (no login).
+
+> This Basic-auth login only unlocks the explorer page. To actually *call*
+> secured endpoints, still use the **Authorize** button with a Bearer token
+> (a provider/provisioner API key or a user JWT) as described below.
+
 ## What's in it
 
 Every controller route across the server (~116 endpoints) — factory/tournament


### PR DESCRIPTION
Replaces the static Basic credential for the Swagger explorer with **account-based auth**. `/api` + `/api-json` now require a CourtHive login (email + password) for a **SUPER_ADMIN**, **PROVISIONER**-role user, or **PROVIDER_ADMIN** of any provider — validated by `AuthService.canAccessApiDocs` (bcrypt + the same role model as login). Only Swagger-owned paths gated; real `/api/*` controllers untouched. Prod only; dev open. check-types + eslint + build-storybook green.