### PR TITLE
fix(admin-client): keep unauthenticated /admin landing; add e2e role-routing matrix

### DIFF
--- a/admin-client/e2e/helpers/fixtures.ts
+++ b/admin-client/e2e/helpers/fixtures.ts
@@ -1,0 +1,137 @@
+/**
+ * Test-data fixtures for role-routing e2e (journey 06).
+ *
+ * All creation goes through the admin REST API as the bootstrap super-admin
+ * (the same token `signInViaApi` returns). Users are made login-ready by
+ * walking the real first-login flow (admin-create-user forces
+ * mustChangePassword; we clear it via /auth/complete-first-login) so the test
+ * can drive the login modal directly.
+ *
+ * Tests own cleanup: call `removeUser` / `cleanupProvisioner` in afterAll.
+ */
+import type { APIRequestContext } from '@playwright/test';
+import { API_BASE } from './login';
+
+export const E2E_ROLE_PASSWORD = process.env.E2E_ROLE_PASSWORD ?? 'e2e-role-password-do-not-reuse';
+
+const authHeaders = (token: string) => ({ Authorization: `Bearer ${token}` });
+
+export interface CreateUserOpts {
+  email: string;
+  password?: string;
+  roles?: string[];
+  providerId?: string;
+  providerRole?: 'PROVIDER_ADMIN' | 'DIRECTOR';
+}
+
+/** Unique suffix so parallel/repeat runs don't collide on emails or names. */
+export function uniqueSuffix(): string {
+  return `${Date.now()}-${Math.floor(Math.random() * 10000)}`;
+}
+
+/** Idempotently ensure a provider with the given abbreviation exists; returns its id. */
+export async function ensureProvider(
+  request: APIRequestContext,
+  token: string,
+  organisationAbbreviation: string,
+  organisationName: string,
+): Promise<string> {
+  const addRes = await request.post(`${API_BASE}/provider/add`, {
+    headers: authHeaders(token),
+    data: { organisationAbbreviation, organisationName },
+  });
+  const addBody = await addRes.json().catch(() => ({}));
+  if (addBody?.providerId) return addBody.providerId;
+
+  // Abbreviation already taken (or add errored) — look it up by abbreviation.
+  const listRes = await request.post(`${API_BASE}/provider/allproviders`, { headers: authHeaders(token) });
+  const listBody = await listRes.json();
+  const match = (listBody?.providers ?? []).find(
+    (p: any) => p?.value?.organisationAbbreviation === organisationAbbreviation,
+  );
+  const providerId = match?.value?.organisationId;
+  if (!providerId) {
+    throw new Error(`ensureProvider(${organisationAbbreviation}): could not create or find — ${JSON.stringify(addBody)}`);
+  }
+  return providerId;
+}
+
+/** Create a user that can log in immediately (clears the forced first-login change). */
+export async function createLoginableUser(
+  request: APIRequestContext,
+  token: string,
+  opts: CreateUserOpts,
+): Promise<void> {
+  const password = opts.password ?? E2E_ROLE_PASSWORD;
+  const createRes = await request.post(`${API_BASE}/auth/admin-create-user`, {
+    headers: authHeaders(token),
+    data: {
+      email: opts.email,
+      password,
+      roles: opts.roles ?? [],
+      providerId: opts.providerId,
+      providerRole: opts.providerRole,
+    },
+  });
+  if (!createRes.ok()) {
+    throw new Error(`admin-create-user(${opts.email}) failed (${createRes.status()}): ${await createRes.text()}`);
+  }
+
+  // admin-create-user sets mustChangePassword=true. Walk the real first-login
+  // flow to clear it so the user can authenticate directly in the test.
+  const loginRes = await request.post(`${API_BASE}/auth/login`, { data: { email: opts.email, password } });
+  const loginBody = await loginRes.json().catch(() => ({}));
+  if (loginBody?.limitedToken) {
+    const completeRes = await request.post(`${API_BASE}/auth/complete-first-login`, {
+      data: { limitedToken: loginBody.limitedToken, newPassword: password },
+    });
+    if (!completeRes.ok()) {
+      throw new Error(`complete-first-login(${opts.email}) failed (${completeRes.status()}): ${await completeRes.text()}`);
+    }
+  }
+}
+
+/** Remove a user by email (super-admin). Safe to call for cleanup. */
+export async function removeUser(request: APIRequestContext, token: string, email: string): Promise<void> {
+  if (!email) return;
+  await request.post(`${API_BASE}/auth/remove`, { headers: authHeaders(token), data: { email } });
+}
+
+/** Create a provisioner; returns its id. */
+export async function createProvisioner(request: APIRequestContext, token: string, name: string): Promise<string> {
+  const res = await request.post(`${API_BASE}/admin/provisioners`, { headers: authHeaders(token), data: { name } });
+  if (!res.ok()) throw new Error(`create provisioner(${name}) failed (${res.status()}): ${await res.text()}`);
+  const body = await res.json();
+  const id = body?.provisionerId ?? body?.id ?? body?.provisioner?.provisionerId ?? body?.provisioner?.id;
+  if (!id) throw new Error(`create provisioner(${name}): no id in ${JSON.stringify(body)}`);
+  return id;
+}
+
+/** Associate a provider to a provisioner (owner by default). */
+export async function associateProviderToProvisioner(
+  request: APIRequestContext,
+  token: string,
+  provisionerId: string,
+  providerId: string,
+  relationship: 'owner' | 'subsidiary' = 'owner',
+): Promise<void> {
+  const res = await request.post(`${API_BASE}/admin/provisioners/${provisionerId}/providers`, {
+    headers: authHeaders(token),
+    data: { providerId, relationship },
+  });
+  if (!res.ok()) throw new Error(`associate provider failed (${res.status()}): ${await res.text()}`);
+}
+
+/** Assign an existing user as a representative of a provisioner (grants the PROVISIONER role). */
+export async function assignProvisionerRep(
+  request: APIRequestContext,
+  token: string,
+  provisionerId: string,
+  email: string,
+): Promise<void> {
+  const res = await request.post(`${API_BASE}/admin/provisioners/${provisionerId}/users`, {
+    headers: authHeaders(token),
+    data: { email },
+  });
+  if (!res.ok()) throw new Error(`assign rep(${email}) failed (${res.status()}): ${await res.text()}`);
+}

--- a/admin-client/e2e/helpers/login.ts
+++ b/admin-client/e2e/helpers/login.ts
@@ -46,13 +46,38 @@ export async function loginAsSuperAdmin(page: Page): Promise<void> {
 }
 
 export async function signInViaApi(request: APIRequestContext): Promise<string> {
-  const res = await request.post(`${API_BASE}/auth/login`, {
-    data: { email: E2E_ADMIN_EMAIL, password: E2E_ADMIN_PASSWORD },
-  });
+  return signInAs(request, E2E_ADMIN_EMAIL, E2E_ADMIN_PASSWORD);
+}
+
+/** API login as an arbitrary user; returns the JWT. */
+export async function signInAs(request: APIRequestContext, email: string, password: string): Promise<string> {
+  const res = await request.post(`${API_BASE}/auth/login`, { data: { email, password } });
   if (!res.ok()) {
-    throw new Error(`signInViaApi failed (${res.status()}): ${await res.text()}`);
+    throw new Error(`signInAs(${email}) failed (${res.status()}): ${await res.text()}`);
   }
   const body = await res.json();
-  if (!body?.token) throw new Error(`signInViaApi: missing token in response: ${JSON.stringify(body)}`);
+  if (!body?.token) throw new Error(`signInAs(${email}): missing token in response: ${JSON.stringify(body)}`);
   return body.token;
+}
+
+/**
+ * UI login as an arbitrary user via the login modal. Does NOT assert a landing
+ * page (it varies by role) — the caller asserts the resulting route/container.
+ * Resolves once the modal has closed (token set + post-login navigation fired).
+ */
+export async function loginAs(page: Page, email: string, password: string): Promise<void> {
+  await page.goto('');
+  await page.locator('#login').click();
+  await page.locator('#loginEmail').fill(email);
+  await page.locator('#loginPassword').fill(password);
+  // The login button is `close: true` — the modal closes synchronously on click
+  // while sign-in runs async. Wait for the /auth/login response AND the token to
+  // land so the caller can reliably assert the role-based landing / deep-link.
+  const loginResponse = page.waitForResponse(
+    (r) => r.url().includes('/auth/login') && r.request().method() === 'POST',
+    { timeout: 15_000 },
+  );
+  await page.locator('#loginButton').click();
+  await loginResponse;
+  await page.waitForFunction(() => !!localStorage.getItem('tmxToken'), null, { timeout: 10_000 });
 }

--- a/admin-client/e2e/journeys/01-login-and-navigate.spec.ts
+++ b/admin-client/e2e/journeys/01-login-and-navigate.spec.ts
@@ -11,8 +11,15 @@ test.describe('Journey 01 — login + navigate', () => {
   test('navbar shows super-admin icons', async ({ page }) => {
     await loginAsSuperAdmin(page);
     await expect(page.locator(S.H_SYSTEM)).toBeVisible();
-    await expect(page.locator(S.H_PROVISIONER)).toBeVisible();
     await expect(page.locator(S.H_SYNC)).toBeVisible();
+    // The provisioner icon is gated for super-admins: navVisibility shows it
+    // only after an active provisioner is selected (the /provisioner/* API
+    // needs the X-Provisioner-Id header). Simulate that selection, then assert.
+    await page.evaluate(() => {
+      localStorage.setItem('admin_active_provisioner', 'e2e-active-provisioner');
+      document.dispatchEvent(new CustomEvent('admin:provisioner-changed'));
+    });
+    await expect(page.locator(S.H_PROVISIONER)).toBeVisible();
   });
 
   test('clicking system icon stays on /system', async ({ page }) => {

--- a/admin-client/e2e/journeys/06-role-routing.spec.ts
+++ b/admin-client/e2e/journeys/06-role-routing.spec.ts
@@ -1,0 +1,116 @@
+import { test, expect, request as apiRequest, type APIRequestContext } from '@playwright/test';
+import {
+  ensureProvider,
+  createProvisioner,
+  removeUser,
+  assignProvisionerRep,
+  createLoginableUser,
+  associateProviderToProvisioner,
+  E2E_ROLE_PASSWORD,
+  uniqueSuffix,
+} from '../helpers/fixtures';
+import { cleanupProvisioner } from '../helpers/cleanup';
+import { loginAs, signInViaApi } from '../helpers/login';
+import { S } from '../helpers/selectors';
+
+/**
+ * Journey 06 — role-based routing into the admin console.
+ *
+ * Covers the matrix introduced by the provisioner-admin-routing work: the
+ * admin-client routes super-admin → /system, provisioner → /provisioner,
+ * PROVIDER_ADMIN → /admin, and everyone else (DIRECTOR / plain client) to the
+ * /no-access view instead of silently dumping them into /admin. Also guards the
+ * /admin deep-link and the no-access logout path.
+ *
+ * Seeds real server users via the admin API (bootstrap super-admin token) and
+ * tears them down in afterAll. Requires a live server on :8383 (global-setup
+ * asserts it). Legacy global-`admin` routing is covered by the adminAccess unit
+ * test — admin-create-user rejects that deprecated role, so it's not seeded here.
+ */
+const suffix = uniqueSuffix();
+const PROVIDER_ADMIN_EMAIL = `e2e-padmin-${suffix}@courthive.test`;
+const DIRECTOR_EMAIL = `e2e-director-${suffix}@courthive.test`;
+const PLAIN_EMAIL = `e2e-plain-${suffix}@courthive.test`;
+const REP_EMAIL = `e2e-prov-rep-${suffix}@courthive.test`;
+const PROVISIONER_NAME = `E2E-Role-Provisioner-${suffix}`;
+
+let ctx: APIRequestContext;
+let token: string;
+let providerId: string;
+let provisionerId: string;
+
+test.describe('Journey 06 — role-based routing', () => {
+  test.beforeAll(async () => {
+    ctx = await apiRequest.newContext();
+    token = await signInViaApi(ctx);
+
+    providerId = await ensureProvider(ctx, token, 'E2EROLE', 'E2E Role Provider');
+
+    await createLoginableUser(ctx, token, {
+      email: PROVIDER_ADMIN_EMAIL,
+      roles: ['client'],
+      providerId,
+      providerRole: 'PROVIDER_ADMIN',
+    });
+    await createLoginableUser(ctx, token, {
+      email: DIRECTOR_EMAIL,
+      roles: ['client'],
+      providerId,
+      providerRole: 'DIRECTOR',
+    });
+    await createLoginableUser(ctx, token, { email: PLAIN_EMAIL, roles: ['client'] });
+
+    // Provisioner representative: create the user, then a provisioner that owns
+    // the provider, then attach the user as a rep (grants the PROVISIONER role).
+    await createLoginableUser(ctx, token, { email: REP_EMAIL, roles: ['client'] });
+    provisionerId = await createProvisioner(ctx, token, PROVISIONER_NAME);
+    await associateProviderToProvisioner(ctx, token, provisionerId, providerId, 'owner');
+    await assignProvisionerRep(ctx, token, provisionerId, REP_EMAIL);
+  });
+
+  test.afterAll(async () => {
+    if (!ctx) return;
+    await cleanupProvisioner(ctx, provisionerId);
+    await removeUser(ctx, token, PROVIDER_ADMIN_EMAIL);
+    await removeUser(ctx, token, DIRECTOR_EMAIL);
+    await removeUser(ctx, token, PLAIN_EMAIL);
+    await removeUser(ctx, token, REP_EMAIL);
+    await ctx.dispose();
+  });
+
+  test('PROVIDER_ADMIN lands on /admin', async ({ page }) => {
+    await loginAs(page, PROVIDER_ADMIN_EMAIL, E2E_ROLE_PASSWORD);
+    await expect(page).toHaveURL(/#\/admin/);
+    await expect(page.locator(S.TMX_ADMIN)).toBeVisible();
+  });
+
+  test('a DIRECTOR-only account lands on /no-access, not /admin', async ({ page }) => {
+    await loginAs(page, DIRECTOR_EMAIL, E2E_ROLE_PASSWORD);
+    await expect(page).toHaveURL(/#\/no-access/);
+    await expect(page.getByText('No admin access')).toBeVisible();
+  });
+
+  test('a plain client account lands on /no-access', async ({ page }) => {
+    await loginAs(page, PLAIN_EMAIL, E2E_ROLE_PASSWORD);
+    await expect(page).toHaveURL(/#\/no-access/);
+  });
+
+  test('a provisioner representative lands on /provisioner', async ({ page }) => {
+    await loginAs(page, REP_EMAIL, E2E_ROLE_PASSWORD);
+    await expect(page).toHaveURL(/#\/provisioner/);
+    await expect(page.locator(S.TMX_PROVISIONER)).toBeVisible();
+  });
+
+  test('a DIRECTOR deep-linking to /admin is bounced to /no-access', async ({ page }) => {
+    await loginAs(page, DIRECTOR_EMAIL, E2E_ROLE_PASSWORD);
+    await page.goto('/#/admin');
+    await expect(page).toHaveURL(/#\/no-access/);
+  });
+
+  test('no-access logout returns the user to the login affordance', async ({ page }) => {
+    await loginAs(page, DIRECTOR_EMAIL, E2E_ROLE_PASSWORD);
+    await expect(page.getByText('No admin access')).toBeVisible();
+    await page.getByRole('button', { name: 'Log out' }).click();
+    await expect(page.locator(S.LOGIN)).toBeVisible();
+  });
+});

--- a/admin-client/src/router/router.ts
+++ b/admin-client/src/router/router.ts
@@ -67,7 +67,11 @@ export function routeAdmin(): void {
 
   router.on('/admin', () => {
     const state = getLoginState();
-    if (!canAccessAdmin(state)) {
+    // Only bounce a logged-IN user who lacks access. An unauthenticated visit
+    // falls through to the admin shell (pre-existing behavior — the login
+    // affordance lives in the navbar), so we don't show "No admin access" to
+    // someone who simply hasn't logged in yet.
+    if (state && !canAccessAdmin(state)) {
       router.navigate(`/${NO_ACCESS_ROUTE}`);
       return;
     }
@@ -159,7 +163,9 @@ export function routeAdmin(): void {
       router.navigate(`/${SYSTEM}`);
     } else if (state?.roles?.includes(PROVISIONER)) {
       router.navigate(`/${PROVISIONER_ROUTE}`);
-    } else if (canAccessAdmin(state)) {
+    } else if (!state || canAccessAdmin(state)) {
+      // `!state` = not logged in: keep the pre-existing admin-shell landing
+      // (login lives in the navbar). Logged-in admins also land on /admin.
       router.navigate('/admin');
     } else {
       router.navigate(`/${NO_ACCESS_ROUTE}`);


### PR DESCRIPTION
Follow-up to the merged provisioner-admin-routing work (#690) — adds end-to-end coverage for the role-routing matrix and fixes a regression it introduced.

## Fix
The #690 `/` handler sent **every** non-super/non-provisioner through to `/no-access` — including **unauthenticated** visitors, who previously landed on the admin shell (the login affordance lives in the navbar). This scopes the `/no-access` redirect (in both the `/` handler and the `/admin` guard) to **logged-in** users who lack access; unauthenticated visits keep the prior admin-shell landing.

## Tests — admin-client journey 06 (6/6 pass against a live server)
- provisioner representative → `/provisioner`
- PROVIDER_ADMIN → `/admin`
- DIRECTOR-only → `/no-access` (not `/admin`)
- plain client → `/no-access`
- DIRECTOR deep-linking to `/admin` → bounced to `/no-access`
- no-access logout → returns to the login affordance

New `e2e/helpers/fixtures.ts` seeds providers / role-scoped users / provisioners via the admin API (users made login-ready through the real first-login flow), plus generic `loginAs`/`signInAs`. Legacy global-`admin` routing is covered by the `adminAccess` unit test (the deprecated role can't be created via `admin-create-user`).

## TMX e2e — deferred
The matching TMX suite (provider switcher + `isActiveProviderAdmin` gating) is **not** included: TMX's authenticated boot is server-coupled and the app would not boot to the navbar in a local worktree harness (confirmed by the existing journey 31 also failing there), so I couldn't verify it locally. The TMX gating logic is already covered by `isProviderAdmin.test.ts` (9 unit cases). A TMX role e2e should be built on the journey-28 real-login pattern and validated in CI.

Verified: admin-client check-types + lint (router) clean; journey 06 6/6 green.