### PR TITLE
feat: capture draw-deletion audit trail via factory AUDIT topic (CODES Phase 6)

### DIFF
--- a/src/modules/audit/audit.controller.ts
+++ b/src/modules/audit/audit.controller.ts
@@ -28,4 +28,18 @@ export class AuditController {
   getDeletedTournaments(@Body() body: { from?: string; to?: string; limit?: number }) {
     return this.auditService.getDeletedTournaments(body);
   }
+
+  /**
+   * Get audit rows for deleted draw definitions. Each row's
+   * metadata.deletedDrawSnapshot contains the full drawDefinition body so the
+   * deletion is recoverable. Super-admin only.
+   */
+  @Post('deleted-draws')
+  @Roles([SUPER_ADMIN])
+  @HttpCode(HttpStatus.OK)
+  getDeletedDraws(
+    @Body() body: { tournamentId?: string; eventId?: string; from?: string; to?: string; limit?: number },
+  ) {
+    return this.auditService.getDeletedDraws(body);
+  }
 }

--- a/src/modules/audit/audit.service.spec.ts
+++ b/src/modules/audit/audit.service.spec.ts
@@ -147,4 +147,97 @@ describe('AuditService', () => {
       expect(mockStorage.findByActionType).toHaveBeenCalledWith('DELETE_TOURNAMENT', undefined);
     });
   });
+
+  describe('recordDrawDeletion', () => {
+    it('appends a DELETE_DRAW row with the snapshot in metadata', async () => {
+      const snapshot = { drawId: 'd-1', drawName: 'MD32', drawType: 'SINGLE_ELIMINATION', structures: [] };
+      await service.recordDrawDeletion({
+        tournamentId: 't-1',
+        eventId: 'e-1',
+        drawId: 'd-1',
+        drawName: 'MD32',
+        drawType: 'SINGLE_ELIMINATION',
+        deletedDrawSnapshot: snapshot,
+        userId: 'user-1',
+        userEmail: 'admin@test.com',
+      });
+
+      expect(mockStorage.append).toHaveBeenCalledTimes(1);
+      const row = mockStorage.append.mock.calls[0][0];
+      expect(row.actionType).toBe('DELETE_DRAW');
+      expect(row.tournamentId).toBe('t-1');
+      expect(row.metadata.deletedDrawSnapshot).toEqual(snapshot);
+      expect(row.metadata.eventId).toBe('e-1');
+      expect(row.metadata.drawId).toBe('d-1');
+      expect(row.methods[0].method).toBe('deleteDrawDefinitions');
+      expect(row.methods[0].params.drawIds).toEqual(['d-1']);
+    });
+
+    it('does not throw when storage.append fails (fail-soft)', async () => {
+      mockStorage.append.mockRejectedValue(new Error('DB down'));
+      await expect(
+        service.recordDrawDeletion({
+          tournamentId: 't-1',
+          drawId: 'd-1',
+          deletedDrawSnapshot: { drawId: 'd-1' },
+        }),
+      ).resolves.not.toThrow();
+    });
+
+    it('preserves auditData when provided', async () => {
+      await service.recordDrawDeletion({
+        tournamentId: 't-1',
+        drawId: 'd-1',
+        deletedDrawSnapshot: { drawId: 'd-1' },
+        auditData: { reason: 'user-initiated' },
+      });
+      const row = mockStorage.append.mock.calls[0][0];
+      expect(row.metadata.auditData).toEqual({ reason: 'user-initiated' });
+    });
+
+    it('omits auditData when not provided', async () => {
+      await service.recordDrawDeletion({
+        tournamentId: 't-1',
+        drawId: 'd-1',
+        deletedDrawSnapshot: { drawId: 'd-1' },
+      });
+      const row = mockStorage.append.mock.calls[0][0];
+      expect(row.metadata.auditData).toBeUndefined();
+    });
+  });
+
+  describe('getDeletedDraws', () => {
+    it('queries by tournamentId and filters to DELETE_DRAW', async () => {
+      mockStorage.findByTournamentId.mockResolvedValue([
+        { auditId: 'a-1', actionType: 'DELETE_DRAW', metadata: { drawId: 'd-1', eventId: 'e-1' } },
+        { auditId: 'a-2', actionType: 'MUTATION', metadata: {} },
+      ]);
+
+      const result: any = await service.getDeletedDraws({ tournamentId: 't-1' });
+      expect(result.success).toBe(true);
+      expect(result.auditRows).toHaveLength(1);
+      expect(result.auditRows[0].actionType).toBe('DELETE_DRAW');
+      expect(mockStorage.findByTournamentId).toHaveBeenCalledWith('t-1', expect.any(Object));
+    });
+
+    it('queries by action type when no tournamentId is given', async () => {
+      mockStorage.findByActionType.mockResolvedValue([
+        { auditId: 'a-1', actionType: 'DELETE_DRAW', metadata: { drawId: 'd-1', eventId: 'e-1' } },
+      ]);
+      const result: any = await service.getDeletedDraws();
+      expect(result.success).toBe(true);
+      expect(result.auditRows).toHaveLength(1);
+      expect(mockStorage.findByActionType).toHaveBeenCalledWith('DELETE_DRAW', undefined);
+    });
+
+    it('filters by eventId in metadata when provided', async () => {
+      mockStorage.findByActionType.mockResolvedValue([
+        { auditId: 'a-1', actionType: 'DELETE_DRAW', metadata: { drawId: 'd-1', eventId: 'e-1' } },
+        { auditId: 'a-2', actionType: 'DELETE_DRAW', metadata: { drawId: 'd-2', eventId: 'e-2' } },
+      ]);
+      const result: any = await service.getDeletedDraws({ eventId: 'e-2' });
+      expect(result.auditRows).toHaveLength(1);
+      expect(result.auditRows[0].metadata.drawId).toBe('d-2');
+    });
+  });
 });

--- a/src/modules/audit/audit.service.ts
+++ b/src/modules/audit/audit.service.ts
@@ -154,6 +154,66 @@ export class AuditService implements OnModuleInit, OnModuleDestroy {
   }
 
   /**
+   * Record one draw-deletion event per deleted drawDefinition.
+   *
+   * Called from the factory AUDIT topic subscription in getMutationEngine
+   * whenever deleteDrawDefinitions runs. The full drawDefinition snapshot is
+   * stashed in metadata.deletedDrawDetail so the deletion is recoverable
+   * post-hoc. Fail-soft: errors are logged but never block the ack.
+   */
+  async recordDrawDeletion(params: {
+    tournamentId: string;
+    eventId?: string;
+    drawId: string;
+    drawName?: string;
+    drawType?: string;
+    deletedDrawSnapshot: Record<string, any>;
+    auditData?: Record<string, any>;
+    userId?: string;
+    userEmail?: string;
+    source?: string;
+  }): Promise<void> {
+    const {
+      tournamentId,
+      eventId,
+      drawId,
+      drawName,
+      drawType,
+      deletedDrawSnapshot,
+      auditData,
+      userId,
+      userEmail,
+      source,
+    } = params;
+
+    const row: AuditRow = {
+      auditId: tools.UUID(),
+      tournamentId,
+      userId,
+      userEmail,
+      source: source ?? 'tmx',
+      occurredAt: new Date().toISOString(),
+      actionType: 'DELETE_DRAW',
+      methods: [{ method: 'deleteDrawDefinitions', params: { drawIds: [drawId], eventId } }],
+      status: 'applied',
+      metadata: {
+        eventId,
+        drawId,
+        drawName,
+        drawType,
+        deletedDrawSnapshot,
+        ...(auditData ? { auditData } : {}),
+      },
+    };
+
+    try {
+      await this.auditStorage.append(row);
+    } catch (err: any) {
+      this.logger.error(`Failed to record draw deletion audit for ${tournamentId}/${drawId}: ${err.message}`);
+    }
+  }
+
+  /**
    * Record a tournament save event (REST save, not executionQueue).
    */
   async recordSave(params: { tournamentId: string; userId?: string; userEmail?: string }): Promise<void> {
@@ -197,6 +257,27 @@ export class AuditService implements OnModuleInit, OnModuleDestroy {
   }): Promise<{ success: boolean; auditRows: AuditRow[] }> {
     const rows = await this.auditStorage.findByActionType('DELETE_TOURNAMENT', params);
     return { success: true, auditRows: rows };
+  }
+
+  /**
+   * Return DELETE_DRAW audit rows, optionally filtered by tournamentId and/or
+   * eventId. The snapshot for each row sits in metadata.deletedDrawSnapshot.
+   */
+  async getDeletedDraws(params?: {
+    tournamentId?: string;
+    eventId?: string;
+    from?: string;
+    to?: string;
+    limit?: number;
+  }): Promise<{ success: boolean; auditRows: AuditRow[] }> {
+    const rows = params?.tournamentId
+      ? (await this.auditStorage.findByTournamentId(params.tournamentId, params)).filter(
+          (row) => row.actionType === 'DELETE_DRAW',
+        )
+      : await this.auditStorage.findByActionType('DELETE_DRAW', params);
+
+    const filtered = params?.eventId ? rows.filter((row) => row.metadata?.eventId === params.eventId) : rows;
+    return { success: true, auditRows: filtered };
   }
 
   // ── Prune ──

--- a/src/modules/factory/engines/getMutationEngine.ts
+++ b/src/modules/factory/engines/getMutationEngine.ts
@@ -1,4 +1,4 @@
-import { governors, asyncEngine, globalState, topicConstants } from 'tods-competition-factory';
+import { auditConstants, governors, asyncEngine, globalState, topicConstants } from 'tods-competition-factory';
 import asyncGlobalState from './asyncGlobalState';
 
 const traverse = true;
@@ -12,6 +12,11 @@ globalState.setGlobalSubscriptions({
     // any subscriptions that don't need access to cacheManager can go here
   },
 });
+// CODES Phase 6: the server is the canonical audit trail for drawDeletions.
+// The factory suppresses all local drawDeletions writes when this is true,
+// dispatches only the AUDIT topic notice. The AuditService subscription below
+// captures the snapshot.
+globalState.setAuditAuthorityServer(true);
 asyncGlobalState.createInstanceState(); // is there only one instance of asyncGlobalState?
 
 export function getMutationEngine(services?, publicNotices?: any[]) {
@@ -142,6 +147,42 @@ export function getMutationEngine(services?, publicNotices?: any[]) {
       [topicConstants.UNPUBLISH_TOURNAMENT]: (params) => {
         for (const item of params) {
           clearCache(item.tournamentId);
+        }
+      },
+      [topicConstants.AUDIT]: (params) => {
+        // Each params entry: { tournamentId, detail: auditTrail }
+        // auditTrail is an array of audit entries; deleteDrawDefinitions emits
+        // one entry per deleted draw with action=DELETE_DRAW_DEFINITIONS and
+        // payload.drawDefinitions being a single-element array of the snapshot.
+        const auditService = services?.auditService;
+        if (!auditService) return;
+        for (const item of params) {
+          const { tournamentId, detail } = item ?? {};
+          if (!tournamentId || !Array.isArray(detail)) continue;
+          for (const entry of detail) {
+            if (entry?.action !== auditConstants.DELETE_DRAW_DEFINITIONS) continue;
+            const drawDefinitions = entry?.payload?.drawDefinitions ?? [];
+            const eventId = entry?.payload?.eventId;
+            const auditData = entry?.payload?.auditData;
+            for (const drawDefinition of drawDefinitions) {
+              auditService
+                .recordDrawDeletion({
+                  tournamentId,
+                  eventId,
+                  drawId: drawDefinition?.drawId,
+                  drawName: drawDefinition?.drawName,
+                  drawType: drawDefinition?.drawType,
+                  deletedDrawSnapshot: drawDefinition,
+                  auditData,
+                  userId: services?.userId,
+                  userEmail: services?.userEmail,
+                  source: services?.auditSource,
+                })
+                .catch(() => {
+                  /* fail-soft — AuditService logs internally */
+                });
+            }
+          }
         }
       },
       [topicConstants.MODIFY_TOURNAMENT_DETAIL]: (params) => {

--- a/src/modules/factory/functions/private/executionQueue.ts
+++ b/src/modules/factory/functions/private/executionQueue.ts
@@ -39,7 +39,15 @@ export async function executionQueue(
       if (result.error) return result;
 
       const mutationEngine = getMutationEngine(
-        { ...services, cacheManager: deferredClearCache, tournamentStorageService: storage },
+        {
+          ...services,
+          cacheManager: deferredClearCache,
+          tournamentStorageService: storage,
+          auditService,
+          userId: payload?.userId,
+          userEmail: payload?.userEmail,
+          auditSource: payload?.auditSource?.type === 'provisioner' ? 'provisioner' : payload?.source ?? 'tmx',
+        },
         publicNotices,
       );
       mutationEngine.setState(result.tournamentRecords);

--- a/src/storage/interfaces/audit-storage.interface.ts
+++ b/src/storage/interfaces/audit-storage.interface.ts
@@ -13,7 +13,7 @@ export interface AuditRow {
   userEmail?: string;
   source?: string;
   occurredAt: string;
-  actionType: 'MUTATION' | 'DELETE_TOURNAMENT' | 'SAVE' | string;
+  actionType: 'MUTATION' | 'DELETE_TOURNAMENT' | 'DELETE_DRAW' | 'SAVE' | string;
   methods: Array<{ method: string; params?: any }>;
   status: 'applied' | 'rejected' | 'partial' | string;
   metadata?: Record<string, any>;


### PR DESCRIPTION
## Summary

CODES Phase 6 — server side. Companion to the factory [`feat!: drawDeletions opt-in + server-authoritative gating`](https://github.com/CourtHive/competition-factory/pull/new/feat/codes-phase-6-drawdeletions) PR. **Depends on factory >= 5.0.0-alpha.1 for the `auditAuthorityServer` engine flag.**

The factory's `deleteDrawDefinitions` already emitted a `topicConstants.AUDIT` notice carrying the full drawDefinition snapshot in `detail[].payload.drawDefinitions`. Until now the server dropped that notice on the floor; this PR wires it into the existing `AuditService`. **No new Postgres table** — the snapshot rides in the existing `audit_log.metadata` JSONB column.

## What changes

- `AuditService.recordDrawDeletion` — writes one `DELETE_DRAW` row per deleted draw with `metadata.deletedDrawSnapshot` holding the body
- `AuditService.getDeletedDraws` — queries by `tournamentId` or by action type, filterable by `eventId`
- `getMutationEngine` — subscribes to `topicConstants.AUDIT`, routes notices with `action=DELETE_DRAW_DEFINITIONS` into `recordDrawDeletion`; fail-soft
- `getMutationEngine` — calls `globalState.setAuditAuthorityServer(true)` once at module init so the factory suppresses its own local drawDeletions writes
- `executionQueue` — threads `auditService` + `userId` / `userEmail` / `auditSource` through the services bag so subscriptions can attribute audit rows
- `POST /audit/deleted-draws` (super-admin) — returns the audit rows; the snapshot in `metadata.deletedDrawSnapshot` makes deletions recoverable post-hoc

Restore endpoint (POST to re-insert the snapshot into the tournamentRecord and stamp `restored_at`) is **intentionally deferred** to a follow-up — needs its own permission/UX story.

## Why no new table

The original design doc sketched a dedicated `draw_deletion_audit` Postgres table. After surveying the codebase, the existing `AuditService` + `IAuditStorage` + `PostgresAuditStorage` already had every primitive needed: append-only ingest with retention pruning, per-tournament queries, per-actionType queries, and a JSONB `metadata` column. A dedicated table would have been redundant; the cost in operational complexity outweighed the marginal schema clarity. The `actionType: 'DELETE_DRAW'` discriminator and `metadata.deletedDrawSnapshot` JSONB carry everything the recovery query needs.

## Verification

- `pnpm lint` — green
- `pnpm test` — 97 suites / 861 pass / 0 fail (+7 new in `audit.service.spec.ts`, no regressions)
- `pnpm build` — green

## Test plan

- [ ] Factory PR merges + a `5.0.0-alpha.1` release is published / linked
- [ ] CI green
- [ ] Manual smoke: TMX user with super-admin role deletes a draw; `POST /audit/deleted-draws { tournamentId }` returns a row with `metadata.deletedDrawSnapshot` matching the deleted body
- [ ] Manual smoke: confirm the tournamentRecord no longer carries a `DRAW_DELETIONS` extension after a deletion (server-authoritative gating in effect)