### PR TITLE
chore(deps): bump tods-competition-factory to 5.0.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -86,7 +86,7 @@
     "reflect-metadata": "0.2.2",
     "rxjs": "7.8.2",
     "socket.io": "4.8.3",
-    "tods-competition-factory": "4.2.0",
+    "tods-competition-factory": "5.0.0",
     "tods-tmx-classic-converter": "3.0.5",
     "tslib": "^2.6.2",
     "@courthive/provider-config": "^0.3.0",


### PR DESCRIPTION
## Summary

- Bumps `tods-competition-factory` from `4.2.0` → `5.0.0` (published 2026-05-31)
- Server uses `asyncEngine` (per-request state isolation via `async_hooks`); CODES Phase 0-7 defaults to NATIVE write mode — verify production tournaments still round-trip cleanly
- See factory's [4.x → 5.0.0 migration guide](https://github.com/CourtHive/competition-factory/blob/master/documentation/docs/migration/4.x-to-5.0.0.md)

## Local verification

- `pnpm lint` — clean
- `pnpm check-types` — clean
- `pnpm test` — 1026 tests pass across 106 suites

## Test plan

- [ ] CI strip-link path resolves `5.0.0` from npm
- [ ] `pnpm test:e2e` against a staging Postgres
- [ ] Spot-check `/factory/save` round-trip on a real tournament