### PR TITLE
ci: mirror sync-i18n workflow for admin-client en.json

### DIFF
--- a/.github/workflows/sync-i18n.yml
+++ b/.github/workflows/sync-i18n.yml
@@ -1,0 +1,95 @@
+name: sync-i18n
+
+# When the admin-client's bundled en.json changes on main, propagate
+# the additions / updates upstream to CourtHive/courthive-i18n. Same
+# pattern as TMX/.github/workflows/sync-i18n.yml and
+# courthive-public/.github/workflows/sync-i18n.yml — all three call
+# into courthive-i18n's `scripts/merge-source-en.cjs` so merge policy
+# lives in exactly one place.
+#
+# The admin-client is the SPA bundled by competition-factory-server
+# (admin/system/provisioner pages). Only the admin-client owns user-
+# facing strings inside this repo — server-side i18n (CFS email
+# templates etc.) syncs through its own path if/when added.
+#
+# Auth: the courthive-release-bot App needs Contents:Write +
+# Pull requests:Write on courthive-i18n (in addition to
+# competition-factory-server). Same RELEASE_BOT_CLIENT_ID +
+# RELEASE_BOT_PRIVATE_KEY secrets as the other consumers reuse.
+
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - admin-client/src/i18n/locales/en.json
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  sync:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Mint App token
+        id: app-token
+        uses: actions/create-github-app-token@v3
+        with:
+          client-id: ${{ secrets.RELEASE_BOT_CLIENT_ID }}
+          private-key: ${{ secrets.RELEASE_BOT_PRIVATE_KEY }}
+          owner: CourtHive
+          repositories: competition-factory-server,courthive-i18n
+
+      - name: Checkout competition-factory-server
+        uses: actions/checkout@v6
+        with:
+          path: source
+
+      - name: Checkout courthive-i18n
+        uses: actions/checkout@v6
+        with:
+          repository: CourtHive/courthive-i18n
+          token: ${{ steps.app-token.outputs.token }}
+          path: i18n
+          persist-credentials: true
+
+      - uses: actions/setup-node@v6
+        with:
+          node-version: 24
+
+      - name: Merge en.json into courthive-i18n
+        id: merge
+        working-directory: i18n
+        run: |
+          set +e
+          node scripts/merge-source-en.cjs \
+            --source ../source/admin-client/src/i18n/locales/en.json \
+            --label admin-client > /tmp/pr-body.md
+          code=$?
+          set -e
+          if [ "$code" -eq 2 ]; then
+            echo "skip=true" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          if [ "$code" -ne 0 ]; then
+            echo "merge script failed with exit $code" >&2
+            exit 1
+          fi
+          echo "skip=false" >> "$GITHUB_OUTPUT"
+
+      - name: Open / update PR on courthive-i18n
+        if: steps.merge.outputs.skip != 'true'
+        uses: peter-evans/create-pull-request@v8
+        with:
+          token: ${{ steps.app-token.outputs.token }}
+          path: i18n
+          base: main
+          branch: chore/sync-i18n-from-admin-client
+          delete-branch: true
+          commit-message: |
+            chore(i18n): sync en.json from admin-client
+
+            See PR body for the full list of added / updated keys.
+          title: 'chore(i18n): sync en.json from admin-client'
+          body-path: /tmp/pr-body.md


### PR DESCRIPTION
## Summary

Closes the asymmetry surfaced during the `/system` Audit tab work (PR #716, commit `0db89c4`): TMX and `courthive-public` both have a `sync-i18n.yml` workflow that auto-propagates `en.json` edits to `courthive-i18n`. CFS did not — so the new `system.audit.*` keys in `admin-client/src/i18n/locales/en.json` live only in admin-client and other locales fall back to English at runtime.

Adds the same workflow, pointing at `admin-client/src/i18n/locales/en.json` as the source path with label `admin-client`.

## What it does

On push to `main` touching the source path:

1. Mints a `courthive-release-bot` App token scoped to `competition-factory-server` + `courthive-i18n`.
2. Checks out CFS + courthive-i18n side-by-side.
3. Runs `courthive-i18n/scripts/merge-source-en.cjs --source ../source/admin-client/src/i18n/locales/en.json --label admin-client`.
4. Opens `chore/sync-i18n-from-admin-client` PR on courthive-i18n with the markdown summary of added / updated keys as the body.

## Auth

`RELEASE_BOT_CLIENT_ID` + `RELEASE_BOT_PRIVATE_KEY` secrets verified present on this repo via `gh secret list`. The courthive-release-bot App must already have `Contents:Write` + `Pull requests:Write` on `competition-factory-server` (used by `release-please.yml` here) and on `courthive-i18n` (used by TMX + courthive-public's sync workflows).

## Test plan

- [ ] On merge, manually trigger the workflow via `workflow_dispatch` to confirm the App token mints cleanly
- [ ] Re-save `admin-client/src/i18n/locales/en.json` (no-op whitespace) and push to main — workflow should open a no-changes PR on courthive-i18n (which the merge script's exit code 2 will skip)