### PR TITLE
fix(provisioner): block api-key provisioners from user-administration endpoints

### DIFF
--- a/admin-client/pnpm-lock.yaml
+++ b/admin-client/pnpm-lock.yaml
@@ -34,7 +34,7 @@ importers:
         version: 8.11.1
       tabulator-tables:
         specifier: ^6.3.1
-        version: 6.4.0
+        version: 6.5.0
       tods-competition-factory:
         specifier: 5.6.0
         version: 5.6.0
@@ -2023,8 +2023,8 @@ packages:
   tabbable@6.4.0:
     resolution: {integrity: sha512-05PUHKSNE8ou2dwIxTngl4EzcnsCDZGJ/iCLtDflR/SHB/ny14rXc+qU5P4mG9JkusiV7EivzY9Mhm55AzAvCg==}
 
-  tabulator-tables@6.4.0:
-    resolution: {integrity: sha512-Lxh+leFNoBo/Yyr4USs6gxqbfo8anYUaUMmoT91pfVLtoUgl/dE+qV7ahnFrKVMCYYqGG33aIMPR7FzpPBaNYA==}
+  tabulator-tables@6.5.0:
+    resolution: {integrity: sha512-n0S4rvb2tGJnVBXoiB8ns1liGfSz+sgniG5a92vEY+Wqj3R4L2LB+bF29OeWmEJwo4KAsdhfeknW2S92s/mvMw==}
 
   timepicker-ui@4.4.0:
     resolution: {integrity: sha512-+ncFBnZYrBxk8viJ6eZv2jZ5UeMnVuxtOBecHZBxpE+zgn9zpZsStXLcYVDAvBPnECIEcQJwvZ60s6/qEt08jQ==}
@@ -4093,7 +4093,7 @@ snapshots:
 
   tabbable@6.4.0: {}
 
-  tabulator-tables@6.4.0: {}
+  tabulator-tables@6.5.0: {}
 
   timepicker-ui@4.4.0: {}
 

--- a/src/modules/account/auth/auth.controller.ts
+++ b/src/modules/account/auth/auth.controller.ts
@@ -150,10 +150,12 @@ export class AuthController {
     @Body() body: AdminCreateUserDto,
     @User() user?: any,
     @UserCtx() userContext?: UserContext,
+    @Req() req?: any,
   ) {
     return this.authService.adminCreateUser(body, {
       userContext,
       provisionerIds: user?.provisionerIds,
+      isProvisioner: !!req?.provisioner,
     });
   }
 
@@ -174,10 +176,12 @@ export class AuthController {
     @Body() params: ModifyUserDto,
     @User() user?: any,
     @UserCtx() userContext?: UserContext,
+    @Req() req?: any,
   ) {
     return this.authService.modifyUser(params, {
       userContext,
       provisionerIds: user?.provisionerIds,
+      isProvisioner: !!req?.provisioner,
     });
   }
 
@@ -197,10 +201,12 @@ export class AuthController {
     @Body() body: { email: string; newPassword?: string },
     @User() user?: any,
     @UserCtx() userContext?: UserContext,
+    @Req() req?: any,
   ) {
     return this.authService.adminResetPassword(body.email, body.newPassword, {
       userContext,
       provisionerIds: user?.provisionerIds,
+      isProvisioner: !!req?.provisioner,
     });
   }
 

--- a/src/modules/account/auth/auth.service.ts
+++ b/src/modules/account/auth/auth.service.ts
@@ -695,7 +695,7 @@ export class AuthService {
       permissions?: string[];
       services?: string[];
     },
-    editor?: { userContext?: UserContext; provisionerIds?: string[] },
+    editor?: { userContext?: UserContext; provisionerIds?: string[]; isProvisioner?: boolean },
   ) {
     const email = (body?.email ?? '').toLowerCase().trim();
     if (!email) return { error: 'Email is required' };
@@ -720,6 +720,7 @@ export class AuthService {
         providerId,
         provisionerIds: editor?.provisionerIds,
         provisionerProviderStorage: this.provisionerProviderStorage,
+        isProvisioner: editor?.isProvisioner,
       });
     }
 
@@ -867,7 +868,7 @@ export class AuthService {
   async adminResetPassword(
     rawEmail: string,
     newPassword?: string,
-    editor?: { userContext?: UserContext; provisionerIds?: string[] },
+    editor?: { userContext?: UserContext; provisionerIds?: string[]; isProvisioner?: boolean },
   ) {
     if (!rawEmail) return { error: 'Email is required' };
     // Normalize for the same reason as modifyUser — userStorage.update
@@ -893,6 +894,7 @@ export class AuthService {
             providerId: row.providerId,
             provisionerIds: editor?.provisionerIds,
             provisionerProviderStorage: this.provisionerProviderStorage,
+            isProvisioner: editor?.isProvisioner,
           });
           allowed = true;
           break;
@@ -961,7 +963,7 @@ export class AuthService {
 
   async modifyUser(
     params: { email: string; [key: string]: any },
-    editor?: { userContext?: UserContext; provisionerIds?: string[] },
+    editor?: { userContext?: UserContext; provisionerIds?: string[]; isProvisioner?: boolean },
   ) {
     const { email: rawEmail, contactEmail, ...updates } = params;
     if (!rawEmail) return { error: 'Email is required' };
@@ -1062,7 +1064,7 @@ export class AuthService {
    */
   private async assertModifyUserAuthority(
     user: any,
-    editor?: { userContext?: UserContext; provisionerIds?: string[] },
+    editor?: { userContext?: UserContext; provisionerIds?: string[]; isProvisioner?: boolean },
   ): Promise<void> {
     const targetUserId = user.userId ?? user.user_id;
     const targetRows = targetUserId
@@ -1075,6 +1077,7 @@ export class AuthService {
           providerId: row.providerId,
           provisionerIds: editor?.provisionerIds,
           provisionerProviderStorage: this.provisionerProviderStorage,
+          isProvisioner: editor?.isProvisioner,
         });
         return;
       } catch {

--- a/src/modules/account/auth/helpers/assertProviderEditor.spec.ts
+++ b/src/modules/account/auth/helpers/assertProviderEditor.spec.ts
@@ -59,6 +59,38 @@ describe('assertProviderEditor', () => {
     ).resolves.toBeUndefined();
   });
 
+  it('rejects a provisioner-authenticated request relying on the synthetic PROVIDER_ADMIN role', async () => {
+    // The API-key loophole: ProvisionerMiddleware mints providerRoles[P]=PROVIDER_ADMIN
+    // for the impersonated provider. With isProvisioner set and no real
+    // provisioner→provider relationship (provisionerIds), this must be rejected.
+    await expect(
+      assertProviderEditor({
+        userContext: ctx({
+          userId: 'provisioner:prov-1',
+          providerRoles: { [PROVIDER_P]: 'PROVIDER_ADMIN' },
+          providerIds: [PROVIDER_P],
+        }),
+        providerId: PROVIDER_P,
+        isProvisioner: true,
+      }),
+    ).rejects.toThrow(ForbiddenException);
+  });
+
+  it('allows a provisioner-authenticated request backed by a real provisioner→provider relationship', async () => {
+    // A PROVISIONER-role JWT user carries provisionerIds; the relationship branch
+    // authorises even though the synthetic providerRoles shortcut is skipped.
+    const storage = mockProvisionerProviderStorage([['prov-1', PROVIDER_P]]);
+    await expect(
+      assertProviderEditor({
+        userContext: ctx({ providerRoles: { [PROVIDER_P]: 'PROVIDER_ADMIN' }, providerIds: [PROVIDER_P] }),
+        providerId: PROVIDER_P,
+        provisionerIds: ['prov-1'],
+        provisionerProviderStorage: storage,
+        isProvisioner: true,
+      }),
+    ).resolves.toBeUndefined();
+  });
+
   it('rejects PROVIDER_ADMIN at a different provider', async () => {
     await expect(
       assertProviderEditor({

--- a/src/modules/account/auth/helpers/assertProviderEditor.ts
+++ b/src/modules/account/auth/helpers/assertProviderEditor.ts
@@ -13,6 +13,19 @@
  *   PROVISIONER administering P → may edit at P
  *   PROVIDER_ADMIN at P      → may edit at P
  *   anyone else              → 403
+ *
+ * One subtlety: when a request is authenticated as a provisioner
+ * (`req.provisioner` set — API key or PROVISIONER-role JWT), ProvisionerMiddleware
+ * mints a *synthetic* `providerRoles[P] = PROVIDER_ADMIN` for the impersonated
+ * provider so tournament/score endpoints work unchanged. That synthetic role must
+ * NOT be treated as real PROVIDER_ADMIN authority for user administration —
+ * otherwise a bare `prov_` API key + `X-Provider-Id` could create/modify/reset
+ * users (the loophole this guards against). Callers pass `isProvisioner` so that,
+ * for provisioner-authenticated requests, authority must come from a real
+ * provisioner→provider relationship (`provisionerIds`) — which an API key, having
+ * no `provisionerIds`, never satisfies. A PROVISIONER-role JWT user still passes
+ * via that relationship branch; a plain PROVIDER_ADMIN human (no `req.provisioner`)
+ * still passes via `providerRoles`.
  */
 import { ForbiddenException } from '@nestjs/common';
 import { PROVIDER_ADMIN } from 'src/common/constants/roles';
@@ -30,6 +43,14 @@ export interface AssertProviderEditorArgs {
   provisionerIds?: string[];
   /** Required when `provisionerIds` is non-empty so the provisioner→provider relationship can be checked. */
   provisionerProviderStorage?: IProvisionerProviderStorage;
+  /**
+   * True when the request is authenticated as a provisioner (`req.provisioner`
+   * is set). When true, the synthetic `providerRoles[providerId] === PROVIDER_ADMIN`
+   * minted by ProvisionerMiddleware is ignored — authority must come from a real
+   * provisioner→provider relationship via `provisionerIds`. Closes the API-key
+   * loophole where `prov_` + `X-Provider-Id` could administer users.
+   */
+  isProvisioner?: boolean;
 }
 
 /**
@@ -37,12 +58,16 @@ export interface AssertProviderEditorArgs {
  * user_provider rows at `providerId`. Returns void on success.
  */
 export async function assertProviderEditor(args: AssertProviderEditorArgs): Promise<void> {
-  const { userContext, providerId, provisionerIds, provisionerProviderStorage } = args;
+  const { userContext, providerId, provisionerIds, provisionerProviderStorage, isProvisioner } = args;
   if (!userContext) throw new ForbiddenException('Authentication required');
 
   if (userContext.isSuperAdmin) return;
 
-  if (userContext.providerRoles?.[providerId] === PROVIDER_ADMIN) return;
+  // A real PROVIDER_ADMIN (human with a user_providers row) is authorised here.
+  // Skip this branch for provisioner-authenticated requests: their PROVIDER_ADMIN
+  // role is synthetic (minted from the provisioner→provider relationship), so it
+  // must be re-proven via `provisionerIds` below rather than trusted outright.
+  if (!isProvisioner && userContext.providerRoles?.[providerId] === PROVIDER_ADMIN) return;
 
   if (provisionerIds?.length && provisionerProviderStorage) {
     for (const provisionerId of provisionerIds) {

--- a/src/modules/provisioner/provisioner-user-admin-loophole.e2e.spec.ts
+++ b/src/modules/provisioner/provisioner-user-admin-loophole.e2e.spec.ts
@@ -1,0 +1,177 @@
+/**
+ * Regression test for the provisioner user-administration loophole.
+ *
+ * ProvisionerMiddleware injects a synthetic user with roles:[CLIENT,…] and a
+ * synthetic providerRoles[P]=PROVIDER_ADMIN for the impersonated provider so
+ * tournament/score endpoints work unchanged. That synthetic PROVIDER_ADMIN role
+ * ALSO satisfied `assertProviderEditor`, which let a bare `prov_` API key +
+ * `X-Provider-Id` reach the user-administration endpoints
+ * (`/auth/admin-create-user`, `/auth/admin-reset-password`, the
+ * `/provisioner/users/:userId/providers` mutations) — an unintended side door.
+ *
+ * The fix threads `isProvisioner` into `assertProviderEditor`; for
+ * provisioner-authenticated requests the synthetic role is ignored and authority
+ * must come from a real provisioner→provider relationship (which an API key,
+ * carrying no provisionerIds, never has). This test pins that an API-key
+ * provisioner is now rejected while:
+ *   - the provisioner's legitimate (non-user-admin) surface still works, and
+ *   - SUPER_ADMIN can still create users through the same endpoint.
+ *
+ * Requires STORAGE_PROVIDER=postgres + Redis (same as the other provisioner e2e).
+ */
+import { AppModule } from 'src/modules/app/app.module';
+import { INestApplication } from '@nestjs/common';
+import { Test, TestingModule } from '@nestjs/testing';
+import request from 'supertest';
+
+import { TEST_EMAIL, TEST_PASSWORD } from 'src/common/constants/test';
+
+const e2eEnabled = process.env.STORAGE_PROVIDER === 'postgres';
+const d = e2eEnabled ? describe : describe.skip;
+
+d('Provisioner / user-administration loophole', () => {
+  let app: INestApplication;
+  let adminToken: string;
+  let provisionerId: string;
+  let apiKey: string;
+  let providerId: string;
+  const createdUserEmails: string[] = [];
+
+  beforeAll(async () => {
+    const moduleRef: TestingModule = await Test.createTestingModule({
+      imports: [AppModule],
+    }).compile();
+
+    app = moduleRef.createNestApplication();
+    await app.init();
+
+    const httpServer = app.getHttpServer();
+    httpServer.keepAliveTimeout = 0;
+    httpServer.headersTimeout = 0;
+
+    const loginRes = await request(app.getHttpServer())
+      .post('/auth/login')
+      .send({ email: TEST_EMAIL, password: TEST_PASSWORD })
+      .expect(200);
+    adminToken = loginRes.body.token;
+
+    const provRes = await request(app.getHttpServer())
+      .post('/admin/provisioners')
+      .set('Authorization', `Bearer ${adminToken}`)
+      .send({ name: `E2E-Loophole-${Date.now()}`, config: { test: true } })
+      .expect(201);
+    provisionerId = provRes.body.provisioner.provisionerId;
+
+    const keyRes = await request(app.getHttpServer())
+      .post(`/admin/provisioners/${provisionerId}/keys`)
+      .set('Authorization', `Bearer ${adminToken}`)
+      .send({ label: 'e2e-loophole' })
+      .expect(201);
+    apiKey = keyRes.body.apiKey;
+
+    // Provider created via the provisioner endpoint → 'owner' relationship.
+    const provider = await request(app.getHttpServer())
+      .post('/provisioner/providers')
+      .set('Authorization', `Bearer ${apiKey}`)
+      .send({ organisationAbbreviation: `EL${Date.now()}`, organisationName: 'E2E Loophole Provider' })
+      .expect(201);
+    providerId = provider.body.providerId;
+  });
+
+  afterAll(async () => {
+    try {
+      // Remove any users created by the SUPER_ADMIN control case.
+      for (const email of createdUserEmails) {
+        try {
+          await request(app.getHttpServer())
+            .post('/auth/remove')
+            .set('Authorization', `Bearer ${adminToken}`)
+            .send({ email });
+        } catch {
+          /* ignore */
+        }
+      }
+
+      if (provisionerId && adminToken) {
+        try {
+          await request(app.getHttpServer())
+            .put(`/admin/provisioners/${provisionerId}`)
+            .set('Authorization', `Bearer ${adminToken}`)
+            .send({ isActive: false });
+          await request(app.getHttpServer())
+            .delete(`/admin/provisioners/${provisionerId}`)
+            .set('Authorization', `Bearer ${adminToken}`);
+        } catch {
+          /* ignore */
+        }
+      }
+
+      const { PROVIDER_STORAGE } = await import('src/storage/interfaces');
+      const providerStorage: any = app.get(PROVIDER_STORAGE);
+      try { if (providerId) await providerStorage.removeProvider(providerId); } catch { /* ignore */ }
+    } finally {
+      await app.close();
+    }
+  });
+
+  it('rejects API-key provisioner creating a user via /auth/admin-create-user (loophole closed)', async () => {
+    const res = await request(app.getHttpServer())
+      .post('/auth/admin-create-user')
+      .set('Authorization', `Bearer ${apiKey}`)
+      .set('X-Provider-Id', providerId)
+      .send({
+        email: `loophole-${Date.now()}@example.com`,
+        providerId,
+        providerRole: 'DIRECTOR',
+      });
+
+    expect(res.status).toBe(403);
+    expect(res.body?.success).toBeUndefined();
+  });
+
+  it('rejects API-key provisioner resetting a password via /auth/admin-reset-password', async () => {
+    const res = await request(app.getHttpServer())
+      .post('/auth/admin-reset-password')
+      .set('Authorization', `Bearer ${apiKey}`)
+      .set('X-Provider-Id', providerId)
+      .send({ email: TEST_EMAIL });
+
+    // The synthetic PROVIDER_ADMIN no longer authorises; SUPER_ADMIN is the
+    // only editor the target (TEST_EMAIL) would resolve to, which the API key
+    // is not. Authorization fails before any reset occurs.
+    expect(res.status).toBe(403);
+  });
+
+  it('rejects API-key provisioner mutating user_providers associations', async () => {
+    const res = await request(app.getHttpServer())
+      .put(`/provisioner/users/00000000-0000-0000-0000-0000000000aa/providers/${providerId}`)
+      .set('Authorization', `Bearer ${apiKey}`)
+      .set('X-Provider-Id', providerId)
+      .send({ providerRole: 'PROVIDER_ADMIN' });
+
+    expect(res.status).toBe(403);
+  });
+
+  it('still allows the API-key provisioner its legitimate surface (providers directory)', async () => {
+    const res = await request(app.getHttpServer())
+      .get('/provisioner/providers')
+      .set('Authorization', `Bearer ${apiKey}`)
+      .set('X-Provider-Id', providerId)
+      .expect(200);
+
+    expect(Array.isArray(res.body) || Array.isArray(res.body?.providers)).toBe(true);
+  });
+
+  it('still allows SUPER_ADMIN to create a user via the same endpoint', async () => {
+    const email = `admin-created-${Date.now()}@example.com`;
+    const res = await request(app.getHttpServer())
+      .post('/auth/admin-create-user')
+      .set('Authorization', `Bearer ${adminToken}`)
+      .send({ email, providerId, providerRole: 'DIRECTOR' }) // no contactEmail → clipboard path, no mail sent
+      .expect(200);
+
+    expect(res.body?.success).toBe(true);
+    expect(res.body?.mode).toBe('password-returned');
+    createdUserEmails.push(email);
+  });
+});

--- a/src/modules/provisioner/users-providers.controller.ts
+++ b/src/modules/provisioner/users-providers.controller.ts
@@ -25,6 +25,7 @@ import {
   Inject,
   Param,
   Put,
+  Req,
   UseGuards,
 } from '@nestjs/common';
 
@@ -97,12 +98,14 @@ export class UsersProvidersController {
     @Body() body: { providerRole?: string },
     @User() user?: any,
     @UserCtx() userContext?: UserContext,
+    @Req() req?: any,
   ) {
     await assertProviderEditor({
       userContext,
       providerId,
       provisionerIds: user?.provisionerIds,
       provisionerProviderStorage: this.provisionerProviderStorage,
+      isProvisioner: !!req?.provisioner,
     });
 
     const providerRole = body?.providerRole;
@@ -135,12 +138,14 @@ export class UsersProvidersController {
     @Param('providerId') providerId: string,
     @User() user?: any,
     @UserCtx() userContext?: UserContext,
+    @Req() req?: any,
   ) {
     await assertProviderEditor({
       userContext,
       providerId,
       provisionerIds: user?.provisionerIds,
       provisionerProviderStorage: this.provisionerProviderStorage,
+      isProvisioner: !!req?.provisioner,
     });
 
     // Last-admin-block also gates remove — can't leave the provider

--- a/src/stories/provisioner/Authentication.mdx
+++ b/src/stories/provisioner/Authentication.mdx
@@ -70,6 +70,36 @@ request.userContext = {
 };
 ```
 
+## Authorization boundary — what the synthetic context can and cannot do
+
+The synthetic `providerRoles[providerId] = 'PROVIDER_ADMIN'` exists so **tournament and
+scoring** endpoints (`/factory/*`, `/auth/tracker-token`, …) accept the call and route
+ownership to the right provider. It is **not** a general grant of provider-admin authority.
+
+In particular, it does **not** authorize **user administration**. The account-administration
+endpoints funnel through a single authorization helper, `assertProviderEditor`, which treats a
+provisioner-authenticated request specially: the synthetic `PROVIDER_ADMIN` role is ignored, and
+authority must instead come from a **real provisioner→provider relationship**. An API key carries
+no `provisionerIds`, so it never satisfies that check and is rejected with **403**.
+
+<table>
+  <thead>
+    <tr><th style={{ textAlign: 'left' }}>Caller</th><th style={{ textAlign: 'left' }}>Tournament / scoring ops</th><th style={{ textAlign: 'left' }}>User administration</th></tr>
+  </thead>
+  <tbody>
+    <tr><td>Provisioner <strong>API key</strong> (<code>prov_sk_live_*</code>) + <code>X-Provider-Id</code></td><td>✅ Allowed (synthetic <code>PROVIDER_ADMIN</code>)</td><td>❌ <strong>403</strong> — synthetic role not honored</td></tr>
+    <tr><td>Provisioner <strong>JWT user</strong> (<code>PROVISIONER</code> role) + <code>X-Provider-Id</code></td><td>✅ Allowed</td><td>✅ Allowed via the real provisioner→provider relationship</td></tr>
+    <tr><td>Human <strong>PROVIDER_ADMIN</strong> (normal session)</td><td>✅ Allowed</td><td>✅ Allowed (real <code>user_providers</code> role)</td></tr>
+  </tbody>
+</table>
+
+The user-administration endpoints gated this way are `/auth/admin-create-user`,
+`/auth/admin-reset-password`, `/auth/modify`, and the admin-UI `user_providers` association
+endpoints (`PUT`/`DELETE /provisioner/users/:userId/providers/:providerId`). To provision end-user
+accounts from an integration, use the SSO endpoint `POST /provisioner/users` (see
+**Provisioner/User Management**), which is purpose-built for API-key callers and validates the
+provisioner→provider relationship directly.
+
 ## Security Properties
 
 - **No plaintext storage** — API keys are SHA-256 hashed before persistence

--- a/src/stories/provisioner/OnBehalfOfProvider.mdx
+++ b/src/stories/provisioner/OnBehalfOfProvider.mdx
@@ -33,8 +33,14 @@ X-Provider-Id: <providerId>
 
 Server-side, the middleware validates the key, looks up the provisioner↔provider
 relationship, and — if valid — injects a synthetic `PROVIDER_ADMIN` user context
-scoped to that provider. Downstream endpoints then behave exactly as if a provider
+scoped to that provider. Tournament and scoring endpoints then behave as if a provider
 admin of that provider had called them.
+
+> **The synthetic role is scoped to tournament/scoring work, not account administration.**
+> A provisioner **API key** cannot create or modify users, reset passwords, or edit
+> `user_providers` associations through the console admin endpoints — those reject API-key
+> callers with **403**. Provision end-user accounts via `POST /provisioner/users` (SSO). See
+> **Provisioner/Authentication → Authorization boundary** for the full rule.
 
 If you **omit** `X-Provider-Id`, you are authenticated as the provisioner but have
 no provider scope — only the provisioner-native `/provisioner/*` management
@@ -175,6 +181,7 @@ See **Provisioner/Provider Management**, **Provisioner/User Management**, and
     <tr><td><code>401 Unauthorized</code></td><td>Missing, malformed, revoked, or expired provisioner key.</td></tr>
     <tr><td><code>401</code> / <code>403</code></td><td>A provider-scoped (<code>/factory/&#42;</code>) call with no <code>X-Provider-Id</code>, or an <code>X-Provider-Id</code> you have no relationship to — no provider context is injected, so authorization fails.</td></tr>
     <tr><td><code>403</code></td><td>An owner-only <code>/provisioner/&#42;</code> operation attempted with a <code>subsidiary</code> relationship.</td></tr>
+    <tr><td><code>403</code></td><td>A user-administration endpoint (<code>/auth/admin-create-user</code>, <code>/auth/admin-reset-password</code>, <code>/auth/modify</code>, or a <code>user_providers</code> association mutation) called with an API key — the synthetic <code>PROVIDER_ADMIN</code> does not grant user administration. Use <code>POST /provisioner/users</code> instead.</td></tr>
   </tbody>
 </table>
 

--- a/src/stories/provisioner/UserManagement.mdx
+++ b/src/stories/provisioner/UserManagement.mdx
@@ -6,6 +6,15 @@ import { Meta } from '@storybook/addon-docs/blocks';
 
 Provisioners create and manage SSO users — users who authenticate via the provisioner's external identity system rather than a local password.
 
+> **`POST /provisioner/users` is the only user-creation endpoint available to a provisioner
+> API key.** It creates an SSO-only account and validates the provisioner→provider relationship
+> directly. The console admin endpoints that create **password** accounts and send "set your
+> password" onboarding email (`/auth/admin-create-user`) — along with `/auth/admin-reset-password`,
+> `/auth/modify`, and the `user_providers` association endpoints — **reject API-key callers with
+> 403**. Those require a real authenticated administrator (a human `PROVIDER_ADMIN`/`SUPER_ADMIN`,
+> or a `PROVISIONER`-role JWT user). See **Provisioner/Authentication → Authorization boundary**
+> for why.
+
 ## Create SSO User
 
 ```http


### PR DESCRIPTION
## Summary

Closes an unintended authorization side door: a provisioner `prov_` **API key** + `X-Provider-Id` could reach the **user-administration** endpoints (`/auth/admin-create-user`, `/auth/admin-reset-password`, `/auth/modify`, and the admin-UI `PUT/DELETE /provisioner/users/:userId/providers`).

`ProvisionerMiddleware` mints a synthetic user carrying `roles:[CLIENT,…]` and a synthetic `providerRoles[P] = PROVIDER_ADMIN` for the impersonated provider so tournament/score endpoints work unchanged. That synthetic `PROVIDER_ADMIN` also satisfied `assertProviderEditor` — the shared authorization chokepoint — which is what let a bare API key administer users.

## Fix

Thread an `isProvisioner` flag (`= !!req.provisioner`) from the auth + users-providers controllers, through the `auth.service` `editor` shape, into `assertProviderEditor`. When a request is provisioner-authenticated, the synthetic `providerRoles[P] === PROVIDER_ADMIN` shortcut is **skipped** — authority must come from a real provisioner→provider relationship (`provisionerIds`), which an API key never carries → **403**.

Because every user-admin path funnels through `assertProviderEditor`, the single change closes all of them at the root.

### Preserved (intentionally unaffected)
- **PROVISIONER-role JWT users** (real humans) — pass via the relationship branch
- **Plain human PROVIDER_ADMIN** (no `req.provisioner`) — unchanged
- **`POST /provisioner/users`** (SSO user creation; does its own `getRelationship` check, never touched `assertProviderEditor`)
- **`POST /auth/tracker-token`** (intentional `SCORE` provisioner capability) and all tournament/score ops

## Tests
- `assertProviderEditor.spec.ts` — 2 new cases (synthetic role rejected; real relationship still allowed)
- `provisioner-user-admin-loophole.e2e.spec.ts` — new, **5 cases, executed against local Postgres**: API-key provisioner → 403 on create-user / reset-password / user_providers mutation; legitimate `GET /provisioner/providers` → 200; SUPER_ADMIN create-user → 200 control
- `check-types` ✅, `eslint` ✅ (zero warnings), 331 provisioner+auth tests ✅

Docs: `Mentat/planning/PROVISIONER_API_REFERENCE.md` gains an API-key scope note (separate Mentat commit).
