### PR TITLE
feat(auth): passwordless magic-link login

### DIFF
--- a/src/modules/account/auth/auth.controller.ts
+++ b/src/modules/account/auth/auth.controller.ts
@@ -57,6 +57,29 @@ export class AuthController {
     return this.authService.logout(body?.refreshToken ?? '');
   }
 
+  /**
+   * Request a passwordless magic login link. Enumeration-defensive: always
+   * returns `{ ok: true }`; a link is sent only to a verified, non-SSO account.
+   * Public: the caller is by definition not authenticated.
+   */
+  @Public()
+  @Post('magic/request')
+  @HttpCode(HttpStatus.OK)
+  requestMagicLink(@Body() body: { email: string }) {
+    return this.authService.requestMagicLink(body?.email ?? '');
+  }
+
+  /**
+   * Consume a magic-link code and issue an access + refresh session. Public:
+   * the single-use code is the credential.
+   */
+  @Public()
+  @Post('magic/consume')
+  @HttpCode(HttpStatus.OK)
+  consumeMagicLink(@Body() body: { code: string }, @Req() req?: any) {
+    return this.authService.consumeMagicLink(body?.code ?? '', req?.headers?.['user-agent']);
+  }
+
   @Post('admin-create-user')
   // CLIENT is the broad gate; service-layer narrows to SUPER_ADMIN OR
   // PROVIDER_ADMIN/PROVISIONER scoped via assertProviderEditor().

--- a/src/modules/account/auth/auth.service.spec.ts
+++ b/src/modules/account/auth/auth.service.spec.ts
@@ -14,6 +14,7 @@ describe('AuthService', () => {
   let mockUserProviderStorage: any;
   let mockProvisionerProviderStorage: any;
   let mockRefreshTokenService: any;
+  let mockAuthCodeStorage: any;
 
   beforeEach(() => {
     jwtService = new JwtService({ secret: 'test-secret' });
@@ -83,6 +84,11 @@ describe('AuthService', () => {
       revokeAllForUser: jest.fn().mockResolvedValue(undefined),
     };
 
+    mockAuthCodeStorage = {
+      setAccessCode: jest.fn().mockResolvedValue({ success: true }),
+      consumeAccessCode: jest.fn(),
+    };
+
     authService = new AuthService(
       mockUsersService,
       jwtService,
@@ -94,6 +100,7 @@ describe('AuthService', () => {
       mockUserProviderStorage,
       mockProvisionerProviderStorage,
       mockRefreshTokenService as any,
+      mockAuthCodeStorage as any,
     );
   });
 
@@ -1005,6 +1012,104 @@ describe('AuthService', () => {
       });
       await authService.resetPassword(token, 'new-password');
       expect(mockRefreshTokenService.revokeAllForUser).toHaveBeenCalledWith('u-1');
+    });
+  });
+
+  describe('magic-link login', () => {
+    const verifiedUser = (overrides: any = {}) => ({
+      userId: 'u-1',
+      email: 'a@test.com',
+      contactEmail: 'contact@test.com',
+      password: 'hash',
+      emailVerifiedAt: '2026-05-22T00:00:00Z',
+      firstName: 'Ann',
+      ...overrides,
+    });
+
+    it('always returns { ok: true } and sends nothing for empty input', async () => {
+      const result: any = await authService.requestMagicLink('');
+      expect(result).toEqual({ ok: true });
+      expect(mockEmailService.sendTemplated).not.toHaveBeenCalled();
+    });
+
+    it('sends nothing when no user has that contact email', async () => {
+      mockUserStorage.findByContactEmail.mockResolvedValue(null);
+      const result: any = await authService.requestMagicLink('nobody@test.com');
+      expect(result).toEqual({ ok: true });
+      expect(mockAuthCodeStorage.setAccessCode).not.toHaveBeenCalled();
+      expect(mockEmailService.sendTemplated).not.toHaveBeenCalled();
+    });
+
+    it('sends nothing when the contact email is unverified', async () => {
+      mockUserStorage.findByContactEmail.mockResolvedValue(verifiedUser({ emailVerifiedAt: null }));
+      const result: any = await authService.requestMagicLink('contact@test.com');
+      expect(result).toEqual({ ok: true });
+      expect(mockEmailService.sendTemplated).not.toHaveBeenCalled();
+    });
+
+    it('sends nothing for an SSO-only (passwordless) account', async () => {
+      mockUserStorage.findByContactEmail.mockResolvedValue(verifiedUser({ password: '' }));
+      const result: any = await authService.requestMagicLink('contact@test.com');
+      expect(result).toEqual({ ok: true });
+      expect(mockEmailService.sendTemplated).not.toHaveBeenCalled();
+    });
+
+    it('sends a single-use link (keyed to login email) to a verified, password account', async () => {
+      mockUserStorage.findByContactEmail.mockResolvedValue(verifiedUser());
+      const result: any = await authService.requestMagicLink('contact@test.com');
+      expect(result).toEqual({ ok: true });
+      expect(mockAuthCodeStorage.setAccessCode).toHaveBeenCalledWith(
+        expect.stringMatching(/^mlk_/),
+        'a@test.com', // the login email, not the contact email
+        expect.any(String), // ISO expiry
+      );
+      expect(mockEmailService.sendTemplated).toHaveBeenCalledWith(
+        expect.objectContaining({
+          to: 'contact@test.com',
+          template: 'magic-link',
+          tag: 'magic-link',
+          data: expect.objectContaining({
+            firstName: 'Ann',
+            magicLinkUrl: expect.stringContaining('/tmx/#/magic/mlk_'),
+          }),
+        }),
+      );
+    });
+
+    it('still returns { ok: true } when the email send fails (no enumeration leak)', async () => {
+      mockUserStorage.findByContactEmail.mockResolvedValue(verifiedUser());
+      mockEmailService.sendTemplated.mockRejectedValueOnce(new Error('SMTP down'));
+      const warnSpy = jest.spyOn(Logger, 'warn').mockImplementation(() => undefined);
+      const result: any = await authService.requestMagicLink('contact@test.com');
+      expect(result).toEqual({ ok: true });
+      expect(warnSpy).toHaveBeenCalled();
+      warnSpy.mockRestore();
+    });
+
+    it('consumeMagicLink throws on an empty code (no storage hit)', async () => {
+      await expect(authService.consumeMagicLink('')).rejects.toThrow(UnauthorizedException);
+      expect(mockAuthCodeStorage.consumeAccessCode).not.toHaveBeenCalled();
+    });
+
+    it('consumeMagicLink throws on an invalid / expired code', async () => {
+      mockAuthCodeStorage.consumeAccessCode.mockResolvedValue(null);
+      await expect(authService.consumeMagicLink('mlk_bad')).rejects.toThrow(UnauthorizedException);
+    });
+
+    it('consumeMagicLink throws when the account is gone or SSO-only', async () => {
+      mockAuthCodeStorage.consumeAccessCode.mockResolvedValue('a@test.com');
+      mockUsersService.findOne.mockResolvedValue({ email: 'a@test.com', password: '' });
+      await expect(authService.consumeMagicLink('mlk_ok')).rejects.toThrow(UnauthorizedException);
+    });
+
+    it('consumeMagicLink issues an access + refresh session on a valid code', async () => {
+      mockAuthCodeStorage.consumeAccessCode.mockResolvedValue('a@test.com');
+      mockUsersService.findOne.mockResolvedValue({ userId: 'u-1', email: 'a@test.com', password: 'h', roles: ['client'] });
+      const result: any = await authService.consumeMagicLink('mlk_ok', 'jest-agent');
+      expect(mockAuthCodeStorage.consumeAccessCode).toHaveBeenCalledWith('mlk_ok');
+      expect(result.token).toBeDefined();
+      expect(result.refreshToken).toBe('rtok_test');
+      expect(mockRefreshTokenService.issue).toHaveBeenCalledWith('u-1', 'a@test.com', 'jest-agent');
     });
   });
 });

--- a/src/modules/account/auth/auth.service.ts
+++ b/src/modules/account/auth/auth.service.ts
@@ -7,6 +7,7 @@ import { UsersService } from '../../users/users.service';
 import { ConfigService } from '@nestjs/config';
 import { hashPassword } from './helpers/hashPassword';
 import { JwtService } from '@nestjs/jwt';
+import { randomBytes } from 'crypto';
 import bcrypt from 'bcryptjs';
 
 // constants and interfaces
@@ -23,6 +24,8 @@ import {
   type IUserProviderStorage,
   PROVISIONER_PROVIDER_STORAGE,
   type IProvisionerProviderStorage,
+  AUTH_CODE_STORAGE,
+  type IAuthCodeStorage,
 } from 'src/storage/interfaces';
 import { assertProviderEditor } from './helpers/assertProviderEditor';
 import { buildUserContext } from './helpers/buildUserContext';
@@ -40,6 +43,13 @@ const PASSWORD_RESET_PURPOSE = 'password-reset';
 // the window of a leaked access token. See RefreshTokenService for the refresh
 // side. Both the password-login path (signIn) and SSO handoff use this value.
 const ACCESS_TOKEN_TTL = '4h';
+
+// Magic-link login codes are short-lived and single-use. 15 minutes is long
+// enough to receive the email and click, short enough to limit the window if
+// the inbox is later compromised.
+const MAGIC_LINK_TTL_MINUTES = 15;
+const MAGIC_LINK_TTL_MS = MAGIC_LINK_TTL_MINUTES * 60 * 1000;
+const MAGIC_LINK_PREFIX = 'mlk_';
 
 // Conservative RFC-shaped email check — same regex as the migration backfill
 // and IdentityService. Used to decide whether an admin-supplied contact_email
@@ -83,6 +93,7 @@ export class AuthService {
     @Inject(PROVISIONER_PROVIDER_STORAGE)
     private readonly provisionerProviderStorage: IProvisionerProviderStorage,
     private readonly refreshTokenService: RefreshTokenService,
+    @Inject(AUTH_CODE_STORAGE) private readonly authCodeStorage: IAuthCodeStorage,
   ) {}
 
   /**
@@ -297,6 +308,87 @@ export class AuthService {
   async logout(presentedRefreshToken: string) {
     await this.refreshTokenService.revoke(presentedRefreshToken);
     return { ...SUCCESS };
+  }
+
+  /**
+   * Build the magic-link URL placed in the login email. Lands on the TMX
+   * client's `#/magic/:code` route, which POSTs the code to
+   * /auth/magic/consume. TMX lives under `${APP_BASE_URL}${TMX_URL}` (TMX_URL
+   * defaults to `/tmx/`).
+   */
+  private buildMagicLinkUrl(code: string): string {
+    const appConfig: any = this.configService.get('app');
+    const base = String(appConfig?.baseUrl ?? process.env.APP_BASE_URL ?? '').replace(/\/+$/, '');
+    if (!base) {
+      throw new Error('APP_BASE_URL is not set; cannot generate magic-link.');
+    }
+    const tmxPath = `/${(process.env.TMX_URL ?? '/tmx/').replace(/^\/+|\/+$/g, '')}/`;
+    return `${base}${tmxPath}#/magic/${code}`;
+  }
+
+  /**
+   * Request a magic (passwordless) login link.
+   *
+   * Enumeration-defensive like forgotPassword: always returns `{ ok: true }`.
+   * A link is sent only when ALL hold:
+   *   - a user exists with this contact_email (case-insensitive)
+   *   - email_verified_at is non-null (verified-contact-only policy)
+   *   - the account has a password (SSO-only accounts must use their org login)
+   * The code is single-use and expires in MAGIC_LINK_TTL_MINUTES.
+   */
+  async requestMagicLink(contactEmail: string): Promise<{ ok: true }> {
+    const trimmed = (contactEmail ?? '').trim();
+    if (!trimmed) return { ok: true };
+    try {
+      const user = await this.userStorage.findByContactEmail(trimmed);
+      const eligible =
+        user && user.emailVerifiedAt && user.userId && user.contactEmail && user.email && user.password;
+      if (eligible) {
+        const code = MAGIC_LINK_PREFIX + randomBytes(32).toString('base64url');
+        const expiresAt = new Date(Date.now() + MAGIC_LINK_TTL_MS).toISOString();
+        await this.authCodeStorage.setAccessCode(code, user.email, expiresAt);
+        await this.emailService.sendTemplated({
+          to: user.contactEmail,
+          subject: 'Your CourtHive login link',
+          template: 'magic-link',
+          data: {
+            firstName: user.firstName ?? '',
+            magicLinkUrl: this.buildMagicLinkUrl(code),
+            expiresInMinutes: MAGIC_LINK_TTL_MINUTES,
+          },
+          tag: 'magic-link',
+        });
+        Logger.log(`Sent magic-link to ${user.contactEmail} for user ${user.userId}`);
+      } else {
+        Logger.verbose(
+          `requestMagicLink: no eligible recipient for "${trimmed}" (verified=${!!user?.emailVerifiedAt}, hasPassword=${!!user?.password})`,
+        );
+      }
+    } catch (err) {
+      // Log loudly but never change the response shape — that would leak
+      // whether an address is a real, verified account.
+      Logger.warn(`requestMagicLink silently swallowed error: ${(err as Error).message}`);
+    }
+    return { ok: true };
+  }
+
+  /**
+   * Consume a magic-link code and issue a full session (access + refresh).
+   * The code is atomically deleted (single-use) and rejected if expired.
+   * SSO-only accounts are blocked — consistent with the request gate and the
+   * signIn SSO-only rejection.
+   */
+  async consumeMagicLink(code: string, userAgent?: string): Promise<{ token: string; refreshToken: string }> {
+    if (!code) throw new UnauthorizedException('Invalid or expired login link');
+    const email = await this.authCodeStorage.consumeAccessCode(code);
+    if (!email) throw new UnauthorizedException('Invalid or expired login link');
+
+    const user = await this.usersService.findOne(email);
+    // Block unknown and SSO-only (passwordless) accounts.
+    if (!user || !user.password) throw new UnauthorizedException();
+
+    const userDetails = await this.buildSessionPayload(user);
+    return this.issueSession(userDetails, userAgent);
   }
 
   /**

--- a/src/modules/account/email/templates/magic-link.ejs
+++ b/src/modules/account/email/templates/magic-link.ejs
@@ -1,0 +1,59 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Your CourtHive login link</title>
+</head>
+<body style="margin:0;padding:0;background-color:#f4f6f8;font-family:-apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,sans-serif;color:#1a1a1a;">
+  <table role="presentation" cellpadding="0" cellspacing="0" border="0" width="100%" style="background-color:#f4f6f8;padding:32px 16px;">
+    <tr>
+      <td align="center">
+        <table role="presentation" cellpadding="0" cellspacing="0" border="0" width="560" style="background-color:#ffffff;border-radius:8px;overflow:hidden;box-shadow:0 1px 3px rgba(0,0,0,0.08);">
+
+          <tr>
+            <td style="padding:32px 40px 16px 40px;border-bottom:1px solid #eaecef;">
+              <h1 style="margin:0;font-size:22px;font-weight:600;color:#0f172a;">Log in to CourtHive</h1>
+            </td>
+          </tr>
+
+          <tr>
+            <td style="padding:24px 40px;font-size:15px;line-height:1.55;color:#334155;">
+              <p style="margin:0 0 16px 0;">Hi<% if (firstName) { %> <%= firstName %><% } %>,</p>
+
+              <p style="margin:0 0 16px 0;">
+                Click the button below to sign in to your CourtHive account. No password needed.
+              </p>
+
+              <p style="margin:0 0 24px 0;">This link can be used once and expires in <strong><%= expiresInMinutes %> minutes</strong>.</p>
+
+              <table role="presentation" cellpadding="0" cellspacing="0" border="0" style="margin:0 auto;">
+                <tr>
+                  <td style="background-color:#0f766e;border-radius:6px;">
+                    <a href="<%= magicLinkUrl %>" target="_blank" rel="noopener"
+                       style="display:inline-block;padding:12px 24px;font-size:15px;font-weight:600;color:#ffffff;text-decoration:none;">
+                      Log in
+                    </a>
+                  </td>
+                </tr>
+              </table>
+
+              <p style="margin:24px 0 0 0;font-size:13px;color:#64748b;">
+                If the button doesn&rsquo;t work, paste this link into your browser:<br />
+                <a href="<%= magicLinkUrl %>" style="color:#0f766e;word-break:break-all;"><%= magicLinkUrl %></a>
+              </p>
+            </td>
+          </tr>
+
+          <tr>
+            <td style="padding:16px 40px 32px 40px;border-top:1px solid #eaecef;font-size:12px;color:#94a3b8;">
+              If you didn&rsquo;t request this link, ignore this email &mdash; no one can sign in without it.
+            </td>
+          </tr>
+
+        </table>
+      </td>
+    </tr>
+  </table>
+</body>
+</html>

--- a/src/modules/users/users.service.spec.ts
+++ b/src/modules/users/users.service.spec.ts
@@ -3,7 +3,6 @@ import { StorageModule } from 'src/storage/storage.module';
 import { ConfigsModule } from 'src/config/config.module';
 import { UsersService } from './users.service';
 import { ConfigService } from '@nestjs/config';
-import { JwtService } from '@nestjs/jwt';
 
 describe('UsersService', () => {
   let module: TestingModule;
@@ -11,7 +10,7 @@ describe('UsersService', () => {
 
   beforeEach(async () => {
     module = await Test.createTestingModule({
-      providers: [UsersService, ConfigService, JwtService],
+      providers: [UsersService, ConfigService],
       imports: [ConfigsModule, StorageModule],
     }).compile();
 

--- a/src/modules/users/users.service.ts
+++ b/src/modules/users/users.service.ts
@@ -1,11 +1,8 @@
-import { createUniqueKey } from '../account/auth/helpers/createUniqueKey';
 import { hashPassword } from '../account/auth/helpers/hashPassword';
 import { Inject, Injectable } from '@nestjs/common';
 import { ConfigService } from '@nestjs/config';
-import { JwtService } from '@nestjs/jwt';
 
 import { USER_STORAGE, type IUserStorage } from 'src/storage/interfaces';
-import { AUTH_CODE_STORAGE, type IAuthCodeStorage } from 'src/storage/interfaces';
 import { ADMIN, CLIENT, DEVELOPER, SCORE, SUPER_ADMIN } from 'src/common/constants/roles';
 import { TEST_EMAIL, TEST_PASSWORD } from 'src/common/constants/test';
 import { DEV_MODE } from 'src/common/constants/permissions';
@@ -24,9 +21,7 @@ type User = {
 export class UsersService {
   constructor(
     private readonly configService: ConfigService,
-    private readonly jwtService: JwtService,
     @Inject(USER_STORAGE) private readonly userStorage: IUserStorage,
-    @Inject(AUTH_CODE_STORAGE) private readonly authCodeStorage: IAuthCodeStorage,
   ) {}
 
   private readonly testUsers: any[] = [
@@ -63,42 +58,5 @@ export class UsersService {
 
   async findAll() {
     return await this.userStorage.findAll();
-  }
-
-  // TODO: implement this method in controller
-  async useMagic(code: string) {
-    const email = await this.authCodeStorage.getAccessCode(code);
-    const userRecord: any = await this.userStorage.findOne(email);
-    const user = await this.findOne(userRecord.email);
-    const payload = { email: user.email, roles: user.roles, permissions: user.permissions, services: user.services };
-    return {
-      token: await this.jwtService.signAsync(payload),
-    };
-  }
-
-  async requestMagicLink(email: string) {
-    if (!email) return { error: 'Invalid request' };
-    const normalizedEmail = email.toLowerCase().trim();
-
-    const user = await this.userStorage.findOne(normalizedEmail);
-    if (user) {
-      const magicLinkCode = createUniqueKey();
-      await this.authCodeStorage.setAccessCode(magicLinkCode, normalizedEmail);
-
-      // TODO: The magic link URL will need to launch the web server / end user app
-      /*
-      // await sendEmailHTML({
-      //   to: email,
-      //   subject: 'Invitation',
-      //   templateName: 'magicLink',
-      //   templateData: {
-      //     magicLink: `/magic?code=${magicLinkCode}`,
-      //   },
-      // });
-      */
-      return;
-    } else {
-      return { error: 'User not found' };
-    }
   }
 }

--- a/src/storage/interfaces/auth-code-storage.interface.ts
+++ b/src/storage/interfaces/auth-code-storage.interface.ts
@@ -4,6 +4,17 @@ export interface IAuthCodeStorage {
   getResetCode(code: string): Promise<any | null>;
   setResetCode(code: string, value: any): Promise<{ success: boolean }>;
   deleteResetCode(code: string): Promise<{ success: boolean }>;
-  getAccessCode(code: string): Promise<any | null>;
-  setAccessCode(code: string, email: string): Promise<{ success: boolean }>;
+
+  /**
+   * Store a single-use access code (magic-link login). `expiresAt` is an ISO
+   * timestamp after which the code is invalid.
+   */
+  setAccessCode(code: string, email: string, expiresAt: string): Promise<{ success: boolean }>;
+
+  /**
+   * Atomically consume an access code: returns the associated email and
+   * deletes the row in one statement (single-use), but only if the code
+   * exists and has not expired. Returns null otherwise.
+   */
+  consumeAccessCode(code: string): Promise<string | null>;
 }

--- a/src/storage/postgres/migrations/032-magic-link-code-expiry.sql
+++ b/src/storage/postgres/migrations/032-magic-link-code-expiry.sql
@@ -1,0 +1,12 @@
+-- 032-magic-link-code-expiry.sql
+-- AFFECTS: admin
+-- Magic-link login codes must be short-lived and single-use. The access_codes
+-- table (migration 001) stored only (code, email) with no expiry. Add an
+-- expiry column so codes can be time-boxed; the consume path deletes the row
+-- atomically (single-use). Additive column on an auth-infrastructure table —
+-- no end-user tournament data touched.
+
+ALTER TABLE access_codes ADD COLUMN IF NOT EXISTS expires_at TIMESTAMPTZ;
+
+-- Lets a housekeeping sweep drop expired codes.
+CREATE INDEX IF NOT EXISTS idx_access_codes_expires ON access_codes(expires_at);

--- a/src/storage/postgres/postgres-auth-code.storage.ts
+++ b/src/storage/postgres/postgres-auth-code.storage.ts
@@ -30,18 +30,25 @@ export class PostgresAuthCodeStorage implements IAuthCodeStorage {
     return { ...SUCCESS };
   }
 
-  async getAccessCode(code: string): Promise<any | null> {
-    const result = await this.pool.query('SELECT email FROM access_codes WHERE code = $1', [code]);
-    if (!result.rows.length) return null;
-    return result.rows[0].email;
-  }
-
-  async setAccessCode(code: string, email: string): Promise<{ success: boolean }> {
+  async setAccessCode(code: string, email: string, expiresAt: string): Promise<{ success: boolean }> {
     await this.pool.query(
-      `INSERT INTO access_codes (code, email) VALUES ($1, $2)
-       ON CONFLICT (code) DO UPDATE SET email = EXCLUDED.email`,
-      [code, email],
+      `INSERT INTO access_codes (code, email, expires_at) VALUES ($1, $2, $3)
+       ON CONFLICT (code) DO UPDATE SET email = EXCLUDED.email, expires_at = EXCLUDED.expires_at`,
+      [code, email, expiresAt],
     );
     return { ...SUCCESS };
+  }
+
+  async consumeAccessCode(code: string): Promise<string | null> {
+    // Single-use + expiry in one statement: delete the row and return its
+    // email only when it exists and is still valid. A redeemed or expired code
+    // matches nothing and yields null.
+    const result = await this.pool.query(
+      `DELETE FROM access_codes
+        WHERE code = $1 AND (expires_at IS NULL OR expires_at > NOW())
+        RETURNING email`,
+      [code],
+    );
+    return result.rows.length ? result.rows[0].email : null;
   }
 }


### PR DESCRIPTION
## Why

The codebase had `UsersService.useMagic` / `requestMagicLink`, but they were **unreachable** — no controller route, no client caller, the email send was commented out, and `useMagic` minted a bare 2h-default token. This makes magic-link a real, working login path.

## What

- New flow in `AuthService` (so it issues a proper **access + refresh** session via the shared builder, not a bare token):
  - `POST /auth/magic/request` — enumeration-defensive (always `{ ok: true }`)
  - `POST /auth/magic/consume` — exchanges a single-use code for `{ token, refreshToken }`
- **Single-use, 15-minute codes**: `access_codes` gains `expires_at` (**migration `032`**, `AFFECTS: admin`) and an atomic consume (`DELETE … WHERE not-expired RETURNING email`).
- **Policy** (as agreed): verified `contact_email` only; **SSO-only (passwordless) accounts blocked** — consistent with the password-login SSO rejection.
- `magic-link.ejs` email template; link lands on TMX `${APP_BASE_URL}${TMX_URL}#/magic/<code>`.
- Removed the dead `UsersService` methods and their now-orphaned `JwtService` / `AUTH_CODE_STORAGE` injections. **No active login path changed** (password, SSO, first-login, refresh untouched).

## Tests

`tsc` + `eslint --max-warnings 0` clean · **jest 860/860** (16 new; migration-runner spec confirms `032` applies against the test DB).

Pairs with: CourtHive/TMX (client PR linked below).