### PR TITLE
chore(deps): bump tods-competition-factory to 5.2.5 (IONSport schedule hydration fix)

### DIFF
--- a/package.json
+++ b/package.json
@@ -85,7 +85,7 @@
     "reflect-metadata": "0.2.2",
     "rxjs": "7.8.2",
     "socket.io": "4.8.3",
-    "tods-competition-factory": "5.2.4",
+    "tods-competition-factory": "5.2.5",
     "tods-tmx-classic-converter": "3.0.5",
     "tslib": "^2.6.2",
     "@courthive/provider-config": "^0.5.0",


### PR DESCRIPTION
## Summary
Bumps `tods-competition-factory` `5.2.4` → `5.2.5`.

5.2.5 ships [factory PR #4423](https://github.com/CourtHive/competition-factory/pull/4423) — the `addMatchUpContext` fix that preserves the hydrated `matchUp.schedule` (`venueName` / `courtName` / `venueAbbreviation` / `isoDateString` / `milliseconds` / `time` + applied embargo/publish-state filtering) under NATIVE schema-write mode.

CFS runs the `/factory/scheduledmatchups` hydration on prod, so **this bump is what restores the missing name fields** on the response courthive-public (and IONSport's integration) read. Without it, prod will keep returning the bare-bones `{ venueId, courtId, courtOrder, scheduledDate, scheduledTime }` shape that IONSport reported.

## Test plan
- [ ] CI green
- [ ] Deploy to prod
- [ ] Verify IONSport tournament `ccb37afb-039e-48a4-82d7-284830058812` — `/factory/scheduledmatchups` response should now carry `schedule.venueName: "Rick Macci Tennis Academy"` and `schedule.courtName: "Court N"` on each scheduled matchUp