### PR TITLE
chore(deps): drop dead @nestjs/serve-static dep

### DIFF
--- a/package.json
+++ b/package.json
@@ -60,7 +60,6 @@
     "@nestjs/jwt": "11.0.2",
     "@nestjs/platform-express": "11.1.24",
     "@nestjs/platform-socket.io": "11.1.24",
-    "@nestjs/serve-static": "5.0.5",
     "@nestjs/swagger": "11.4.4",
     "@nestjs/websockets": "11.1.24",
     "axios": "^1.6.8",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -45,9 +45,6 @@ importers:
       '@nestjs/platform-socket.io':
         specifier: 11.1.24
         version: 11.1.24(@nestjs/common@11.1.24(class-transformer@0.5.1)(class-validator@0.15.1)(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/websockets@11.1.24)(rxjs@7.8.2)
-      '@nestjs/serve-static':
-        specifier: 5.0.5
-        version: 5.0.5(@nestjs/common@11.1.24(class-transformer@0.5.1)(class-validator@0.15.1)(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/core@11.1.24)(express@5.2.1)
       '@nestjs/swagger':
         specifier: 11.4.4
         version: 11.4.4(@nestjs/common@11.1.24(class-transformer@0.5.1)(class-validator@0.15.1)(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/core@11.1.24)(class-transformer@0.5.1)(class-validator@0.15.1)(reflect-metadata@0.2.2)
@@ -1418,22 +1415,6 @@ packages:
       typescript: '>=4.8.2'
     peerDependenciesMeta:
       prettier:
-        optional: true
-
-  '@nestjs/serve-static@5.0.5':
-    resolution: {integrity: sha512-AhYx3N9aMwR2cb0w5Nlb5nHNYiAcF74ea/D/xna+PxlXwjmwGN/PpC/5fuMtOwmPBMgOTxNPOnB8C9LDZBSgyw==}
-    peerDependencies:
-      '@fastify/static': ^8.0.4 || ^9.0.0
-      '@nestjs/common': ^11.0.2
-      '@nestjs/core': ^11.0.2
-      express: ^5.0.1
-      fastify: ^5.2.1
-    peerDependenciesMeta:
-      '@fastify/static':
-        optional: true
-      express:
-        optional: true
-      fastify:
         optional: true
 
   '@nestjs/swagger@11.4.4':
@@ -7034,14 +7015,6 @@ snapshots:
       prettier: 3.8.3
     transitivePeerDependencies:
       - chokidar
-
-  '@nestjs/serve-static@5.0.5(@nestjs/common@11.1.24(class-transformer@0.5.1)(class-validator@0.15.1)(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/core@11.1.24)(express@5.2.1)':
-    dependencies:
-      '@nestjs/common': 11.1.24(class-transformer@0.5.1)(class-validator@0.15.1)(reflect-metadata@0.2.2)(rxjs@7.8.2)
-      '@nestjs/core': 11.1.24(@nestjs/common@11.1.24(class-transformer@0.5.1)(class-validator@0.15.1)(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/platform-express@11.1.24)(@nestjs/websockets@11.1.24)(reflect-metadata@0.2.2)(rxjs@7.8.2)
-      path-to-regexp: 8.4.2
-    optionalDependencies:
-      express: 5.2.1
 
   '@nestjs/swagger@11.4.4(@nestjs/common@11.1.24(class-transformer@0.5.1)(class-validator@0.15.1)(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/core@11.1.24)(class-transformer@0.5.1)(class-validator@0.15.1)(reflect-metadata@0.2.2)':
     dependencies:


### PR DESCRIPTION
## Summary

After `a850688` retired the last per-path `ServeStaticModule` entries for `/tmx`, `/tmx-beta`, `/pub`, the `@nestjs/serve-static` dep has zero references in `src/`. Removing it. CFS is now purely REST + WebSocket; static SPAs are served by NGINX at the edge.

Confirmed dead:

```
grep -rn '@nestjs/serve-static\|ServeStaticModule' src/
# → only the historical-context comment in src/modules/app/app.module.ts
```

## Test plan

- [ ] `pnpm install` locally (refreshes `pnpm-lock.yaml`) — **CI will be red until this is done and pushed onto the PR branch**
- [ ] `pnpm lint` clean
- [ ] `pnpm check-types` clean
- [ ] `pnpm build` clean
- [ ] `pnpm test` green
- [ ] Smoke-test prod: `/tmx/`, `/tmx-beta/`, `/pub/`, `/console/`, `/epixodic/`, `/ams/health` all 200 (NGINX-edge serving is unaffected by this removal)