### PR TITLE
feat(swagger): gate /api on shared-DB hosts (SWAGGER_REQUIRE_AUTH)

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -53,13 +53,21 @@ async function bootstrap() {
   // covers every operation. Public endpoints simply ignore the token.
   document.security = [{ bearer: [] }];
 
-  // In production the Swagger explorer + spec are gated behind HTTP Basic auth.
-  // Credentials are real accounts — SUPER_ADMIN, PROVISIONER, or PROVIDER_ADMIN
-  // users (the ones who actually exercise the API) — validated by AuthService
-  // against the users table. Only Swagger-owned paths are gated; real `/api/*`
-  // controllers (e.g. /api/config, /api/bolt-history) are untouched. Dev
-  // (non-production) stays open.
-  const swaggerLocked = process.env.NODE_ENV === 'production' || process.env.APP_MODE === 'production';
+  // The Swagger explorer + spec are gated behind HTTP Basic auth on any host
+  // that talks to the shared/production database. Credentials are real accounts
+  // — SUPER_ADMIN, PROVISIONER, or PROVIDER_ADMIN users (the ones who actually
+  // exercise the API) — validated by AuthService against the users table. Only
+  // Swagger-owned paths are gated; real `/api/*` controllers (e.g. /api/config,
+  // /api/bolt-history) are untouched.
+  //
+  // Gating triggers for production (nest) AND the shared-DB staging host
+  // (courthive-mentat — runs APP_MODE=development but points at the same
+  // Postgres), which sets SWAGGER_REQUIRE_AUTH=true. Isolated local dev with
+  // its own database leaves all three unset and keeps the explorer open.
+  const swaggerLocked =
+    process.env.SWAGGER_REQUIRE_AUTH === 'true' ||
+    process.env.NODE_ENV === 'production' ||
+    process.env.APP_MODE === 'production';
   if (swaggerLocked) {
     const authService = app.get(AuthService);
     const isSwaggerPath = (p: string): boolean =>

--- a/src/stories/api-reference/SwaggerUI.mdx
+++ b/src/stories/api-reference/SwaggerUI.mdx
@@ -31,8 +31,9 @@ roles that exercise the API:
 - **Provisioners** (users with the provisioner role)
 - **Provider admins** (of any provider)
 
-Other accounts — and anonymous visitors — get `401`. In local development the
-explorer is open (no login).
+Other accounts — and anonymous visitors — get `401`. The gate is active on any
+host that talks to the shared/production database (production and the shared-DB
+staging host); isolated local development with its own database is open.
 
 > This Basic-auth login only unlocks the explorer page. To actually *call*
 > secured endpoints, still use the **Authorize** button with a Bearer token


### PR DESCRIPTION
courthive-mentat runs `APP_MODE=development` but points at the **same Postgres as production**, so its `/api` explorer was open. Adds a `SWAGGER_REQUIRE_AUTH=true` opt-in that gates the explorer on any shared-DB host regardless of APP_MODE. nest still gates via production; isolated local dev stays open. Endpoints themselves were always guarded; this closes the explorer-surface gap.