### PR TITLE
fix(server): restore /tmx, /tmx-beta, /pub static serving (WS-17 step #3 follow-up)

### DIFF
--- a/src/modules/app/app.module.ts
+++ b/src/modules/app/app.module.ts
@@ -18,6 +18,7 @@ import { MessagingModule } from '../messaging/messaging.module';
 import { ProvidersModule } from '../providers/providers.module';
 import { StorageModule } from '../../storage/storage.module';
 import { ConfigsModule } from '../../config/config.module';
+import { ServeStaticModule } from '@nestjs/serve-static';
 import { FactoryModule } from '../factory/factory.module';
 import { I18nModule } from '../i18n/i18n.module';
 import { RuntimeConfigController } from './runtime-config.controller';
@@ -27,16 +28,30 @@ import { UsersModule } from '../users/users.module';
 import { AccountModule } from '../account/account.module';
 import { AppService } from './app.service';
 import { Module } from '@nestjs/common';
+import { join } from 'path';
 
 // Core modules — always loaded regardless of profile.
 //
-// The admin-client SPA used to be served here via
-//   ServeStaticModule.forRoot({ rootPath: join(process.cwd(), 'client') })
-// which exposed shared/client/admin/ at /admin. Removed 2026-06-06 (WS-17
-// step #3) — courthive-console (the wholesale relocation in courthive-ams/
-// client/) supersedes admin-client; NGINX serves /admin from
-// /var/www/courthive-console/ at the edge. See planning/AMS_DEPLOY_AND_RETIREMENT.md.
+// /tmx, /tmx-beta, /pub are served from `client/<sub>` on this server.
+// /admin used to be served the same way from `client/admin`, but as of
+// WS-17 step #3 (commit f27f168) that SPA is retired — its replacement
+// is courthive-console at `/console/`, served by NGINX at the edge from
+// /var/www/courthive-console/. See planning/AMS_DEPLOY_AND_RETIREMENT.md.
+//
+// The original WS-17 commit retired the whole `ServeStaticModule.forRoot
+// ({ rootPath: client })` block, which also took `/tmx`, `/tmx-beta` and
+// `/pub` down — the catch-all root was serving them too. Re-add the
+// module with per-path entries so admin stays retired but the other
+// three are restored.
+const clientRoot = join(process.cwd(), 'client');
+const staticClientModules = [
+  ServeStaticModule.forRoot({ rootPath: join(clientRoot, 'tmx'), serveRoot: '/tmx' }),
+  ServeStaticModule.forRoot({ rootPath: join(clientRoot, 'tmx-beta'), serveRoot: '/tmx-beta' }),
+  ServeStaticModule.forRoot({ rootPath: join(clientRoot, 'pub'), serveRoot: '/pub' }),
+];
+
 const coreModules = [
+  ...staticClientModules,
   StorageModule,
   ConfigsModule,
   FederationDataModule,


### PR DESCRIPTION
## Summary
[`f27f168`](https://github.com/CourtHive/competition-factory-server/commit/f27f168) (WS-17 step #3) retired the broad `ServeStaticModule.forRoot({ rootPath: 'client' })` to take `/admin/` off CFS. But that catch-all root was also serving `/tmx/`, `/tmx-beta/`, `/pub/` — so when I deployed CFS for the factory `5.2.5` bump today, prod TMX (`courthive.net/tmx`) went `Cannot GET /tmx/` 404.

Triage timeline:
- Deploy `2026-06-07T11:56` → `/tmx/` 404 in prod
- Rolled back via symlink swap to `releases/2026-06-03-1713-7d7eaea` → `/tmx/` 200 again, but factory back to `5.2.3` (IONSport fix reverted)
- This PR restores `/tmx`, `/tmx-beta`, `/pub` with per-path entries while keeping `/admin/` off CFS (the actual WS-17 intent — NGINX serves the replacement at `/console/`)

## Behaviour after deploy
| Path | Source | Status |
|---|---|---|
| `/tmx/` | CFS (`client/tmx`) | 200 |
| `/tmx-beta/` | CFS (`client/tmx-beta`) | 200 |
| `/pub/` | CFS (`client/pub`) | 200 |
| `/admin/` | none on CFS | 404 (intended WS-17 end state) |
| `/console/` | NGINX (`/var/www/courthive-console/`) | 200 (unchanged) |

## Test plan
- [x] `pnpm check-types`
- [x] `pnpm lint`
- [x] `pnpm build`
- [ ] After merge, redeploy CFS, then `curl -I https://courthive.net/tmx/` → 200 + `tmx-beta`/`pub` → 200 + `/admin/` → 404 + `/factory/version` → `5.2.5`