### PR TITLE
test(setup): fail fast when the courthive-ingest build is stale

### DIFF
--- a/src/tests/config/setup.ts
+++ b/src/tests/config/setup.ts
@@ -1,1 +1,24 @@
-module.exports = function setup() {};
+// Jest globalSetup — runs once before the whole suite.
+//
+// Preflight: `courthive-ingest` is a `link:../courthive-ingest` dependency that
+// the server consumes from its `build/` output (build/index.js). During a
+// concurrent local rebuild that output can be momentarily inconsistent — e.g.
+// index.js emitted but build/core/* not yet — which otherwise surfaces as a
+// cryptic per-suite "Cannot find module './core/AdapterRegistry'" load failure.
+// Fail fast here with an actionable message instead. CI builds courthive-ingest
+// before the server, so this only trips during concurrent local dev builds.
+module.exports = async function setup() {
+  try {
+    await import('courthive-ingest');
+  } catch (err: any) {
+    if (err?.code === 'MODULE_NOT_FOUND' || err?.code === 'ERR_MODULE_NOT_FOUND') {
+      throw new Error(
+        `[test setup] Could not load the 'courthive-ingest' build (${err.message}).\n` +
+          `It is a link:../courthive-ingest dependency served from its build/ output, ` +
+          `which is stale or mid-rebuild.\n` +
+          `Rebuild it, then re-run:  (cd ../courthive-ingest && pnpm build)`,
+      );
+    }
+    throw err;
+  }
+};


### PR DESCRIPTION
Adds a jest globalSetup preflight that loads the link:../courthive-ingest dependency once and, on MODULE_NOT_FOUND, throws an actionable 'rebuild courthive-ingest' message instead of a cryptic per-suite `Cannot find module './core/AdapterRegistry'` failure (seen this session when a concurrent session was mid-rebuild of courthive-ingest's build/ output).

Full server suite green with the preflight active: 96 suites / 827 tests. check-types + lint clean.