### PR TITLE
docs(swagger): clarify Authorize button vs page login

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -35,14 +35,29 @@ async function bootstrap() {
   const swaggerConfig = new DocumentBuilder()
     .setTitle('Competition Factory Server API')
     .setDescription(
-      'REST API for the Competition Factory Server. Authenticate with a Bearer token — a provider ' +
-        'API key (`pkey_live_*`), a provisioner API key (`prov_sk_live_*`), or a user JWT. Click ' +
-        '**Authorize** and paste the token. For provisioner calls on behalf of a provider, also send ' +
-        'an `X-Provider-Id` header (use curl or a REST client; it is not part of the generated parameters).',
+      'REST API for the Competition Factory Server.\n\n' +
+        '**There are two separate auth steps — they are easy to confuse:**\n\n' +
+        '1. **Signing in to view this page.** You already did this with your CourtHive account ' +
+        '(super-admin, provisioner, or provider-admin). It only unlocks the documentation.\n' +
+        '2. **Authorizing API calls.** To actually run a request with *Try it out*, click ' +
+        '**Authorize** (top-right) and paste a **Bearer token** — this is *not* the same as the ' +
+        'login above. Use a provider API key (`pkey_live_…`), a provisioner API key ' +
+        '(`prov_sk_live_…`), or a user **JWT** from `POST /auth/login`. Paste only the token ' +
+        '(no `Bearer ` prefix).\n\n' +
+        'For provisioner calls on behalf of a provider, also send an `X-Provider-Id` header ' +
+        '(a custom header — use curl or a REST client, as the *Try it out* form has no field for it).',
     )
     .setVersion('1.0')
     .addBearerAuth(
-      { type: 'http', scheme: 'bearer', bearerFormat: 'Token', description: 'pkey_live_… / prov_sk_live_… / user JWT' },
+      {
+        type: 'http',
+        scheme: 'bearer',
+        bearerFormat: 'Token',
+        description:
+          'Token for CALLING endpoints — NOT the account login that opened this page. Paste a ' +
+          'provider API key (pkey_live_…), a provisioner API key (prov_sk_live_…), or a user JWT ' +
+          'from POST /auth/login. No "Bearer " prefix.',
+      },
       'bearer',
     )
     .build();

--- a/src/stories/api-reference/SwaggerUI.mdx
+++ b/src/stories/api-reference/SwaggerUI.mdx
@@ -53,17 +53,28 @@ inferred from the controllers and their DTOs.
 3. Click **Try it out**, fill in the parameters, and **Execute** to call the live
    server.
 
-### Authenticating
+### Authenticating — two separate steps (easy to confuse)
 
-1. Click the **Authorize** button (top-right).
-2. Paste a Bearer token — any of:
-   - a **provider** API key (`pkey_live_*`) — see **Provider API/Authentication**
-   - a **provisioner** API key (`prov_sk_live_*`) — see **Provisioner/Authentication**
-   - a **user JWT** (from login)
-3. Authorized requests then carry the token automatically.
+1. **The browser login that opened this page** (Basic auth) — your CourtHive
+   account. It only grants permission to *view* the explorer (see **Access
+   (production)** above). It does **not** authenticate the requests you run here.
+2. **The Authorize button** (top-right) — attaches a **Bearer token** so the
+   requests you send with **Try it out** are authenticated against the API. This
+   is a *different* credential from your page login.
 
-> Paste only the token itself in the Authorize dialog — Swagger adds the
-> `Bearer ` prefix for you.
+In the **Authorize** dialog, paste **one** of:
+
+- a **provider** API key (`pkey_live_*`) — see **Provider API/Authentication**
+- a **provisioner** API key (`prov_sk_live_*`) — see **Provisioner/Authentication**
+- a **user JWT** — get one from `POST /auth/login` (email + password), or copy it
+  from your signed-in TMX session
+
+Paste only the token itself — Swagger adds the `Bearer ` prefix for you. Then
+**Try it out → Execute** sends it automatically.
+
+> **Why two logins?** The page gate keeps the API surface private; the Authorize
+> token is what the server checks on each endpoint call. Viewing the docs and
+> calling an endpoint are deliberately separate.
 
 ### On-behalf-of header (provisioners)
 


### PR DESCRIPTION
The Swagger page login (Basic auth, view-only) and the **Authorize** button (Bearer token, to call endpoints) are different and were confusing users. Makes both explicit in the OpenAPI `info.description` + the Authorize-dialog `description`, and in the Storybook doc. Clarifies the token is a provider/provisioner API key or a user JWT from `POST /auth/login`.