### PR TITLE
fix: provider-scoped tournament delete safeguards (authz, archive, end-date guard, calendar detach)

### DIFF
--- a/src/modules/factory/helpers/checkTournamentAccess.ts
+++ b/src/modules/factory/helpers/checkTournamentAccess.ts
@@ -96,6 +96,43 @@ export function canMutateTournament(
 }
 
 /**
+ * Can this user DELETE this tournament?
+ *
+ * Deliberately NOT gated by ENABLE_TOURNAMENT_ACCESS_SCOPING: deletion is
+ * destructive and must always be bound to the tournament's owning provider,
+ * even while the broader view/mutate scoping is still being rolled out. A
+ * global `deleteTournament` permission grants the *capability* to delete but
+ * never widens *scope* across providers — that decision lives here.
+ *
+ * Allowed when the user is SUPER_ADMIN, a provisioner-owner of the
+ * tournament's provider, PROVIDER_ADMIN at that provider, or a provider member
+ * (e.g. DIRECTOR) who created or was assigned the tournament. Tournaments with
+ * no provider, or callers with no userContext, are denied (fail closed).
+ */
+export function canDeleteTournament(
+  tournament: any,
+  userContext: UserContext | undefined,
+  assignedTournamentIds: Set<string> = new Set(),
+): boolean {
+  if (!userContext) return false;
+  if (userContext.isSuperAdmin) return true;
+
+  const providerId = getTournamentProviderId(tournament);
+  if (!providerId) return false; // No owning provider → only SUPER_ADMIN may delete.
+
+  if (userContext.provisionerProviderIds?.includes(providerId)) return true;
+
+  const roleAtProvider = userContext.providerRoles[providerId];
+  if (!roleAtProvider) return false; // No association with the owning provider.
+  if (roleAtProvider === PROVIDER_ADMIN) return true;
+
+  // Non-admin provider role (e.g. DIRECTOR): only own or assigned tournaments.
+  const createdBy = getCreatedByUserId(tournament);
+  if (createdBy && createdBy === userContext.userId) return true;
+  return tournament?.tournamentId ? assignedTournamentIds.has(tournament.tournamentId) : false;
+}
+
+/**
  * Filter a list of tournament calendar entries to only those the user can see.
  *
  * Each entry must have at minimum `{ tournamentId, providerId }` and

--- a/src/modules/provisioner/sso.controller.ts
+++ b/src/modules/provisioner/sso.controller.ts
@@ -106,7 +106,12 @@ export class SsoController {
     const userDetails = { ...user };
     delete userDetails.password;
     const jwtPayload = { ...userDetails, providerIds: userContext.providerIds, providerRoles: userContext.providerRoles };
-    const accessToken = await this.jwtService.signAsync(jwtPayload);
+    // Match the direct-login session lifetime (auth.service.ts signIn uses
+    // `expiresIn: '1d'`). Without this override the SSO session inherits the
+    // JwtModule default (JWT_VALIDITY, '2h' in prod), so provisioner-handoff
+    // users silently expired hours sooner than password-login users and saw
+    // an unexpected 401 mid-session.
+    const accessToken = await this.jwtService.signAsync(jwtPayload, { expiresIn: '1d' });
 
     // Track last access for both user and the provider this SSO token resolved to.
     // Failures are non-fatal but visible — silent .catch() previously hid mismatches.

--- a/src/storage/interfaces/tournament-storage.interface.ts
+++ b/src/storage/interfaces/tournament-storage.interface.ts
@@ -22,5 +22,16 @@ export interface ITournamentStorage {
     tournamentId?: string;
   }): Promise<{ success?: boolean; removed?: number; error?: string }>;
 
+  /**
+   * Archive a full tournament record before deletion so the delete is
+   * recoverable. Must succeed before `removeTournamentRecords` runs — callers
+   * treat a failed archive as a hard stop on the delete.
+   */
+  archiveTournamentRecord(params: {
+    tournamentRecord: any;
+    deletedByUserId?: string;
+    deletedByEmail?: string;
+  }): Promise<{ success?: boolean; error?: string }>;
+
   listTournamentIds(): Promise<string[]>;
 }

--- a/src/storage/postgres/migrations/030-add-deleted-tournaments.sql
+++ b/src/storage/postgres/migrations/030-add-deleted-tournaments.sql
@@ -1,0 +1,21 @@
+-- Archive of deleted tournament records so a delete is always recoverable.
+-- Written (as a hard prerequisite) before any DELETE FROM tournaments, so the
+-- full TODS record + who/when is retained even for an intentional deletion.
+-- See incident 2026-05-23 (Battle of Boca): a hard delete with no server-side
+-- copy was recoverable only because the TD happened to have the record open.
+
+CREATE TABLE IF NOT EXISTS deleted_tournaments (
+  tournament_id        TEXT NOT NULL,
+  provider_id          TEXT,
+  tournament_name      TEXT,
+  start_date           DATE,
+  end_date             DATE,
+  data                 JSONB NOT NULL,
+  deleted_at           TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  deleted_by_user_id   UUID,
+  deleted_by_email     TEXT,
+  PRIMARY KEY (tournament_id, deleted_at)
+);
+
+CREATE INDEX IF NOT EXISTS idx_deleted_tournaments_provider ON deleted_tournaments (provider_id);
+CREATE INDEX IF NOT EXISTS idx_deleted_tournaments_deleted_at ON deleted_tournaments (deleted_at DESC);

--- a/src/storage/postgres/postgres-tournament.storage.ts
+++ b/src/storage/postgres/postgres-tournament.storage.ts
@@ -92,6 +92,33 @@ export class PostgresTournamentStorage implements ITournamentStorage {
     return { ...SUCCESS, removed: result.rowCount ?? 0 };
   }
 
+  async archiveTournamentRecord({
+    tournamentRecord,
+    deletedByUserId,
+    deletedByEmail,
+  }: {
+    tournamentRecord: any;
+    deletedByUserId?: string;
+    deletedByEmail?: string;
+  }) {
+    const key = tournamentRecord?.tournamentId;
+    if (!key) return { error: 'Invalid tournamentRecord' };
+
+    const providerId = tournamentRecord.parentOrganisation?.organisationId ?? null;
+    const tournamentName = tournamentRecord.tournamentName ?? null;
+    const startDate = tournamentRecord.startDate ?? null;
+    const endDate = tournamentRecord.endDate ?? null;
+
+    await this.pool.query(
+      `INSERT INTO deleted_tournaments
+         (tournament_id, provider_id, tournament_name, start_date, end_date, data, deleted_by_user_id, deleted_by_email)
+       VALUES ($1, $2, $3, $4, $5, $6, $7, $8)`,
+      [key, providerId, tournamentName, startDate, endDate, JSON.stringify(tournamentRecord), deletedByUserId ?? null, deletedByEmail ?? null],
+    );
+
+    return { ...SUCCESS };
+  }
+
   async listTournamentIds(): Promise<string[]> {
     const result = await this.pool.query('SELECT tournament_id FROM tournaments ORDER BY tournament_id');
     return result.rows.map((row) => row.tournament_id);

--- a/src/storage/tournament-storage.service.spec.ts
+++ b/src/storage/tournament-storage.service.spec.ts
@@ -1,0 +1,208 @@
+import { TournamentStorageService } from './tournament-storage.service';
+import { canDeleteTournament } from 'src/modules/factory/helpers/checkTournamentAccess';
+import { PROVIDER_ADMIN, DIRECTOR } from 'src/common/constants/roles';
+
+// getCalendarEntry calls the factory's getTournamentInfo; stub it so these unit
+// tests exercise the facade's calendar logic, not the factory.
+jest.mock('src/helpers/getCalendarEntry', () => ({
+  getCalendarEntry: ({ tournamentRecord }: any) => ({
+    tournamentId: tournamentRecord.tournamentId,
+    providerId: tournamentRecord.parentOrganisation?.organisationId,
+    searchText: (tournamentRecord.tournamentName || '').toLowerCase(),
+    tournament: { tournamentName: tournamentRecord.tournamentName },
+  }),
+}));
+
+const BOBOCA = 'prov-boboca';
+const ION = 'prov-ion';
+const TID = 'tourn-1';
+
+const abbrFor = (providerId: string) => (providerId === BOBOCA ? 'BOBOCA' : 'ION');
+
+function buildRecord(over: any = {}) {
+  const providerId = over.providerId ?? BOBOCA;
+  return {
+    tournamentId: over.tournamentId ?? TID,
+    tournamentName: over.tournamentName ?? 'Battle of Boca',
+    endDate: 'endDate' in over ? over.endDate : '2020-01-01',
+    isMock: over.isMock ?? false,
+    parentOrganisation: { organisationId: providerId, organisationAbbreviation: abbrFor(providerId) },
+    extensions: over.createdBy ? [{ name: 'createdByUserId', value: over.createdBy }] : [],
+  };
+}
+
+function ctx(over: any = {}) {
+  return { userId: 'u-1', isSuperAdmin: false, providerRoles: {}, provisionerProviderIds: [], providerIds: [], ...over };
+}
+
+describe('TournamentStorageService — delete safeguards', () => {
+  let service: TournamentStorageService;
+  let tournamentStorage: any;
+  let providerStorage: any;
+  let calendarStorage: any;
+
+  beforeEach(() => {
+    tournamentStorage = {
+      findTournamentRecord: jest.fn(),
+      archiveTournamentRecord: jest.fn().mockResolvedValue({ success: true }),
+      removeTournamentRecords: jest.fn().mockResolvedValue({ success: true, removed: 1 }),
+      saveTournamentRecord: jest.fn().mockResolvedValue({ success: true }),
+    };
+    providerStorage = { getProvider: jest.fn().mockResolvedValue({ organisationAbbreviation: 'BOBOCA' }) };
+    calendarStorage = {
+      getCalendar: jest
+        .fn()
+        .mockResolvedValue({ provider: { organisationAbbreviation: 'BOBOCA' }, tournaments: [{ tournamentId: TID }] }),
+      setCalendar: jest.fn().mockResolvedValue({ success: true }),
+      listCalendars: jest.fn().mockResolvedValue([]),
+    };
+    service = new TournamentStorageService(tournamentStorage, providerStorage, calendarStorage);
+  });
+
+  const adminAt = (providerId: string) => ctx({ userId: 'clubx', providerRoles: { [providerId]: PROVIDER_ADMIN } });
+
+  it('denies a cross-provider delete even with the global deleteTournament permission', async () => {
+    tournamentStorage.findTournamentRecord.mockResolvedValue({ tournamentRecord: buildRecord({ providerId: BOBOCA }) });
+    const result: any = await service.removeTournamentRecords(
+      { tournamentId: TID },
+      { userId: 'smadler', email: 's@x.com', roles: ['admin'], permissions: ['deleteTournament'] },
+      undefined,
+      ctx({ userId: 'smadler', providerRoles: { [ION]: PROVIDER_ADMIN } }),
+    );
+    expect(result.errorCode).toBe('ERR_DELETE_FORBIDDEN');
+    expect(result.removed).toBe(0);
+    expect(tournamentStorage.archiveTournamentRecord).not.toHaveBeenCalled();
+    expect(tournamentStorage.removeTournamentRecords).not.toHaveBeenCalled();
+  });
+
+  it('allows a PROVIDER_ADMIN at the tournament’s own provider (ended tournament)', async () => {
+    tournamentStorage.findTournamentRecord.mockResolvedValue({ tournamentRecord: buildRecord({ providerId: BOBOCA }) });
+    const result: any = await service.removeTournamentRecords({ tournamentId: TID }, { userId: 'clubx' }, undefined, adminAt(BOBOCA));
+    expect(result.removed).toBe(1);
+    expect(tournamentStorage.archiveTournamentRecord).toHaveBeenCalledTimes(1);
+    expect(tournamentStorage.removeTournamentRecords).toHaveBeenCalledWith({ tournamentIds: [TID] });
+  });
+
+  it('allows a SUPER_ADMIN to delete across providers', async () => {
+    tournamentStorage.findTournamentRecord.mockResolvedValue({ tournamentRecord: buildRecord({ providerId: BOBOCA }) });
+    const result: any = await service.removeTournamentRecords({ tournamentId: TID }, { userId: 'root' }, undefined, ctx({ isSuperAdmin: true }));
+    expect(result.removed).toBe(1);
+  });
+
+  it('archives BEFORE deleting the row', async () => {
+    const order: string[] = [];
+    tournamentStorage.findTournamentRecord.mockResolvedValue({ tournamentRecord: buildRecord({ providerId: BOBOCA }) });
+    tournamentStorage.archiveTournamentRecord.mockImplementation(async () => {
+      order.push('archive');
+      return { success: true };
+    });
+    tournamentStorage.removeTournamentRecords.mockImplementation(async () => {
+      order.push('delete');
+      return { removed: 1 };
+    });
+    await service.removeTournamentRecords({ tournamentId: TID }, { userId: 'clubx' }, undefined, adminAt(BOBOCA));
+    expect(order).toEqual(['archive', 'delete']);
+  });
+
+  it('aborts the delete when archiving fails', async () => {
+    tournamentStorage.findTournamentRecord.mockResolvedValue({ tournamentRecord: buildRecord({ providerId: BOBOCA }) });
+    tournamentStorage.archiveTournamentRecord.mockResolvedValue({ error: 'DB down' });
+    const result: any = await service.removeTournamentRecords({ tournamentId: TID }, { userId: 'clubx' }, undefined, adminAt(BOBOCA));
+    expect(result.errorCode).toBe('ERR_ARCHIVE_FAILED');
+    expect(tournamentStorage.removeTournamentRecords).not.toHaveBeenCalled();
+  });
+
+  it('blocks deleting a non-mock tournament whose end date is in the future', async () => {
+    tournamentStorage.findTournamentRecord.mockResolvedValue({
+      tournamentRecord: buildRecord({ providerId: BOBOCA, endDate: '2999-01-01' }),
+    });
+    const result: any = await service.removeTournamentRecords({ tournamentId: TID }, { userId: 'clubx' }, undefined, adminAt(BOBOCA));
+    expect(result.errorCode).toBe('ERR_TOURNAMENT_NOT_ENDED');
+    expect(tournamentStorage.archiveTournamentRecord).not.toHaveBeenCalled();
+    expect(tournamentStorage.removeTournamentRecords).not.toHaveBeenCalled();
+  });
+
+  it('allows deleting a mock tournament regardless of end date', async () => {
+    tournamentStorage.findTournamentRecord.mockResolvedValue({
+      tournamentRecord: buildRecord({ providerId: BOBOCA, endDate: '2999-01-01', isMock: true }),
+    });
+    const result: any = await service.removeTournamentRecords({ tournamentId: TID }, { userId: 'clubx' }, undefined, adminAt(BOBOCA));
+    expect(result.removed).toBe(1);
+  });
+
+  it('removes the calendar entry from the tournament’s OWN provider, leaving siblings', async () => {
+    tournamentStorage.findTournamentRecord.mockResolvedValue({ tournamentRecord: buildRecord({ providerId: BOBOCA }) });
+    calendarStorage.getCalendar.mockResolvedValue({
+      provider: { organisationAbbreviation: 'BOBOCA' },
+      tournaments: [{ tournamentId: TID }, { tournamentId: 'other' }],
+    });
+    await service.removeTournamentRecords({ tournamentId: TID }, { userId: 'clubx' }, undefined, adminAt(BOBOCA));
+    expect(providerStorage.getProvider).toHaveBeenCalledWith(BOBOCA);
+    expect(calendarStorage.setCalendar).toHaveBeenCalledWith(
+      'BOBOCA',
+      expect.objectContaining({ tournaments: [{ tournamentId: 'other' }] }),
+    );
+  });
+});
+
+describe('TournamentStorageService — detach-on-move (save side-effect)', () => {
+  let service: TournamentStorageService;
+  let tournamentStorage: any;
+  let providerStorage: any;
+  let calendarStorage: any;
+
+  beforeEach(() => {
+    tournamentStorage = { saveTournamentRecord: jest.fn().mockResolvedValue({ success: true }) };
+    providerStorage = { getProvider: jest.fn().mockResolvedValue({ organisationAbbreviation: 'BOBOCA' }) };
+    calendarStorage = {
+      getCalendar: jest.fn().mockResolvedValue({ provider: { organisationAbbreviation: 'BOBOCA' }, tournaments: [] }),
+      setCalendar: jest.fn().mockResolvedValue({ success: true }),
+      listCalendars: jest.fn().mockResolvedValue([]),
+    };
+    service = new TournamentStorageService(tournamentStorage, providerStorage, calendarStorage);
+  });
+
+  it('detaches the tournament from another provider’s calendar when first added to its new provider', async () => {
+    calendarStorage.listCalendars.mockResolvedValue([
+      { key: 'ION', value: { provider: { organisationAbbreviation: 'ION' }, tournaments: [{ tournamentId: TID }, { tournamentId: 'keep' }] } },
+      { key: 'BOBOCA', value: { provider: { organisationAbbreviation: 'BOBOCA' }, tournaments: [] } },
+    ]);
+    await service.saveTournamentRecord({ tournamentRecord: buildRecord({ providerId: BOBOCA }) });
+    expect(calendarStorage.setCalendar).toHaveBeenCalledWith(
+      'ION',
+      expect.objectContaining({ tournaments: [{ tournamentId: 'keep' }] }),
+    );
+  });
+
+  it('does NOT scan other calendars on a normal update (tournament already listed in its provider)', async () => {
+    calendarStorage.getCalendar.mockResolvedValue({
+      provider: { organisationAbbreviation: 'BOBOCA' },
+      tournaments: [{ tournamentId: TID, tournament: {} }],
+    });
+    await service.saveTournamentRecord({ tournamentRecord: buildRecord({ providerId: BOBOCA }) });
+    expect(calendarStorage.listCalendars).not.toHaveBeenCalled();
+  });
+});
+
+describe('canDeleteTournament — provider-scoped, flag-independent', () => {
+  const rec = (providerId: string, createdBy?: string) => ({
+    tournamentId: TID,
+    parentOrganisation: { organisationId: providerId },
+    extensions: createdBy ? [{ name: 'createdByUserId', value: createdBy }] : [],
+  });
+
+  it('denies when there is no userContext', () => expect(canDeleteTournament(rec(BOBOCA), undefined)).toBe(false));
+  it('allows SUPER_ADMIN anywhere', () => expect(canDeleteTournament(rec(BOBOCA), ctx({ isSuperAdmin: true }))).toBe(true));
+  it('allows a provisioner-owner of the provider', () =>
+    expect(canDeleteTournament(rec(BOBOCA), ctx({ provisionerProviderIds: [BOBOCA] }))).toBe(true));
+  it('allows PROVIDER_ADMIN at the provider', () =>
+    expect(canDeleteTournament(rec(BOBOCA), ctx({ providerRoles: { [BOBOCA]: PROVIDER_ADMIN } }))).toBe(true));
+  it('denies PROVIDER_ADMIN at a DIFFERENT provider', () =>
+    expect(canDeleteTournament(rec(BOBOCA), ctx({ providerRoles: { [ION]: PROVIDER_ADMIN } }))).toBe(false));
+  it('allows a DIRECTOR who created the tournament', () =>
+    expect(canDeleteTournament(rec(BOBOCA, 'u-1'), ctx({ providerRoles: { [BOBOCA]: DIRECTOR } }))).toBe(true));
+  it('denies a DIRECTOR who did not create it', () =>
+    expect(canDeleteTournament(rec(BOBOCA, 'someone-else'), ctx({ providerRoles: { [BOBOCA]: DIRECTOR } }))).toBe(false));
+  it('denies when the tournament has no owning provider', () =>
+    expect(canDeleteTournament({ tournamentId: TID, parentOrganisation: {} }, ctx())).toBe(false));
+});

--- a/src/storage/tournament-storage.service.ts
+++ b/src/storage/tournament-storage.service.ts
@@ -3,9 +3,8 @@ import { Inject, Injectable } from '@nestjs/common';
 import { TOURNAMENT_STORAGE, type ITournamentStorage } from './interfaces/tournament-storage.interface';
 import { PROVIDER_STORAGE, type IProviderStorage } from './interfaces/provider-storage.interface';
 import { CALENDAR_STORAGE, type ICalendarStorage } from './interfaces/calendar-storage.interface';
-import { CREATED_BY_USER_ID } from 'src/modules/factory/helpers/checkTournamentAccess';
+import { CREATED_BY_USER_ID, canDeleteTournament } from 'src/modules/factory/helpers/checkTournamentAccess';
 import type { UserContext } from 'src/modules/account/auth/decorators/user-context.decorator';
-import { PROVIDER_ADMIN } from 'src/common/constants/roles';
 
 import { getCalendarEntry } from 'src/helpers/getCalendarEntry';
 import { SUCCESS } from 'src/common/constants/app';
@@ -92,73 +91,122 @@ export class TournamentStorageService {
   ) {
     const tournamentIds: string[] =
       params?.tournamentIds ?? ([params?.tournamentId].filter(Boolean) as string[]);
-    const providerId: string | undefined = user?.providerId || params.providerId;
     let removed = 0;
 
     for (const tournamentId of tournamentIds) {
-      // Resolve auth in three layers, cheapest first:
-      // 1. Per-user `permissions` array (legacy granular grant) — or no
-      //    permissions field at all (back-compat for older user records).
-      // 2. SUPER_ADMIN role.
-      // 3. PROVIDER_ADMIN at the tournament's owning provider — provider
-      //    admins logically should be able to delete their own provider's
-      //    tournaments without needing the separate `deleteTournament`
-      //    permission checkbox. Requires loading the tournament record.
-      let hasDeletePermission =
-        !user?.permissions ||
-        user.permissions.includes('deleteTournament') ||
-        user.roles?.includes('superadmin');
-
-      let isCreator = false;
-      let existingRecord: any;
-      if (!hasDeletePermission && user?.userId) {
-        const existing: any = await this.tournamentStorage.findTournamentRecord({ tournamentId });
-        existingRecord = existing?.tournamentRecord;
-        const createdBy = (existingRecord?.extensions ?? []).find((e) => e?.name === 'createdByUserId')?.value;
-        isCreator = !!createdBy && createdBy === user.userId;
-
-        // PROVIDER_ADMIN at the tournament's provider also implies delete.
-        if (!isCreator && userContext) {
-          const tournamentProviderId = existingRecord?.parentOrganisation?.organisationId;
-          if (
-            tournamentProviderId &&
-            userContext.providerRoles?.[tournamentProviderId] === PROVIDER_ADMIN
-          ) {
-            hasDeletePermission = true;
-          }
-        }
-      }
-
-      if (hasDeletePermission || isCreator) {
-        // Record the deletion in the audit trail BEFORE removing the record.
-        // Fail-soft: audit errors don't block the deletion.
-        if (auditService?.recordDeletion) {
-          try {
-            if (!existingRecord) {
-              const existing: any = await this.tournamentStorage.findTournamentRecord({ tournamentId });
-              existingRecord = existing?.tournamentRecord;
-            }
-            await auditService.recordDeletion({
-              tournamentId,
-              tournamentName: existingRecord?.tournamentName,
-              providerId: existingRecord?.parentOrganisation?.organisationId ?? providerId,
-              userId: user?.userId,
-              userEmail: user?.email,
-            });
-          } catch {
-            // Audit failure is non-blocking
-          }
-        }
-
-        await this.tournamentStorage.removeTournamentRecords({ tournamentIds: [tournamentId] });
-        if (providerId) {
-          await this.removeFromCalendar({ providerId, tournamentId });
-          removed += 1;
-        }
-      }
+      const result = await this.deleteSingleTournament({ tournamentId, user, userContext, auditService });
+      if (result.error) return { ...result, removed };
+      if (result.removed) removed += 1;
     }
 
     return { ...SUCCESS, removed };
+  }
+
+  /**
+   * Delete one tournament with all safety gates, in order:
+   *   1. Provider-scoped authorization (canDeleteTournament — always enforced).
+   *   2. End-date guard: a non-mock tournament may only be deleted once its
+   *      endDate is in the past (move the end date back to delete an active one).
+   *   3. Archive the full record (HARD prerequisite — abort the delete if it fails).
+   *   4. Audit (fail-soft).
+   *   5. Remove the row, then detach from its OWN provider's calendar.
+   */
+  private async deleteSingleTournament({
+    tournamentId,
+    user,
+    userContext,
+    auditService,
+  }: {
+    tournamentId: string;
+    user?: any;
+    userContext?: UserContext;
+    auditService?: any;
+  }): Promise<{ removed?: boolean; error?: string; errorCode?: string }> {
+    const existing: any = await this.tournamentStorage.findTournamentRecord({ tournamentId });
+    const existingRecord = existing?.tournamentRecord;
+    if (!existingRecord) return { removed: false }; // Nothing to delete.
+
+    if (!this.isDeleteAuthorized(existingRecord, user, userContext)) {
+      return { error: 'Not authorized to delete this tournament', errorCode: 'ERR_DELETE_FORBIDDEN' };
+    }
+
+    const guard = this.checkDeletableByEndDate(existingRecord);
+    if (guard.error) return guard;
+
+    // Archive BEFORE deleting — a failed archive must abort the delete so the
+    // record is always recoverable.
+    const archiveResult: any = await this.tournamentStorage.archiveTournamentRecord({
+      tournamentRecord: existingRecord,
+      deletedByUserId: user?.userId,
+      deletedByEmail: user?.email,
+    });
+    if (archiveResult?.error) {
+      return { error: 'Could not archive tournament; deletion aborted', errorCode: 'ERR_ARCHIVE_FAILED' };
+    }
+
+    await this.recordDeletionSafely({ auditService, tournamentId, existingRecord, user });
+
+    await this.tournamentStorage.removeTournamentRecords({ tournamentIds: [tournamentId] });
+
+    // Detach from the tournament's OWN provider's calendar (not the actor's).
+    const tournamentProviderId = existingRecord?.parentOrganisation?.organisationId;
+    if (tournamentProviderId) {
+      await this.removeFromCalendar({ providerId: tournamentProviderId, tournamentId });
+    }
+
+    return { removed: true };
+  }
+
+  /**
+   * Provider-scoped delete authorization. A global `deleteTournament` permission
+   * is a capability, NOT a cross-tenant scope grant — scope is decided by
+   * canDeleteTournament against the tournament's own provider. Legacy SUPER_ADMIN
+   * via `user.roles` is honored when no userContext is present (fail closed otherwise).
+   */
+  private isDeleteAuthorized(tournamentRecord: any, user: any, userContext?: UserContext): boolean {
+    if (userContext) return canDeleteTournament(tournamentRecord, userContext);
+    return !!user?.roles?.includes('superadmin');
+  }
+
+  /**
+   * Non-mock tournaments may only be deleted once their endDate is in the past.
+   * Mock tournaments (isMock) are exempt. To delete an in-progress tournament,
+   * a director first moves its endDate to a past date.
+   */
+  private checkDeletableByEndDate(tournamentRecord: any): { error?: string; errorCode?: string } {
+    if (tournamentRecord?.isMock === true) return {};
+    const endDate: string | undefined = tournamentRecord?.endDate;
+    const today = new Date().toISOString().slice(0, 10);
+    if (endDate && endDate < today) return {};
+    return {
+      error: 'Cannot delete a tournament before its end date. Set the end date to a past date first, then delete.',
+      errorCode: 'ERR_TOURNAMENT_NOT_ENDED',
+    };
+  }
+
+  private async recordDeletionSafely({
+    auditService,
+    tournamentId,
+    existingRecord,
+    user,
+  }: {
+    auditService?: any;
+    tournamentId: string;
+    existingRecord: any;
+    user?: any;
+  }): Promise<void> {
+    if (!auditService?.recordDeletion) return;
+    try {
+      await auditService.recordDeletion({
+        tournamentId,
+        tournamentName: existingRecord?.tournamentName,
+        providerId: existingRecord?.parentOrganisation?.organisationId,
+        userId: user?.userId,
+        userEmail: user?.email,
+      });
+    } catch {
+      // Audit failure is non-blocking.
+    }
   }
 
   // --- Calendar side-effect helpers ---
@@ -168,27 +216,47 @@ export class TournamentStorageService {
     if (providerResult.error) return providerResult;
 
     const { provider, tournaments } = providerResult;
-    let updatedEntries = tournaments;
     const calendarEntry = getCalendarEntry({ tournamentRecord });
+    if (!calendarEntry) return this.updateCalendar({ provider, tournaments });
 
-    if (calendarEntry) {
-      let modified = false;
-      const modifiedTournaments = tournaments.map((entry) => {
-        if (entry.tournamentId === calendarEntry.tournamentId) {
-          modified = true;
-          return calendarEntry;
-        }
-        return entry;
+    const exists = tournaments.some((entry) => entry.tournamentId === calendarEntry.tournamentId);
+    const updatedEntries = exists
+      ? tournaments.map((entry) => (entry.tournamentId === calendarEntry.tournamentId ? calendarEntry : entry))
+      : [...tournaments, calendarEntry];
+
+    // First time this tournament appears in THIS provider's calendar (create or
+    // provider move): detach it from any OTHER provider's calendar so a moved
+    // tournament never lingers under its source provider (incident 2026-05-23).
+    if (!exists) {
+      await this.detachFromOtherCalendars({
+        tournamentId: calendarEntry.tournamentId,
+        keepAbbr: provider?.organisationAbbreviation,
       });
-
-      if (modified) {
-        updatedEntries = modifiedTournaments;
-      } else {
-        updatedEntries.push(calendarEntry);
-      }
     }
 
     return this.updateCalendar({ provider, tournaments: updatedEntries });
+  }
+
+  /**
+   * Remove a tournament from every provider calendar except `keepAbbr`, enforcing
+   * the invariant that a tournament lives in exactly one provider's calendar —
+   * its current parentOrganisation provider.
+   */
+  private async detachFromOtherCalendars({
+    tournamentId,
+    keepAbbr,
+  }: {
+    tournamentId: string;
+    keepAbbr?: string;
+  }): Promise<void> {
+    const calendars = await this.calendarStorage.listCalendars();
+    for (const { key, value } of calendars) {
+      if (key === keepAbbr) continue;
+      const entries: any[] = value?.tournaments ?? [];
+      if (!entries.some((entry) => entry.tournamentId === tournamentId)) continue;
+      const filtered = entries.filter((entry) => entry.tournamentId !== tournamentId);
+      await this.calendarStorage.setCalendar(key, { provider: value.provider, tournaments: filtered });
+    }
   }
 
   async removeFromCalendar({ providerId, tournamentId }: { providerId: string; tournamentId: string }) {


### PR DESCRIPTION
## Why

On 2026-05-23 an ION-only provider admin hard-deleted a live BOBOCA tournament (created under ION, then moved to BOBOCA). It was recoverable only because the TD had it open in-browser. Root cause: delete authorization keyed off a **global** `deleteTournament` permission (a capability, not a provider scope), a hard delete with no server-side copy, and a provider move that left the tournament still associated with its source provider's calendar.

## What

All changes funnel through the single facade chokepoint (`tournament-storage.service.ts` `removeTournamentRecords`), used by both the socket `executionQueue` and REST `/factory/remove` delete paths:

1. **Provider-scoped delete authz** — new `canDeleteTournament` (flag-independent): allow only SUPER_ADMIN, a provisioner-owner of the provider, PROVIDER_ADMIN at the tournament's *own* provider, or the creator/assignee. A global `deleteTournament` permission no longer widens scope across tenants.
2. **End-date guard** — non-`isMock` tournaments are deletable only once `endDate` is in the past (move the end date back to delete an in-progress one).
3. **Archive-before-delete** — new `deleted_tournaments` table (migration `030`); the archive write is a hard prerequisite that aborts the delete on failure.
4. **Calendar detach-on-move** — calendar removal keys off the tournament's own provider, and on create/move the tournament is detached from any other provider's calendar.

## Tests

18 new unit tests (`tournament-storage.service.spec.ts`); `check-types`, `lint`, and `build` clean; existing storage/audit/factory unit suites pass. (`factory.e2e`/`audit.e2e` only fail to *load* locally due to a concurrent `courthive-ingest` rebuild — unrelated to this surface; CI builds fresh.)

## Notes

- Carries one unrelated rider commit `e690cd4` `fix(auth): align SSO session lifetime with direct login`, added at maintainer direction.
- Migration `030` runs on the next server deploy (batched separately).
