### PR TITLE
feat(factory): lightweight tournament updated-at probe endpoint

### DIFF
--- a/src/modules/factory/dto/fetchTournamentUpdatedAt.dto.ts
+++ b/src/modules/factory/dto/fetchTournamentUpdatedAt.dto.ts
@@ -1,0 +1,6 @@
+import { ApiPropertyOptional } from '@nestjs/swagger';
+
+export class FetchTournamentUpdatedAtDto {
+  @ApiPropertyOptional()
+  tournamentId?: string;
+}

--- a/src/modules/factory/factory.controller.ts
+++ b/src/modules/factory/factory.controller.ts
@@ -1,4 +1,5 @@
 import { GetScheduledMatchUpsDto } from './dto/getCompetitionScheduleMatchUps.dto';
+import { FetchTournamentUpdatedAtDto } from './dto/fetchTournamentUpdatedAt.dto';
 import { RemoveTournamentRecordsDto } from './dto/removeTournamentRecords.dto';
 import { FetchTournamentRecordsDto } from './dto/fetchTournamentRecords.dto';
 import { QueryTournamentRecordsDto } from './dto/queryTournamentRecords.dto';
@@ -248,6 +249,20 @@ export class FactoryController {
     @UserCtx() userContext?: UserContext,
   ) {
     return this.factoryService.fetchTournamentRecords(ftd, user, userContext);
+  }
+
+  // Lightweight staleness probe — returns only `{ updatedAt }`, used by the TMX
+  // client to detect whether it has fallen behind the server without pulling the
+  // full tournament record.
+  @Post('updated-at')
+  @Roles([CLIENT, SUPER_ADMIN])
+  @HttpCode(HttpStatus.OK)
+  fetchTournamentUpdatedAt(
+    @Body() dto: FetchTournamentUpdatedAtDto,
+    @User() user?: any,
+    @UserCtx() userContext?: UserContext,
+  ) {
+    return this.factoryService.fetchTournamentUpdatedAt(dto, user, userContext);
   }
 
   @Post('generate')

--- a/src/modules/factory/factory.service.ts
+++ b/src/modules/factory/factory.service.ts
@@ -88,6 +88,40 @@ export class FactoryService {
     return result;
   }
 
+  // Lightweight staleness probe — returns only `updatedAt`, never the full
+  // record. Reuses the exact same access gates as `fetchTournamentRecords`,
+  // run against a minimal record projected from the JSONB, so the probe can't
+  // leak a timestamp for a tournament the user couldn't otherwise fetch.
+  async fetchTournamentUpdatedAt(params: { tournamentId?: string }, user, userContext?: UserContext) {
+    const validUser = checkUser({ user, userContext });
+    if (!validUser) return { error: 'Invalid user' };
+
+    const { tournamentId } = params;
+    if (!tournamentId) return { error: 'Missing tournamentId' };
+
+    const result: any = await this.tournamentStorageService.fetchTournamentUpdatedAt({ tournamentId });
+    if (result.error) return result;
+
+    const minimalRecord = {
+      parentOrganisation: result.providerId ? { organisationId: result.providerId } : undefined,
+      extensions: result.extensions ?? [],
+      updatedAt: result.updatedAt,
+    };
+    const tournamentRecords = { [tournamentId]: minimalRecord };
+
+    const allowUser = checkProvider({ tournamentRecords, user, userContext });
+    if (!allowUser) return { error: 'User not allowed' };
+
+    if (userContext) {
+      const assignedIds = await this.assignmentsService.getAssignedTournamentIds(userContext.userId);
+      if (!canViewTournament(minimalRecord, userContext, assignedIds)) {
+        return { error: 'User not allowed' };
+      }
+    }
+
+    return { success: true, tournamentId, updatedAt: result.updatedAt };
+  }
+
   async generateTournamentRecord(
     params,
     user,

--- a/src/modules/factory/fetchTournamentUpdatedAt.spec.ts
+++ b/src/modules/factory/fetchTournamentUpdatedAt.spec.ts
@@ -1,0 +1,59 @@
+import { FactoryService } from './factory.service';
+
+// Focused unit test for the lightweight staleness probe. Constructs FactoryService
+// directly with mocked storage + assignments so no Postgres is needed.
+
+const SUPER_ADMIN_USER = { roles: ['superadmin'] };
+
+function makeService(storageImpl: (params: any) => Promise<any>) {
+  const tournamentStorageService = { fetchTournamentUpdatedAt: jest.fn(storageImpl) };
+  const assignmentsService = { getAssignedTournamentIds: jest.fn().mockResolvedValue([]) };
+  const service = new FactoryService(
+    tournamentStorageService as any,
+    assignmentsService as any,
+    {} as any,
+    {} as any,
+    {} as any,
+    {} as any,
+    {} as any,
+  );
+  return { service, tournamentStorageService, assignmentsService };
+}
+
+describe('FactoryService.fetchTournamentUpdatedAt', () => {
+  it('returns only { success, tournamentId, updatedAt } for an authorized user', async () => {
+    const { service } = makeService(async () => ({
+      success: true,
+      tournamentId: 't1',
+      updatedAt: '2026-06-22T00:00:00.000Z',
+      providerId: 'p1',
+      extensions: [{ name: 'secret', value: 'x' }],
+    }));
+
+    const result: any = await service.fetchTournamentUpdatedAt({ tournamentId: 't1' }, SUPER_ADMIN_USER);
+
+    // Must not leak provider/extensions or any full-record fields to the client.
+    expect(Object.keys(result).sort()).toEqual(['success', 'tournamentId', 'updatedAt']);
+    expect(result).toEqual({ success: true, tournamentId: 't1', updatedAt: '2026-06-22T00:00:00.000Z' });
+  });
+
+  it('rejects an invalid user before touching storage', async () => {
+    const { service, tournamentStorageService } = makeService(async () => ({}));
+    const result: any = await service.fetchTournamentUpdatedAt({ tournamentId: 't1' }, undefined);
+    expect(result.error).toBe('Invalid user');
+    expect(tournamentStorageService.fetchTournamentUpdatedAt).not.toHaveBeenCalled();
+  });
+
+  it('errors when tournamentId is missing', async () => {
+    const { service, tournamentStorageService } = makeService(async () => ({}));
+    const result: any = await service.fetchTournamentUpdatedAt({}, SUPER_ADMIN_USER);
+    expect(result.error).toBe('Missing tournamentId');
+    expect(tournamentStorageService.fetchTournamentUpdatedAt).not.toHaveBeenCalled();
+  });
+
+  it('passes through a storage error (e.g. record not found)', async () => {
+    const { service } = makeService(async () => ({ error: 'MISSING_TOURNAMENT_RECORD' }));
+    const result: any = await service.fetchTournamentUpdatedAt({ tournamentId: 'missing' }, SUPER_ADMIN_USER);
+    expect(result.error).toBe('MISSING_TOURNAMENT_RECORD');
+  });
+});

--- a/src/storage/interfaces/tournament-storage.interface.ts
+++ b/src/storage/interfaces/tournament-storage.interface.ts
@@ -10,6 +10,23 @@ export interface ITournamentStorage {
     tournamentId?: string;
   }): Promise<{ success?: boolean; tournamentRecords?: Record<string, any>; fetched?: number; notFound?: number; error?: any }>;
 
+  /**
+   * Lightweight staleness probe — returns only a tournament's `updatedAt`
+   * (plus the minimal fields the access gates need) without loading the full
+   * record. `providerId` and `extensions` are projected from the JSONB for
+   * authorization and are not surfaced to clients.
+   */
+  fetchTournamentUpdatedAt(params: {
+    tournamentId?: string;
+  }): Promise<{
+    success?: boolean;
+    tournamentId?: string;
+    updatedAt?: string;
+    providerId?: string;
+    extensions?: any[];
+    error?: any;
+  }>;
+
   saveTournamentRecord(params: { tournamentRecord: any }): Promise<{ success?: boolean; error?: string }>;
 
   saveTournamentRecords(params: {

--- a/src/storage/postgres/postgres-tournament.storage.ts
+++ b/src/storage/postgres/postgres-tournament.storage.ts
@@ -45,6 +45,37 @@ export class PostgresTournamentStorage implements ITournamentStorage {
     return { ...SUCCESS, tournamentRecords, fetched, notFound };
   }
 
+  async fetchTournamentUpdatedAt({ tournamentId }: { tournamentId?: string }) {
+    if (!tournamentId) {
+      return { error: factoryConstants.errorConditionConstants.MISSING_TOURNAMENT_RECORD };
+    }
+
+    // Project only the few fields needed — Postgres extracts them server-side so
+    // the full `data` JSONB blob is never transferred.
+    const result = await this.pool.query(
+      `SELECT tournament_id,
+              data->>'updatedAt' AS updated_at,
+              data->'parentOrganisation'->>'organisationId' AS provider_id,
+              data->'extensions' AS extensions
+         FROM tournaments
+        WHERE tournament_id = $1`,
+      [tournamentId],
+    );
+
+    if (!result.rows.length) {
+      return { error: factoryConstants.errorConditionConstants.MISSING_TOURNAMENT_RECORD };
+    }
+
+    const row = result.rows[0];
+    return {
+      ...SUCCESS,
+      tournamentId: row.tournament_id,
+      updatedAt: row.updated_at,
+      providerId: row.provider_id,
+      extensions: row.extensions ?? [],
+    };
+  }
+
   async saveTournamentRecord({ tournamentRecord }: { tournamentRecord: any }) {
     const key = tournamentRecord?.tournamentId;
     if (!key) return { error: 'Invalid tournamentRecord' };

--- a/src/storage/tournament-storage.service.ts
+++ b/src/storage/tournament-storage.service.ts
@@ -37,6 +37,10 @@ export class TournamentStorageService {
     return this.tournamentStorage.fetchTournamentRecords(params);
   }
 
+  async fetchTournamentUpdatedAt(params: { tournamentId?: string }) {
+    return this.tournamentStorage.fetchTournamentUpdatedAt(params);
+  }
+
   async listTournamentIds() {
     return this.tournamentStorage.listTournamentIds();
   }


### PR DESCRIPTION
## What

Adds **`POST /factory/updated-at`** returning only `{ tournamentId, updatedAt }` — a cheap staleness probe so the TMX client can detect it has fallen behind the server **without pulling the entire tournament record**.

## How

- **Postgres projection** (`postgres-tournament.storage.ts`): `SELECT data->>'updatedAt', data->'parentOrganisation'->>'organisationId', data->'extensions'` — Postgres extracts the few needed fields server-side, so the full `data` JSONB blob is never transferred.
- **Same access control as the full fetch**: reuses `checkUser` / `checkProvider` / `canViewTournament` against a *minimal record* projected from the JSONB, so the probe can't leak a timestamp for a tournament the user couldn't otherwise fetch. `providerId`/`extensions` are used only for the gate and are **not** returned to the client.
- Threaded through the storage interface, Postgres impl, the storage facade, and `FactoryService`.

## Verification

- New unit test (`fetchTournamentUpdatedAt.spec.ts`, 4 cases): authorized happy-path returns only `{success, tournamentId, updatedAt}` (no leak), invalid-user rejected before storage, missing id errors, storage error passes through.
- check-types, lint, and `nest build` all green.

## Consumer

Paired with TMX PR #1162 (staleness reconnect + poll), which will be reworked to call this probe and surface the existing refresh icon instead of pulling the full record.