### PR TITLE
feat(auth): provisioner-managed providers + scope /admin to real admins

### DIFF
--- a/admin-client/src/constants/tmxConstants.ts
+++ b/admin-client/src/constants/tmxConstants.ts
@@ -16,6 +16,12 @@ export const TMX_DRAWER = 'tmxDrawer';
 export const SUPER_ADMIN = 'superadmin';
 export const ADMIN = 'admin';
 export const PROVISIONER = 'provisioner';
+// Provider-scoped role (from user_providers.provider_role, in the JWT's
+// providerAssociations). Distinct from the deprecated global `admin` role.
+export const PROVIDER_ADMIN = 'PROVIDER_ADMIN';
+
+// Routes
+export const NO_ACCESS_ROUTE = 'no-access';
 
 // System page tabs
 export const SYSTEM = 'system';

--- a/admin-client/src/i18n/locales/en.json
+++ b/admin-client/src/i18n/locales/en.json
@@ -1620,6 +1620,12 @@
     "cannotDeleteParticipant": "Participant is assigned to a draw and cannot be deleted"
   },
 
+  "noAccess": {
+    "title": "No admin access",
+    "message": "Your account doesn't have access to the admin console. If you manage a tournament, use the TMX app instead. Contact your provider administrator if you believe this is an error.",
+    "logOut": "Log out"
+  },
+
   "loginMenu": {
     "authorization": "Authorization",
     "register": "Register",

--- a/admin-client/src/pages/noAccess/renderNoAccess.ts
+++ b/admin-client/src/pages/noAccess/renderNoAccess.ts
@@ -1,0 +1,40 @@
+/**
+ * Shown when a logged-in user has no admin-console access (e.g. a DIRECTOR-only
+ * account). Replaces the old behavior of silently redirecting every non-super /
+ * non-provisioner user into `/admin`.
+ */
+import { removeAllChildNodes } from 'services/dom/transformers';
+import { showTMXadmin } from 'services/transitions/screenSlaver';
+import { logOut } from 'services/authentication/loginState';
+import { TMX_ADMIN } from 'constants/tmxConstants';
+import { t } from 'i18n';
+
+export function renderNoAccess(): void {
+  showTMXadmin();
+
+  const container = document.getElementById(TMX_ADMIN);
+  if (!container) return;
+  removeAllChildNodes(container);
+
+  const wrap = document.createElement('div');
+  wrap.style.cssText =
+    'display:flex; flex-direction:column; align-items:center; justify-content:center; gap:1rem; padding:3rem 1rem; text-align:center;';
+
+  const title = document.createElement('h2');
+  title.textContent = t('noAccess.title');
+  title.style.cssText = 'margin:0;';
+
+  const message = document.createElement('p');
+  message.textContent = t('noAccess.message');
+  message.style.cssText = 'max-width:32rem; color:var(--chc-text-secondary, var(--tmx-text-secondary, #666));';
+
+  const logoutBtn = document.createElement('button');
+  logoutBtn.type = 'button';
+  logoutBtn.textContent = t('noAccess.logOut');
+  logoutBtn.style.cssText =
+    'cursor:pointer; padding:0.5rem 1.25rem; border-radius:4px; border:1px solid var(--chc-border, #ccc); background:transparent;';
+  logoutBtn.addEventListener('click', () => logOut());
+
+  wrap.append(title, message, logoutBtn);
+  container.appendChild(wrap);
+}

--- a/admin-client/src/router/router.ts
+++ b/admin-client/src/router/router.ts
@@ -6,7 +6,9 @@ import { renderContactEmailBanner } from 'components/banners/contactEmailBanner'
 import { renderResetPassword } from 'pages/resetPassword/renderResetPassword';
 import { renderVerifyEmail } from 'pages/verifyEmail/renderVerifyEmail';
 import { renderSystemPage } from 'pages/system/renderSystemPage';
+import { renderNoAccess } from 'pages/noAccess/renderNoAccess';
 import { renderAdminPage } from 'pages/admin/renderAdminPage';
+import { canAccessAdmin } from 'services/authentication/adminAccess';
 import { renderSyncPage } from 'pages/sync/renderSyncPage';
 import { renderTemplatesPage } from 'pages/templates/renderTemplatesPage';
 import { renderPoliciesPage } from 'pages/policies/renderPoliciesPage';
@@ -15,7 +17,7 @@ import { updateNavVisibility } from 'services/navigation/navVisibility';
 import { context } from 'services/context';
 import Navigo from 'navigo';
 
-import { SUPER_ADMIN, PROVISIONER, SYSTEM, PROVISIONER_ROUTE, SANCTIONING, SYNC, TEMPLATES, POLICIES, VERIFY_EMAIL, RESET_PASSWORD } from 'constants/tmxConstants';
+import { SUPER_ADMIN, PROVISIONER, SYSTEM, PROVISIONER_ROUTE, SANCTIONING, SYNC, TEMPLATES, POLICIES, VERIFY_EMAIL, RESET_PASSWORD, NO_ACCESS_ROUTE } from 'constants/tmxConstants';
 
 export function routeAdmin(): void {
   const router = new Navigo('/', { hash: true });
@@ -64,7 +66,18 @@ export function routeAdmin(): void {
   });
 
   router.on('/admin', () => {
+    const state = getLoginState();
+    if (!canAccessAdmin(state)) {
+      router.navigate(`/${NO_ACCESS_ROUTE}`);
+      return;
+    }
     renderAdminPage();
+  });
+
+  // Logged-in users with no admin-console access land here instead of being
+  // silently dropped into /admin.
+  router.on(`/${NO_ACCESS_ROUTE}`, () => {
+    renderNoAccess();
   });
 
   // Provisioner workspace (PROVISIONER role + super-admin oversight)
@@ -146,8 +159,10 @@ export function routeAdmin(): void {
       router.navigate(`/${SYSTEM}`);
     } else if (state?.roles?.includes(PROVISIONER)) {
       router.navigate(`/${PROVISIONER_ROUTE}`);
-    } else {
+    } else if (canAccessAdmin(state)) {
       router.navigate('/admin');
+    } else {
+      router.navigate(`/${NO_ACCESS_ROUTE}`);
     }
   });
 

--- a/admin-client/src/services/authentication/adminAccess.test.ts
+++ b/admin-client/src/services/authentication/adminAccess.test.ts
@@ -1,0 +1,49 @@
+import { describe, expect, it } from 'vitest';
+import { canAccessAdmin } from './adminAccess';
+
+import type { LoginState } from 'types/tmx';
+
+const base = (overrides: Partial<LoginState> = {}): LoginState =>
+  ({ email: 'u@x.com', roles: [], permissions: [], services: [], exp: 0, ...overrides }) as LoginState;
+
+describe('canAccessAdmin', () => {
+  it('denies when no state', () => {
+    expect(canAccessAdmin(undefined)).toBe(false);
+  });
+
+  it('denies a logged-in user with no admin role and no PROVIDER_ADMIN association', () => {
+    expect(canAccessAdmin(base({ roles: ['client', 'score'] }))).toBe(false);
+  });
+
+  it('denies a DIRECTOR-only account', () => {
+    const state = base({
+      roles: ['client'],
+      providerAssociations: [
+        { providerId: 'p1', providerRole: 'DIRECTOR', organisationName: 'P1', organisationAbbreviation: 'P1' },
+      ],
+    });
+    expect(canAccessAdmin(state)).toBe(false);
+  });
+
+  it('grants super-admin', () => {
+    expect(canAccessAdmin(base({ roles: ['superadmin'] }))).toBe(true);
+  });
+
+  it('grants provisioner', () => {
+    expect(canAccessAdmin(base({ roles: ['provisioner'] }))).toBe(true);
+  });
+
+  it('grants the deprecated global admin role (until retired)', () => {
+    expect(canAccessAdmin(base({ roles: ['client', 'admin'] }))).toBe(true);
+  });
+
+  it('grants a PROVIDER_ADMIN association without any global admin role', () => {
+    const state = base({
+      roles: ['client'],
+      providerAssociations: [
+        { providerId: 'p1', providerRole: 'PROVIDER_ADMIN', organisationName: 'P1', organisationAbbreviation: 'P1' },
+      ],
+    });
+    expect(canAccessAdmin(state)).toBe(true);
+  });
+});

--- a/admin-client/src/services/authentication/adminAccess.ts
+++ b/admin-client/src/services/authentication/adminAccess.ts
@@ -1,0 +1,21 @@
+/**
+ * Whether a login state may use the admin console (`/admin`).
+ *
+ * "Real admins" only: super-admin, provisioner, a provider admin (PROVIDER_ADMIN
+ * at any associated provider), or the deprecated global `admin` role (honored
+ * until retired). Plain end-users (e.g. a DIRECTOR-only account) get the
+ * no-access state instead of being silently dropped into the admin app.
+ *
+ * Takes the state as an argument (rather than calling getLoginState) so this
+ * stays free of an import cycle with loginState.
+ */
+import { SUPER_ADMIN, PROVISIONER, ADMIN, PROVIDER_ADMIN } from 'constants/tmxConstants';
+
+import type { LoginState } from 'types/tmx';
+
+export function canAccessAdmin(state?: LoginState): boolean {
+  if (!state) return false;
+  const roles = state.roles ?? [];
+  if (roles.includes(SUPER_ADMIN) || roles.includes(PROVISIONER) || roles.includes(ADMIN)) return true;
+  return (state.providerAssociations ?? []).some((assoc) => assoc.providerRole === PROVIDER_ADMIN);
+}

--- a/admin-client/src/services/authentication/loginState.ts
+++ b/admin-client/src/services/authentication/loginState.ts
@@ -1,10 +1,11 @@
 import { getToken, setToken, removeToken } from './tokenManagement';
+import { canAccessAdmin } from './adminAccess';
 import { validateToken } from './validateToken';
 import { tmxToast } from 'services/notifications/tmxToast';
 import { context } from 'services/context';
 import { t } from 'i18n';
 
-import { SUPER_ADMIN, ADMIN, PROVISIONER } from 'constants/tmxConstants';
+import { SUPER_ADMIN, ADMIN, PROVISIONER, NO_ACCESS_ROUTE } from 'constants/tmxConstants';
 import type { LoginState } from 'types/tmx';
 
 export function styleLogin(state?: LoginState): void {
@@ -48,8 +49,10 @@ export function logIn({ data, callback }: { data: { token: string }; callback?: 
         context.router?.navigate('/system');
       } else if (state.roles?.includes(PROVISIONER)) {
         context.router?.navigate('/provisioner');
-      } else {
+      } else if (canAccessAdmin(state)) {
         context.router?.navigate('/admin');
+      } else {
+        context.router?.navigate(`/${NO_ACCESS_ROUTE}`);
       }
     }
   }

--- a/admin-client/src/types/tmx.ts
+++ b/admin-client/src/types/tmx.ts
@@ -20,6 +20,17 @@ export interface LoginState {
   provider?: ProviderValue;
   providerId?: string;
   providerIds?: string[];
+  /**
+   * Multi-provider associations from `user_providers` (present in the JWT).
+   * Used to grant admin-console access to provider admins without relying on
+   * the deprecated global `admin` role.
+   */
+  providerAssociations?: Array<{
+    providerId: string;
+    providerRole: string;
+    organisationName: string;
+    organisationAbbreviation: string;
+  }>;
   /** Verified contact email (B2). Distinct from `email` (login id). */
   contactEmail?: string | null;
   /** ISO timestamp when contactEmail was verified; null until the user clicks the link. */

--- a/src/modules/account/auth/auth.service.ts
+++ b/src/modules/account/auth/auth.service.ts
@@ -180,13 +180,19 @@ export class AuthService {
 
     // Phase 2A: PROVISIONER-role users carry their provisioner associations
     // in the JWT so the provisioner middleware can resolve them on every
-    // request without a DB lookup.
+    // request without a DB lookup. We also embed the managed providers (with
+    // name/abbreviation) so TMX can offer them in the provider switcher and
+    // grant provider-admin UI when one is active — server authz already
+    // honors provisionerProviderIds (see checkTournamentAccess / checkProvider).
     if (user.userId && user.roles?.includes(PROVISIONER_ROLE)) {
       try {
-        userDetails.provisionerIds = await this.userProvisionerStorage.findProvisionerIdsByUser(user.userId);
+        const provisionerIds = await this.userProvisionerStorage.findProvisionerIdsByUser(user.userId);
+        userDetails.provisionerIds = provisionerIds;
+        userDetails.provisionerProviders = await this.loadProvisionerProviders(provisionerIds);
       } catch (err) {
-        Logger.warn(`Failed to load provisionerIds for ${email}: ${(err as Error).message}`);
+        Logger.warn(`Failed to load provisioner context for ${email}: ${(err as Error).message}`);
         userDetails.provisionerIds = [];
+        userDetails.provisionerProviders = [];
       }
     }
 
@@ -222,6 +228,35 @@ export class AuthService {
     const payload = userDetails;
     const token = await this.jwtService.signAsync(payload, { expiresIn: '1d' });
     return { token };
+  }
+
+  /**
+   * Resolve the distinct set of providers a user's provisioners manage, each
+   * enriched with organisation name/abbreviation for the TMX provider switcher.
+   * Deduped across multiple provisioner associations.
+   */
+  private async loadProvisionerProviders(
+    provisionerIds: string[],
+  ): Promise<Array<{ providerId: string; organisationName: string; organisationAbbreviation: string }>> {
+    const byProviderId = new Map<
+      string,
+      { providerId: string; organisationName: string; organisationAbbreviation: string }
+    >();
+    for (const provisionerId of provisionerIds) {
+      const rows = await this.provisionerProviderStorage.findByProvisioner(provisionerId);
+      for (const row of rows) {
+        if (byProviderId.has(row.providerId)) continue;
+        const provider = await this.providerStorage.getProvider(row.providerId);
+        if (provider) {
+          byProviderId.set(row.providerId, {
+            providerId: row.providerId,
+            organisationName: provider.organisationName,
+            organisationAbbreviation: provider.organisationAbbreviation,
+          });
+        }
+      }
+    }
+    return Array.from(byProviderId.values());
   }
 
   /**

--- a/src/scripts/data-fixes/2026-05-24-retire-legacy-admin-role.sql
+++ b/src/scripts/data-fixes/2026-05-24-retire-legacy-admin-role.sql
@@ -1,0 +1,88 @@
+-- 2026-05-24-retire-legacy-admin-role.sql
+--
+-- Retires the deprecated global `admin` role from users.roles. Root cause of
+-- the "clubx@ionsport.com routed to /admin" report: the global `admin` role
+-- (which 34 of 43 accounts carry as legacy cruft) is what surfaced admin UI in
+-- TMX and made the account admin-routable, independent of the modern
+-- provider-scoped role model (user_providers.provider_role). The correct admin
+-- signal is PROVIDER_ADMIN at a provider (via user_providers) or a
+-- provisioner-managed provider — neither of which needs the global role.
+--
+-- Also repoints clubx@ionsport.com's stale legacy home + last-selected provider
+-- from ION (9fd68963…, a provider the account is NOT associated with) to BOBOCA
+-- (24bf9f25…, where it is PROVIDER_ADMIN). jason1@clubx.com stays a BOBOCA
+-- DIRECTOR — only its global `admin` role is stripped (by statement 1).
+--
+-- !!! ORDERING CONSTRAINT !!!
+-- Deploy the provider-scoped admin gate FIRST (TMX `isActiveProviderAdmin` +
+-- admin-client `canAccessAdmin`, branch fix/provisioner-admin-routing). Until
+-- that ships, TMX grants admin UI ONLY via the global `admin` role, so running
+-- this beforehand would strip every PROVIDER_ADMIN's admin UI. Server authz is
+-- unaffected (it resolves provider roles from user_providers, not the JWT role).
+--
+-- Scope note: this does NOT drop users.provider_id or remove the back-compat
+-- shim in buildUserContext (that is TASKS.md "Phase 5 — Retire users.provider_id").
+-- After this runs the shim is simply a no-op for these accounts.
+--
+-- Idempotent and transaction-wrapped. Safe to re-run.
+--
+-- Usage on courthive-mentat (writes against the nest prod DB):
+--
+--   PGPASSWORD=courthive_dev psql -h 10.128.0.4 -U tennis_aip -d courthive \
+--     -f src/scripts/data-fixes/2026-05-24-retire-legacy-admin-role.sql
+
+\set ON_ERROR_STOP on
+BEGIN;
+
+-- ============================================================================
+-- 0) Before-state report
+-- ============================================================================
+\echo '--- accounts carrying the legacy global admin role (before) ---'
+SELECT count(*) AS legacy_admin_users FROM users WHERE roles @> '["admin"]'::jsonb;
+
+\echo '--- clubX / jason1 (before) ---'
+SELECT email, roles, provider_id, last_selected_provider_id
+FROM users
+WHERE email IN ('clubx@ionsport.com', 'jason1@clubx.com')
+ORDER BY email;
+
+-- ============================================================================
+-- 1) Strip the legacy global "admin" element from users.roles everywhere.
+--    Rebuilds the jsonb array preserving the original order of the survivors.
+--    Idempotent: after this no row matches the WHERE, so a re-run is a no-op.
+-- ============================================================================
+UPDATE users
+SET roles = (
+  SELECT COALESCE(jsonb_agg(elem ORDER BY ord), '[]'::jsonb)
+  FROM jsonb_array_elements(roles) WITH ORDINALITY AS arr(elem, ord)
+  WHERE elem <> '"admin"'::jsonb
+)
+WHERE roles @> '["admin"]'::jsonb;
+
+-- ============================================================================
+-- 2) Repoint clubx@ionsport.com's stale ION pointers to BOBOCA (its only
+--    user_providers association, role PROVIDER_ADMIN). Guarded so a re-run is
+--    a no-op.
+-- ============================================================================
+UPDATE users
+SET provider_id = '24bf9f25-96ca-401e-9660-f5571ebc50ba',
+    last_selected_provider_id = '24bf9f25-96ca-401e-9660-f5571ebc50ba'
+WHERE email = 'clubx@ionsport.com'
+  AND (
+    provider_id IS DISTINCT FROM '24bf9f25-96ca-401e-9660-f5571ebc50ba'
+    OR last_selected_provider_id IS DISTINCT FROM '24bf9f25-96ca-401e-9660-f5571ebc50ba'
+  );
+
+-- ============================================================================
+-- 3) After-state report
+-- ============================================================================
+\echo '--- accounts carrying the legacy global admin role (after; expect 0) ---'
+SELECT count(*) AS legacy_admin_users FROM users WHERE roles @> '["admin"]'::jsonb;
+
+\echo '--- clubX / jason1 (after) ---'
+SELECT email, roles, provider_id, last_selected_provider_id
+FROM users
+WHERE email IN ('clubx@ionsport.com', 'jason1@clubx.com')
+ORDER BY email;
+
+COMMIT;


### PR DESCRIPTION
## Why
clubx@ionsport.com (BOBOCA PROVIDER_ADMIN) was routed into the `/admin` admin-client they "didn't know existed". Root cause: the deprecated global `admin` role (carried by **34 of 43 accounts** system-wide) + the admin-client's blanket `else → /admin` redirect that dropped **every** logged-in non-super/non-provisioner user into the admin panel. Separately, provisioners weren't offered their managed providers in TMX.

## What
**Server (`auth.service.ts`)**
- `signIn` embeds `provisionerProviders` (managed providers with name/abbr) in the login JWT via a new `loadProvisionerProviders` helper, so TMX can offer them in the provider switcher and grant provider-admin UI. Authz already honored `provisionerProviderIds` (`checkTournamentAccess` / `checkProvider`).

**admin-client**
- `canAccessAdmin()` helper + new `/no-access` route & `renderNoAccess` view.
- Router `/` and `/admin` (and `logIn`) route **only real admins** (super-admin / provisioner / `PROVIDER_ADMIN` / legacy `admin`) to `/admin`; everyone else gets the no-access state instead of being silently dumped in.

**Data-fix — NOT run** (`src/scripts/data-fixes/2026-05-24-retire-legacy-admin-role.sql`)
- Strips the legacy global `admin` role from all 34 accounts; repoints clubX's stale ION `provider_id`/`last_selected_provider_id` → BOBOCA. Idempotent, transaction-wrapped, before/after reports.

## Tests
New `adminAccess.test.ts` (7 cases). admin-client **60 pass**; server account/auth jest **132 pass**; check-types, lint, build green across server + admin-client.

## ⚠️ Deploy ordering
Companion client PR: **TMX #1074**. **Deploy the gate (this PR + TMX #1074) before** running the role-retirement data-fix — otherwise stripping the global `admin` role removes every PROVIDER_ADMIN's TMX admin UI. Server authz is unaffected.

Scope note: does **not** drop `users.provider_id` or remove the `buildUserContext` back-compat shim (that is the separate "Phase 5 — Retire users.provider_id" workstream). After the data-fix the shim is simply a no-op for these accounts.