### PR TITLE
feat(auth): rotating refresh tokens for long-lived sessions

### DIFF
--- a/src/modules/account/auth/auth.controller.ts
+++ b/src/modules/account/auth/auth.controller.ts
@@ -1,4 +1,4 @@
-import { Body, Controller, Get, HttpCode, HttpStatus, Patch, Post } from '@nestjs/common';
+import { Body, Controller, Get, HttpCode, HttpStatus, Patch, Post, Req } from '@nestjs/common';
 import { UserCtx, type UserContext } from './decorators/user-context.decorator';
 import { AdminCreateUserDto } from './dto/adminCreateUser.dto';
 import { ForgotPasswordDto } from './dto/forgotPassword.dto';
@@ -30,8 +30,31 @@ export class AuthController {
   @Public()
   @Post('login')
   @HttpCode(HttpStatus.OK)
-  signIn(@Body() signIn: SignInDto) {
-    return this.authService.signIn(signIn.email, signIn.password);
+  signIn(@Body() signIn: SignInDto, @Req() req?: any) {
+    return this.authService.signIn(signIn.email, signIn.password, req?.headers?.['user-agent']);
+  }
+
+  /**
+   * Exchange a rotating refresh token for a fresh access token (+ rotated
+   * refresh token). TMX calls this transparently when the access token nears
+   * expiry or a request 401s. Public: the refresh token is the credential.
+   */
+  @Public()
+  @Post('refresh')
+  @HttpCode(HttpStatus.OK)
+  refresh(@Body() body: { refreshToken: string }, @Req() req?: any) {
+    return this.authService.refreshSession(body?.refreshToken ?? '', req?.headers?.['user-agent']);
+  }
+
+  /**
+   * Revoke a refresh token (logout). Idempotent; always returns success so the
+   * client can clear local state regardless. Public: the token is the credential.
+   */
+  @Public()
+  @Post('logout')
+  @HttpCode(HttpStatus.OK)
+  logout(@Body() body: { refreshToken: string }) {
+    return this.authService.logout(body?.refreshToken ?? '');
   }
 
   @Post('admin-create-user')

--- a/src/modules/account/auth/auth.module.ts
+++ b/src/modules/account/auth/auth.module.ts
@@ -6,6 +6,7 @@ import { AuthController } from './auth.controller';
 import { AuthMiddleware } from './auth.middleware';
 import { AuthGuard } from './guards/auth.guard';
 import { AuthService } from './auth.service';
+import { RefreshTokenService } from './refresh-token.service';
 import { ConfigService } from '@nestjs/config';
 import { APP_GUARD } from '@nestjs/core';
 import { JwtModule } from '@nestjs/jwt';
@@ -31,6 +32,7 @@ const expiresIn: any = rawValidity && isValidJwtExpiresIn(rawValidity) ? rawVali
   ],
   providers: [
     AuthService,
+    RefreshTokenService,
     {
       provide: APP_GUARD,
       useClass: AuthGuard,
@@ -38,7 +40,7 @@ const expiresIn: any = rawValidity && isValidJwtExpiresIn(rawValidity) ? rawVali
     ConfigService,
   ],
   controllers: [AuthController],
-  exports: [AuthService],
+  exports: [AuthService, RefreshTokenService],
 })
 export class AuthModule implements NestModule {
   configure(consumer: MiddlewareConsumer): void {

--- a/src/modules/account/auth/auth.service.spec.ts
+++ b/src/modules/account/auth/auth.service.spec.ts
@@ -13,6 +13,7 @@ describe('AuthService', () => {
   let mockUserStorage: any;
   let mockUserProviderStorage: any;
   let mockProvisionerProviderStorage: any;
+  let mockRefreshTokenService: any;
 
   beforeEach(() => {
     jwtService = new JwtService({ secret: 'test-secret' });
@@ -75,6 +76,13 @@ describe('AuthService', () => {
       disassociate: jest.fn(),
     };
 
+    mockRefreshTokenService = {
+      issue: jest.fn().mockResolvedValue('rtok_test'),
+      rotate: jest.fn(),
+      revoke: jest.fn().mockResolvedValue(undefined),
+      revokeAllForUser: jest.fn().mockResolvedValue(undefined),
+    };
+
     authService = new AuthService(
       mockUsersService,
       jwtService,
@@ -85,6 +93,7 @@ describe('AuthService', () => {
       mockUserProvisionerStorage as any,
       mockUserProviderStorage,
       mockProvisionerProviderStorage,
+      mockRefreshTokenService as any,
     );
   });
 
@@ -156,7 +165,7 @@ describe('AuthService', () => {
 
     it('returns token for valid cleartext password match', async () => {
       mockUsersService.findOne.mockResolvedValue({ email: 'test@test.com', password: 'secret', roles: ['client'] });
-      const result = await authService.signIn('test@test.com', 'secret');
+      const result: any = await authService.signIn('test@test.com', 'secret');
       expect(result.token).toBeDefined();
       expect(typeof result.token).toBe('string');
     });
@@ -164,7 +173,7 @@ describe('AuthService', () => {
     it('returns token for valid bcrypt password match', async () => {
       const hashed = await bcrypt.hash('my-password', 10);
       mockUsersService.findOne.mockResolvedValue({ email: 'test@test.com', password: hashed, roles: ['admin'] });
-      const result = await authService.signIn('test@test.com', 'my-password');
+      const result: any = await authService.signIn('test@test.com', 'my-password');
       expect(result.token).toBeDefined();
     });
 
@@ -178,7 +187,7 @@ describe('AuthService', () => {
       });
       mockProviderStorage.getProvider.mockResolvedValue(provider);
 
-      const result = await authService.signIn('admin@test.com', 'pass');
+      const result: any = await authService.signIn('admin@test.com', 'pass');
       expect(mockProviderStorage.getProvider).toHaveBeenCalledWith('p1');
       expect(result.token).toBeDefined();
     });
@@ -206,7 +215,7 @@ describe('AuthService', () => {
       mockProviderStorage.updateLastAccess.mockRejectedValueOnce(new Error('db down'));
       const warnSpy = jest.spyOn(Logger, 'warn').mockImplementation(() => undefined);
 
-      const result = await authService.signIn('fail@test.com', 'pass');
+      const result: any = await authService.signIn('fail@test.com', 'pass');
       // both .catch handlers run on the next microtask — flush a few times
       await Promise.resolve();
       await Promise.resolve();
@@ -935,6 +944,67 @@ describe('AuthService', () => {
       );
       const updateCall = (mockUserStorage.update as jest.Mock).mock.calls[0];
       expect(updateCall[1].password).not.toBe(hashed);
+    });
+  });
+
+  describe('session tokens (access + refresh)', () => {
+    it('signIn issues a 4h access token plus a refresh token', async () => {
+      mockUsersService.findOne.mockResolvedValue({
+        userId: 'u-1', email: 'a@test.com', password: 'secret', roles: ['client'],
+      });
+      const result: any = await authService.signIn('a@test.com', 'secret', 'jest-agent');
+      expect(result.token).toBeDefined();
+      expect(result.refreshToken).toBe('rtok_test');
+      expect(mockRefreshTokenService.issue).toHaveBeenCalledWith('u-1', 'a@test.com', 'jest-agent');
+      const decoded: any = await jwtService.verifyAsync(result.token);
+      expect(decoded.exp - decoded.iat).toBe(4 * 60 * 60); // 4h, not the old 1d
+    });
+
+    it('refreshSession rotates the token and re-issues a 4h access token', async () => {
+      mockRefreshTokenService.rotate.mockResolvedValue({
+        userId: 'u-1', email: 'a@test.com', refreshToken: 'rtok_next',
+      });
+      mockUsersService.findOne.mockResolvedValue({
+        userId: 'u-1', email: 'a@test.com', password: 'x', roles: ['client'],
+      });
+      const result: any = await authService.refreshSession('rtok_old', 'jest-agent');
+      expect(mockRefreshTokenService.rotate).toHaveBeenCalledWith('rtok_old', 'jest-agent');
+      expect(result.refreshToken).toBe('rtok_next');
+      const decoded: any = await jwtService.verifyAsync(result.token);
+      expect(decoded.email).toBe('a@test.com');
+      expect(decoded.exp - decoded.iat).toBe(4 * 60 * 60);
+    });
+
+    it('refreshSession throws when the user no longer exists', async () => {
+      mockRefreshTokenService.rotate.mockResolvedValue({
+        userId: 'u-x', email: 'gone@test.com', refreshToken: 'rtok_next',
+      });
+      mockUsersService.findOne.mockResolvedValue(null);
+      await expect(authService.refreshSession('rtok_old')).rejects.toThrow(UnauthorizedException);
+    });
+
+    it('refreshSession propagates rotation rejection (reuse / expired) without loading the user', async () => {
+      mockRefreshTokenService.rotate.mockRejectedValue(new UnauthorizedException('Refresh token already used'));
+      await expect(authService.refreshSession('rtok_reused')).rejects.toThrow(UnauthorizedException);
+      expect(mockUsersService.findOne).not.toHaveBeenCalled();
+    });
+
+    it('logout revokes the presented refresh token and returns success', async () => {
+      const result: any = await authService.logout('rtok_bye');
+      expect(mockRefreshTokenService.revoke).toHaveBeenCalledWith('rtok_bye');
+      expect(result.success).toBe(true);
+    });
+
+    it('resetPassword revokes all of the user’s refresh tokens', async () => {
+      const token = await jwtService.signAsync(
+        { userId: 'u-1', contactEmail: 'alice@example.com', purpose: 'password-reset' },
+        { expiresIn: '1h' },
+      );
+      mockUserStorage.findByUserId.mockResolvedValue({
+        userId: 'u-1', contactEmail: 'alice@example.com', emailVerifiedAt: '2026-05-22T00:00:00Z',
+      });
+      await authService.resetPassword(token, 'new-password');
+      expect(mockRefreshTokenService.revokeAllForUser).toHaveBeenCalledWith('u-1');
     });
   });
 });

--- a/src/modules/account/auth/auth.service.ts
+++ b/src/modules/account/auth/auth.service.ts
@@ -26,11 +26,20 @@ import {
 } from 'src/storage/interfaces';
 import { assertProviderEditor } from './helpers/assertProviderEditor';
 import { buildUserContext } from './helpers/buildUserContext';
+import { RefreshTokenService } from './refresh-token.service';
 import type { UserContext } from './decorators/user-context.decorator';
 
 const PASSWORD_RESET_TOKEN_TTL = '1h';
 const ADMIN_ONBOARD_TOKEN_TTL = '7d';
 const PASSWORD_RESET_PURPOSE = 'password-reset';
+
+// Access-token (session JWT) lifetime. Short because TMX silently refreshes it
+// via POST /auth/refresh using a long-lived rotating refresh token. 4h is a
+// deliberate balance: long enough that a brief refresh failure on flaky
+// tournament wifi doesn't immediately log officials out, short enough to bound
+// the window of a leaked access token. See RefreshTokenService for the refresh
+// side. Both the password-login path (signIn) and SSO handoff use this value.
+const ACCESS_TOKEN_TTL = '4h';
 
 // Conservative RFC-shaped email check — same regex as the migration backfill
 // and IdentityService. Used to decide whether an admin-supplied contact_email
@@ -73,6 +82,7 @@ export class AuthService {
     @Inject(USER_PROVIDER_STORAGE) private readonly userProviderStorage: IUserProviderStorage,
     @Inject(PROVISIONER_PROVIDER_STORAGE)
     private readonly provisionerProviderStorage: IProvisionerProviderStorage,
+    private readonly refreshTokenService: RefreshTokenService,
   ) {}
 
   /**
@@ -121,7 +131,7 @@ export class AuthService {
     return `${base}/admin/#/reset-password/${token}`;
   }
 
-  async signIn(email: string, clearTextPassword: string) {
+  async signIn(email: string, clearTextPassword: string, userAgent?: string) {
     if (!email) throw new UnauthorizedException();
     const user = await this.usersService.findOne(email);
 
@@ -130,9 +140,8 @@ export class AuthService {
       throw new UnauthorizedException('This account uses SSO login. Please log in through your organization.');
     }
 
-    const { password, ...userDetails } = user ?? {};
     const passwordMatch =
-      user && (password === clearTextPassword || (await bcrypt.compare(clearTextPassword, user?.password)));
+      user && (user.password === clearTextPassword || (await bcrypt.compare(clearTextPassword, user?.password)));
     if (!passwordMatch) throw new UnauthorizedException();
 
     // Admin-assigned passwords gate into a forced-change flow before a
@@ -145,6 +154,23 @@ export class AuthService {
       );
       return { mustChangePassword: true, limitedToken };
     }
+
+    const userDetails = await this.buildSessionPayload(user);
+    return this.issueSession(userDetails, userAgent);
+  }
+
+  /**
+   * Build the enriched, password-stripped JWT payload for a fully
+   * authenticated user — provider config, provisioner context, and
+   * multi-provider associations — and record last-access as a side effect.
+   *
+   * Shared by signIn and refreshSession so that a silently-refreshed access
+   * token carries exactly the same claims as the one minted at login.
+   */
+  private async buildSessionPayload(user: any): Promise<any> {
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars
+    const { password, ...userDetails } = user ?? {};
+    const email = user.email;
 
     if (user.providerId) {
       const provider = await this.providerStorage.getProvider(user.providerId);
@@ -225,9 +251,52 @@ export class AuthService {
       }
     }
 
-    const payload = userDetails;
-    const token = await this.jwtService.signAsync(payload, { expiresIn: '1d' });
-    return { token };
+    return userDetails;
+  }
+
+  /**
+   * Mint an access token (short-lived JWT) plus a long-lived rotating refresh
+   * token for an already-built session payload. The refresh token's plaintext
+   * is returned to the client exactly once; only its hash is persisted.
+   */
+  private async issueSession(
+    userDetails: any,
+    userAgent?: string,
+  ): Promise<{ token: string; refreshToken: string }> {
+    const token = await this.jwtService.signAsync(userDetails, { expiresIn: ACCESS_TOKEN_TTL });
+    const userId = userDetails.userId ?? userDetails.user_id ?? userDetails.email;
+    const refreshToken = await this.refreshTokenService.issue(userId, userDetails.email, userAgent);
+    return { token, refreshToken };
+  }
+
+  /**
+   * Exchange a valid refresh token for a fresh access token + rotated refresh
+   * token. The presented refresh token is consumed (rotated) by
+   * RefreshTokenService; reuse of an already-rotated token revokes the whole
+   * family. The owning user is reloaded so the new access token reflects any
+   * role/association changes since login. Public endpoint: the refresh token
+   * is the credential.
+   */
+  async refreshSession(
+    presentedRefreshToken: string,
+    userAgent?: string,
+  ): Promise<{ token: string; refreshToken: string }> {
+    const rotated = await this.refreshTokenService.rotate(presentedRefreshToken, userAgent);
+    const user = await this.usersService.findOne(rotated.email);
+    if (!user) throw new UnauthorizedException();
+    const userDetails = await this.buildSessionPayload(user);
+    const token = await this.jwtService.signAsync(userDetails, { expiresIn: ACCESS_TOKEN_TTL });
+    return { token, refreshToken: rotated.refreshToken };
+  }
+
+  /**
+   * Revoke a presented refresh token (logout). Idempotent — always returns
+   * SUCCESS so a client can clear local state without leaking whether the
+   * token was known.
+   */
+  async logout(presentedRefreshToken: string) {
+    await this.refreshTokenService.revoke(presentedRefreshToken);
+    return { ...SUCCESS };
   }
 
   /**
@@ -400,6 +469,12 @@ export class AuthService {
 
     const hashed = await hashPassword(newPassword);
     await this.userStorage.setPasswordByUserId(user.userId, hashed);
+
+    // A password reset invalidates every existing session: kill all refresh
+    // tokens so a leaked/forgotten credential can't keep a session alive.
+    this.refreshTokenService.revokeAllForUser(user.userId).catch((err: any) => {
+      Logger.warn(`revokeAllForUser(${user.userId}) after reset failed: ${err?.message ?? err}`, AuthService.name);
+    });
 
     // Admin-onboard piggyback: a user who just clicked an email link and
     // set their password has proven they control the contact_email. If
@@ -672,6 +747,14 @@ export class AuthService {
     const password = newPassword || createUniqueKey().slice(0, 12);
     user.password = await hashPassword(password);
     await this.userStorage.update(email, user);
+
+    // Admin reset invalidates the target's existing sessions.
+    const targetUserId = user.userId ?? user.user_id;
+    if (targetUserId) {
+      this.refreshTokenService.revokeAllForUser(targetUserId).catch((err: any) => {
+        Logger.warn(`revokeAllForUser(${targetUserId}) after admin reset failed: ${err?.message ?? err}`, AuthService.name);
+      });
+    }
     return { ...SUCCESS, password };
   }
 

--- a/src/modules/account/auth/refresh-token.service.spec.ts
+++ b/src/modules/account/auth/refresh-token.service.spec.ts
@@ -1,0 +1,119 @@
+import { UnauthorizedException } from '@nestjs/common';
+import { RefreshTokenService } from './refresh-token.service';
+
+describe('RefreshTokenService', () => {
+  let service: RefreshTokenService;
+  let storage: any;
+
+  const activeRow = (overrides: any = {}) => ({
+    tokenId: 't-old',
+    userId: 'u-1',
+    email: 'a@test.com',
+    tokenHash: 'hash',
+    familyId: 'fam-1',
+    expiresAt: new Date(Date.now() + 60_000).toISOString(),
+    revokedAt: null,
+    ...overrides,
+  });
+
+  beforeEach(() => {
+    storage = {
+      create: jest.fn().mockImplementation(async (input) => ({ tokenId: 't-new', ...input })),
+      findByHash: jest.fn(),
+      revoke: jest.fn().mockResolvedValue(undefined),
+      revokeFamily: jest.fn().mockResolvedValue(undefined),
+      revokeAllForUser: jest.fn().mockResolvedValue(undefined),
+      deleteExpired: jest.fn().mockResolvedValue(0),
+    };
+    service = new RefreshTokenService(storage);
+  });
+
+  describe('issue', () => {
+    it('stores only a hash and returns a prefixed plaintext token', async () => {
+      const token = await service.issue('u-1', 'a@test.com', 'agent');
+      expect(token.startsWith('rtok_')).toBe(true);
+      expect(storage.create).toHaveBeenCalledTimes(1);
+      const arg = storage.create.mock.calls[0][0];
+      expect(arg.userId).toBe('u-1');
+      expect(arg.email).toBe('a@test.com');
+      expect(arg.userAgent).toBe('agent');
+      // The persisted hash must NOT be the plaintext token.
+      expect(arg.tokenHash).not.toBe(token);
+      expect(arg.tokenHash).toMatch(/^[a-f0-9]{64}$/); // sha256 hex
+      expect(typeof arg.familyId).toBe('string');
+    });
+  });
+
+  describe('rotate', () => {
+    it('rotates a valid token within the same family and revokes the old one', async () => {
+      storage.findByHash.mockResolvedValue(activeRow());
+      const result = await service.rotate('rtok_old', 'agent');
+
+      expect(result.userId).toBe('u-1');
+      expect(result.email).toBe('a@test.com');
+      expect(result.refreshToken.startsWith('rtok_')).toBe(true);
+      expect(result.refreshToken).not.toBe('rtok_old');
+
+      // New token created in the SAME family.
+      const created = storage.create.mock.calls[0][0];
+      expect(created.familyId).toBe('fam-1');
+      // Old token revoked, linked to its successor.
+      expect(storage.revoke).toHaveBeenCalledWith('t-old', 't-new');
+      expect(storage.revokeFamily).not.toHaveBeenCalled();
+    });
+
+    it('throws on a missing token', async () => {
+      await expect(service.rotate('')).rejects.toThrow(UnauthorizedException);
+      expect(storage.findByHash).not.toHaveBeenCalled();
+    });
+
+    it('throws on an unknown token', async () => {
+      storage.findByHash.mockResolvedValue(null);
+      await expect(service.rotate('rtok_nope')).rejects.toThrow(UnauthorizedException);
+    });
+
+    it('detects reuse: a revoked token revokes the whole family', async () => {
+      storage.findByHash.mockResolvedValue(activeRow({ revokedAt: new Date().toISOString() }));
+      await expect(service.rotate('rtok_reused')).rejects.toThrow(/already used/);
+      expect(storage.revokeFamily).toHaveBeenCalledWith('fam-1');
+      expect(storage.create).not.toHaveBeenCalled();
+    });
+
+    it('throws on an expired token', async () => {
+      storage.findByHash.mockResolvedValue(activeRow({ expiresAt: new Date(Date.now() - 1000).toISOString() }));
+      await expect(service.rotate('rtok_expired')).rejects.toThrow(/expired/);
+      expect(storage.create).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('revoke / revokeAllForUser', () => {
+    it('revokes an active presented token', async () => {
+      storage.findByHash.mockResolvedValue(activeRow());
+      await service.revoke('rtok_bye');
+      expect(storage.revoke).toHaveBeenCalledWith('t-old');
+    });
+
+    it('is a no-op for an unknown or empty token', async () => {
+      storage.findByHash.mockResolvedValue(null);
+      await service.revoke('rtok_unknown');
+      await service.revoke('');
+      expect(storage.revoke).not.toHaveBeenCalled();
+    });
+
+    it('does not double-revoke an already-revoked token', async () => {
+      storage.findByHash.mockResolvedValue(activeRow({ revokedAt: new Date().toISOString() }));
+      await service.revoke('rtok_already');
+      expect(storage.revoke).not.toHaveBeenCalled();
+    });
+
+    it('delegates revokeAllForUser to storage', async () => {
+      await service.revokeAllForUser('u-1');
+      expect(storage.revokeAllForUser).toHaveBeenCalledWith('u-1');
+    });
+
+    it('ignores revokeAllForUser with no userId', async () => {
+      await service.revokeAllForUser('');
+      expect(storage.revokeAllForUser).not.toHaveBeenCalled();
+    });
+  });
+});

--- a/src/modules/account/auth/refresh-token.service.ts
+++ b/src/modules/account/auth/refresh-token.service.ts
@@ -1,0 +1,114 @@
+import { Inject, Injectable, Logger, UnauthorizedException } from '@nestjs/common';
+import { createHash, randomBytes, randomUUID } from 'crypto';
+
+import { REFRESH_TOKEN_STORAGE, type IRefreshTokenStorage } from 'src/storage/interfaces';
+
+/** Refresh-token lifetime. Long-lived so a session survives a multi-day event. */
+export const REFRESH_TOKEN_TTL_DAYS = 30;
+const REFRESH_TOKEN_TTL_MS = REFRESH_TOKEN_TTL_DAYS * 24 * 60 * 60 * 1000;
+/** Human-recognisable prefix for the opaque token (purely cosmetic — it is hashed). */
+const REFRESH_TOKEN_PREFIX = 'rtok_';
+
+export interface RotationResult {
+  userId: string;
+  email: string;
+  /** The freshly minted plaintext refresh token to hand back to the client. */
+  refreshToken: string;
+}
+
+/**
+ * Issues, rotates, and revokes opaque refresh tokens. The plaintext token is
+ * returned to the caller exactly once; only its SHA-256 hash is persisted.
+ *
+ * Rotation: every successful refresh mints a new token in the same family and
+ * revokes the one presented. Replaying an already-rotated (revoked) token is
+ * treated as theft — the entire family is revoked so both the attacker's and
+ * the victim's tokens stop working and the user is forced to re-authenticate.
+ *
+ * Shared by AuthService (password login) and SsoController (provisioner
+ * handoff); it depends only on the globally-exported REFRESH_TOKEN_STORAGE.
+ */
+@Injectable()
+export class RefreshTokenService {
+  constructor(@Inject(REFRESH_TOKEN_STORAGE) private readonly storage: IRefreshTokenStorage) {}
+
+  private hash(token: string): string {
+    return createHash('sha256').update(token).digest('hex');
+  }
+
+  private mint(): string {
+    return REFRESH_TOKEN_PREFIX + randomBytes(32).toString('base64url');
+  }
+
+  private expiry(): string {
+    return new Date(Date.now() + REFRESH_TOKEN_TTL_MS).toISOString();
+  }
+
+  /** Issue a brand-new refresh token that starts a fresh rotation family. */
+  async issue(userId: string, email: string, userAgent?: string): Promise<string> {
+    const token = this.mint();
+    await this.storage.create({
+      userId,
+      email,
+      tokenHash: this.hash(token),
+      familyId: randomUUID(),
+      expiresAt: this.expiry(),
+      userAgent,
+    });
+    return token;
+  }
+
+  /**
+   * Validate a presented refresh token and rotate it. Returns the owning user
+   * plus a fresh refresh token (same family). Throws UnauthorizedException for
+   * unknown / expired / revoked tokens. A revoked-token replay revokes the
+   * whole family (reuse detection).
+   */
+  async rotate(presented: string, userAgent?: string): Promise<RotationResult> {
+    if (!presented) throw new UnauthorizedException('Missing refresh token');
+
+    const row = await this.storage.findByHash(this.hash(presented));
+    if (!row) throw new UnauthorizedException('Invalid refresh token');
+
+    if (row.revokedAt) {
+      Logger.warn(
+        `Refresh-token reuse detected for user ${row.userId}; revoking family ${row.familyId}`,
+        RefreshTokenService.name,
+      );
+      await this.storage.revokeFamily(row.familyId);
+      throw new UnauthorizedException('Refresh token already used');
+    }
+
+    if (new Date(row.expiresAt).getTime() <= Date.now()) {
+      throw new UnauthorizedException('Refresh token expired');
+    }
+
+    // Rotate within the same family, then revoke the presented token and link
+    // it to its successor for audit/forensics.
+    const next = this.mint();
+    const created = await this.storage.create({
+      userId: row.userId,
+      email: row.email,
+      tokenHash: this.hash(next),
+      familyId: row.familyId,
+      expiresAt: this.expiry(),
+      userAgent,
+    });
+    await this.storage.revoke(row.tokenId, created.tokenId);
+
+    return { userId: row.userId, email: row.email, refreshToken: next };
+  }
+
+  /** Revoke a single presented refresh token (logout). Idempotent and quiet. */
+  async revoke(presented: string): Promise<void> {
+    if (!presented) return;
+    const row = await this.storage.findByHash(this.hash(presented));
+    if (row && !row.revokedAt) await this.storage.revoke(row.tokenId);
+  }
+
+  /** Revoke every active refresh token for a user (credential change / logout-all). */
+  async revokeAllForUser(userId: string): Promise<void> {
+    if (!userId) return;
+    await this.storage.revokeAllForUser(userId);
+  }
+}

--- a/src/modules/provisioner/provisioner.module.ts
+++ b/src/modules/provisioner/provisioner.module.ts
@@ -7,6 +7,7 @@ import { ProvisionerService } from './provisioner.service';
 import { SsoTokenService } from './sso-token.service';
 import { SsoController } from './sso.controller';
 import { AuditModule } from '../audit/audit.module';
+import { RefreshTokenService } from '../account/auth/refresh-token.service';
 
 @Module({
   imports: [AuditModule],
@@ -16,7 +17,10 @@ import { AuditModule } from '../audit/audit.module';
     SsoController,
     UsersProvidersController,
   ],
-  providers: [ProvisionerService, SsoTokenService],
+  // RefreshTokenService is a stateless helper over the global
+  // REFRESH_TOKEN_STORAGE; providing it here (rather than importing AuthModule,
+  // which configures middleware) avoids cross-module middleware coupling.
+  providers: [ProvisionerService, SsoTokenService, RefreshTokenService],
 })
 export class ProvisionerModule implements NestModule {
   configure(consumer: MiddlewareConsumer): void {

--- a/src/modules/provisioner/sso.controller.spec.ts
+++ b/src/modules/provisioner/sso.controller.spec.ts
@@ -67,10 +67,12 @@ describe('SsoController', () => {
 
     const userProvisionerStorage: any = { findProvisionerIdsByUser: jest.fn().mockResolvedValue([]) };
     const provisionerProviderStorage: any = { findByProvisioner: jest.fn().mockResolvedValue([]) };
+    const refreshTokenService: any = { issue: jest.fn().mockResolvedValue('rtok_sso') };
 
     controller = new SsoController(
       ssoTokenService as any,
       jwtService as any,
+      refreshTokenService,
       ssoIdentityStorage as any,
       userStorage as any,
       userProviderStorage as any,

--- a/src/modules/provisioner/sso.controller.ts
+++ b/src/modules/provisioner/sso.controller.ts
@@ -1,5 +1,6 @@
 import { Body, Controller, HttpCode, HttpStatus, Inject, Logger, Post, Req, UseGuards } from '@nestjs/common';
 import { Public } from '../account/auth/decorators/public.decorator';
+import { RefreshTokenService } from '../account/auth/refresh-token.service';
 import { ProvisionerGuard } from './provisioner.guard';
 import { SsoTokenService } from './sso-token.service';
 import { JwtService } from '@nestjs/jwt';
@@ -25,6 +26,7 @@ export class SsoController {
   constructor(
     private readonly ssoTokenService: SsoTokenService,
     private readonly jwtService: JwtService,
+    private readonly refreshTokenService: RefreshTokenService,
     @Inject(SSO_IDENTITY_STORAGE) private readonly ssoIdentityStorage: ISsoIdentityStorage,
     @Inject(USER_STORAGE) private readonly userStorage: IUserStorage,
     @Inject(USER_PROVIDER_STORAGE) private readonly userProviderStorage: IUserProviderStorage,
@@ -73,7 +75,7 @@ export class SsoController {
   @Post('login-with-token')
   @Public()
   @HttpCode(HttpStatus.OK)
-  async loginWithToken(@Body() body: { token: string }) {
+  async loginWithToken(@Body() body: { token: string }, @Req() req?: any) {
     const { token } = body;
     if (!token) return { error: 'Token is required' };
 
@@ -106,12 +108,20 @@ export class SsoController {
     const userDetails = { ...user };
     delete userDetails.password;
     const jwtPayload = { ...userDetails, providerIds: userContext.providerIds, providerRoles: userContext.providerRoles };
-    // Match the direct-login session lifetime (auth.service.ts signIn uses
-    // `expiresIn: '1d'`). Without this override the SSO session inherits the
-    // JwtModule default (JWT_VALIDITY, '2h' in prod), so provisioner-handoff
-    // users silently expired hours sooner than password-login users and saw
-    // an unexpected 401 mid-session.
-    const accessToken = await this.jwtService.signAsync(jwtPayload, { expiresIn: '1d' });
+    // Match the direct-login access-token lifetime (auth.service.ts ACCESS_TOKEN_TTL).
+    // Without this override the SSO session would inherit the JwtModule default
+    // (JWT_VALIDITY, '2h' in prod). The short lifetime is fine because the
+    // refresh token below keeps the session alive silently.
+    const accessToken = await this.jwtService.signAsync(jwtPayload, { expiresIn: '4h' });
+
+    // Mint a rotating refresh token so SSO-handoff sessions refresh silently
+    // just like password logins (POST /auth/refresh) instead of forcing a new
+    // provisioner handoff every few hours.
+    const refreshToken = await this.refreshTokenService.issue(
+      userContext.userId,
+      userContext.email,
+      req?.headers?.['user-agent'],
+    );
 
     // Track last access for both user and the provider this SSO token resolved to.
     // Failures are non-fatal but visible — silent .catch() previously hid mismatches.
@@ -129,6 +139,7 @@ export class SsoController {
 
     return {
       accessToken,
+      refreshToken,
       user: {
         userId: userContext.userId,
         email: userContext.email,

--- a/src/storage/interfaces/index.ts
+++ b/src/storage/interfaces/index.ts
@@ -71,3 +71,8 @@ export {
   type IProviderArchiveStorage,
   type ProviderArchiveRow,
 } from './provider-archive-storage.interface';
+export {
+  REFRESH_TOKEN_STORAGE,
+  type IRefreshTokenStorage,
+  type RefreshTokenRow,
+} from './refresh-token-storage.interface';

--- a/src/storage/interfaces/refresh-token-storage.interface.ts
+++ b/src/storage/interfaces/refresh-token-storage.interface.ts
@@ -1,0 +1,50 @@
+export const REFRESH_TOKEN_STORAGE = Symbol('REFRESH_TOKEN_STORAGE');
+
+/**
+ * Storage for opaque refresh tokens backing the access/refresh session model.
+ *
+ * Only the SHA-256 *hash* of a refresh token is ever stored — the plaintext
+ * lives solely in the client's localStorage. Tokens are rotated on every use:
+ * each rotation issues a new row in the same `familyId` and revokes the prior
+ * one. Presenting an already-revoked token in a family is treated as theft and
+ * triggers `revokeFamily` (see RefreshTokenService.rotate).
+ */
+export interface IRefreshTokenStorage {
+  /** Persist a new refresh token (hash only). Returns the stored row. */
+  create(input: {
+    userId: string;
+    email: string;
+    tokenHash: string;
+    familyId: string;
+    expiresAt: string;
+    userAgent?: string;
+  }): Promise<RefreshTokenRow>;
+
+  /** Look up a token by its hash, regardless of state. Caller inspects revoked/expired. */
+  findByHash(tokenHash: string): Promise<RefreshTokenRow | null>;
+
+  /** Mark a single token revoked, optionally recording the token that replaced it on rotation. */
+  revoke(tokenId: string, replacedBy?: string): Promise<void>;
+
+  /** Revoke every still-active token in a rotation family (reuse / breach response). */
+  revokeFamily(familyId: string): Promise<void>;
+
+  /** Revoke every still-active token for a user (logout-all / credential change). */
+  revokeAllForUser(userId: string): Promise<void>;
+
+  /** Delete already-expired rows. Returns the number removed. */
+  deleteExpired(): Promise<number>;
+}
+
+export interface RefreshTokenRow {
+  tokenId: string;
+  userId: string;
+  email: string;
+  tokenHash: string;
+  familyId: string;
+  expiresAt: string;
+  createdAt?: string;
+  revokedAt?: string | null;
+  replacedBy?: string | null;
+  userAgent?: string | null;
+}

--- a/src/storage/postgres/migrations/031-add-refresh-tokens.sql
+++ b/src/storage/postgres/migrations/031-add-refresh-tokens.sql
@@ -1,0 +1,33 @@
+-- 031-add-refresh-tokens.sql
+-- AFFECTS: admin
+-- Refresh-token store for the access/refresh JWT session model.
+--
+-- Access tokens stay short-lived (4h) JWTs verified statelessly by AuthGuard.
+-- Refresh tokens are long-lived (30d) opaque secrets, stored here as SHA-256
+-- hashes (never plaintext) and rotated on every use. A rotation chain shares a
+-- `family_id`; presenting an already-rotated (revoked) token is treated as
+-- theft and revokes the whole family. Analogous to auth_codes (also `admin`):
+-- session infrastructure, not end-user tournament data. Purely additive — a
+-- new table, so it cannot break any existing flow.
+
+CREATE TABLE IF NOT EXISTS refresh_tokens (
+  token_id     UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  user_id      TEXT NOT NULL,
+  email        TEXT NOT NULL,
+  token_hash   TEXT NOT NULL UNIQUE,
+  family_id    UUID NOT NULL DEFAULT gen_random_uuid(),
+  expires_at   TIMESTAMPTZ NOT NULL,
+  created_at   TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  revoked_at   TIMESTAMPTZ,
+  replaced_by  UUID,
+  user_agent   TEXT
+);
+
+-- Hot path: look up the presented token by its hash.
+CREATE UNIQUE INDEX IF NOT EXISTS idx_refresh_tokens_hash ON refresh_tokens(token_hash);
+-- Reuse-detection / breach response: revoke an entire rotation family.
+CREATE INDEX IF NOT EXISTS idx_refresh_tokens_family ON refresh_tokens(family_id);
+-- Logout-all and password-change revocation by user.
+CREATE INDEX IF NOT EXISTS idx_refresh_tokens_user ON refresh_tokens(user_id);
+-- Housekeeping sweep of expired rows.
+CREATE INDEX IF NOT EXISTS idx_refresh_tokens_expires ON refresh_tokens(expires_at);

--- a/src/storage/postgres/postgres-refresh-token.storage.ts
+++ b/src/storage/postgres/postgres-refresh-token.storage.ts
@@ -1,0 +1,80 @@
+import { Inject, Injectable } from '@nestjs/common';
+import { Pool } from 'pg';
+
+import { IRefreshTokenStorage, RefreshTokenRow } from '../interfaces/refresh-token-storage.interface';
+import { PG_POOL } from './postgres.config';
+
+@Injectable()
+export class PostgresRefreshTokenStorage implements IRefreshTokenStorage {
+  constructor(@Inject(PG_POOL) private readonly pool: Pool) {}
+
+  async create(input: {
+    userId: string;
+    email: string;
+    tokenHash: string;
+    familyId: string;
+    expiresAt: string;
+    userAgent?: string;
+  }): Promise<RefreshTokenRow> {
+    const result = await this.pool.query(
+      `INSERT INTO refresh_tokens (user_id, email, token_hash, family_id, expires_at, user_agent)
+       VALUES ($1, $2, $3, $4, $5, $6)
+       RETURNING token_id, user_id, email, token_hash, family_id, expires_at, created_at, revoked_at, replaced_by, user_agent`,
+      [input.userId, input.email, input.tokenHash, input.familyId, input.expiresAt, input.userAgent ?? null],
+    );
+    return mapRow(result.rows[0]);
+  }
+
+  async findByHash(tokenHash: string): Promise<RefreshTokenRow | null> {
+    const result = await this.pool.query(
+      `SELECT token_id, user_id, email, token_hash, family_id, expires_at, created_at, revoked_at, replaced_by, user_agent
+       FROM refresh_tokens
+       WHERE token_hash = $1`,
+      [tokenHash],
+    );
+    return result.rows.length ? mapRow(result.rows[0]) : null;
+  }
+
+  async revoke(tokenId: string, replacedBy?: string): Promise<void> {
+    await this.pool.query(
+      `UPDATE refresh_tokens
+       SET revoked_at = NOW(), replaced_by = COALESCE($2, replaced_by)
+       WHERE token_id = $1 AND revoked_at IS NULL`,
+      [tokenId, replacedBy ?? null],
+    );
+  }
+
+  async revokeFamily(familyId: string): Promise<void> {
+    await this.pool.query(
+      'UPDATE refresh_tokens SET revoked_at = NOW() WHERE family_id = $1 AND revoked_at IS NULL',
+      [familyId],
+    );
+  }
+
+  async revokeAllForUser(userId: string): Promise<void> {
+    await this.pool.query(
+      'UPDATE refresh_tokens SET revoked_at = NOW() WHERE user_id = $1 AND revoked_at IS NULL',
+      [userId],
+    );
+  }
+
+  async deleteExpired(): Promise<number> {
+    const result = await this.pool.query('DELETE FROM refresh_tokens WHERE expires_at <= NOW()');
+    return result.rowCount ?? 0;
+  }
+}
+
+function mapRow(row: any): RefreshTokenRow {
+  return {
+    tokenId: row.token_id,
+    userId: row.user_id,
+    email: row.email,
+    tokenHash: row.token_hash,
+    familyId: row.family_id,
+    expiresAt: row.expires_at?.toISOString?.() ?? row.expires_at,
+    createdAt: row.created_at?.toISOString?.() ?? row.created_at,
+    revokedAt: row.revoked_at?.toISOString?.() ?? row.revoked_at ?? null,
+    replacedBy: row.replaced_by ?? null,
+    userAgent: row.user_agent ?? null,
+  };
+}

--- a/src/storage/storage.module.ts
+++ b/src/storage/storage.module.ts
@@ -8,6 +8,7 @@ import { PROVISIONER_STORAGE } from './interfaces/provisioner-storage.interface'
 import { SSO_IDENTITY_STORAGE } from './interfaces/sso-identity-storage.interface';
 import { USER_PROVISIONER_STORAGE } from './interfaces/user-provisioner-storage.interface';
 import { PROVIDER_ARCHIVE_STORAGE } from './interfaces/provider-archive-storage.interface';
+import { REFRESH_TOKEN_STORAGE } from './interfaces/refresh-token-storage.interface';
 import { OFFICIATING_STORAGE } from './interfaces/officiating-storage.interface';
 import { SANCTIONING_STORAGE } from './interfaces/sanctioning-storage.interface';
 import { BOLT_HISTORY_STORAGE } from './interfaces/bolt-history.interface';
@@ -32,6 +33,7 @@ import { PostgresProvisionerStorage } from './postgres/postgres-provisioner.stor
 import { PostgresSsoIdentityStorage } from './postgres/postgres-sso-identity.storage';
 import { PostgresUserProvisionerStorage } from './postgres/postgres-user-provisioner.storage';
 import { PostgresProviderArchiveStorage } from './postgres/postgres-provider-archive.storage';
+import { PostgresRefreshTokenStorage } from './postgres/postgres-refresh-token.storage';
 import { PostgresSanctioningStorage } from './postgres/postgres-sanctioning.storage';
 import { PostgresOfficiatingStorage } from './postgres/postgres-officiating.storage';
 import { PostgresAuditStorage } from './postgres/postgres-audit.storage';
@@ -102,6 +104,7 @@ const ssoIdentityStorageProvider = makeStorageProvider(SSO_IDENTITY_STORAGE, Pos
 const userProvisionerStorageProvider = makeStorageProvider(USER_PROVISIONER_STORAGE, PostgresUserProvisionerStorage);
 const providerArchiveStorageProvider = makeStorageProvider(PROVIDER_ARCHIVE_STORAGE, PostgresProviderArchiveStorage);
 const policyStorageProvider = makeStorageProvider(POLICY_STORAGE, PostgresPolicyStorage);
+const refreshTokenStorageProvider = makeStorageProvider(REFRESH_TOKEN_STORAGE, PostgresRefreshTokenStorage);
 
 @Global()
 @Module({
@@ -132,6 +135,7 @@ const policyStorageProvider = makeStorageProvider(POLICY_STORAGE, PostgresPolicy
     userProvisionerStorageProvider,
     providerArchiveStorageProvider,
     policyStorageProvider,
+    refreshTokenStorageProvider,
     TournamentStorageService,
   ],
   exports: [
@@ -159,6 +163,7 @@ const policyStorageProvider = makeStorageProvider(POLICY_STORAGE, PostgresPolicy
     USER_PROVISIONER_STORAGE,
     PROVIDER_ARCHIVE_STORAGE,
     POLICY_STORAGE,
+    REFRESH_TOKEN_STORAGE,
     TournamentStorageService,
   ],
 })


### PR DESCRIPTION
## Why

Auth was **access-token-only** — every JWT expiry forced a full re-login, with no refresh mechanism. Surfaced by clubx@ionsport.com / BOBOCA (IONSport provisioner): the decoded session token was a 1-day access token with no refresh token anywhere in browser storage or on the wire. (The separate "2-hour" reports were the SSO-handoff path inheriting `JWT_VALIDITY=2h`, already fixed in `e690cd4`.)

## What

Adds a rotating refresh-token model so sessions survive a multi-day event with silent renewal.

- **Access token shortened 1d → 4h**; new **30-day rotating refresh token**.
- `refresh_tokens` table (**migration `031`**, `AFFECTS: admin` — additive new table) stores **SHA-256 hashes only**, never plaintext.
- `RefreshTokenService` — issue / rotate / revoke. Each refresh mints a new token in the same `family_id` and revokes the old one; **replaying an already-rotated token revokes the whole family** (reuse/theft detection).
- `POST /auth/refresh` (rotate) and `POST /auth/logout` (revoke), both `@Public` (the token is the credential).
- Password reset / admin reset now revoke **all** of a user's sessions.
- SSO provisioner handoff issues a refresh token too (parity with password login).

## Design notes

- Refresh token is returned in the JSON body (TMX stores it in `localStorage`), **not** an httpOnly cookie: CFS CORS is `origin:'*'` with no credentials and `cookie-parser` is uninstalled, so cookies would force a CORS allowlist + dep install + CSRF work across every web client. Risk is bounded by short access TTL + rotation + reuse-detection + server-side revocation.
- Storage is Postgres-only (DI symbol `REFRESH_TOKEN_STORAGE`).

## ⚠ Rollout

Ship **with** the matching TMX PR (CourtHive/TMX#1084). TMX is a PWA — a stale cached client hitting this server would get 4h access tokens with no silent refresh (→ 4h logouts). Deploying the ecosystem together avoids this.

## Tests

`tsc --noEmit` clean · `eslint --max-warnings 0` clean · **jest 844/844** (25 new, incl. `RefreshTokenService` rotation/reuse-detection coverage).

Pairs with: CourtHive/TMX#1084