### PR TITLE
feat(chat): page admin chat monitor through full retention window

### DIFF
--- a/src/modules/messaging/tmx/tmx.gateway.spec.ts
+++ b/src/modules/messaging/tmx/tmx.gateway.spec.ts
@@ -74,7 +74,7 @@ function buildGateway(opts: { userStorage?: any; providerStorage?: any } = {}) {
     }),
     recentMessages: jest.fn().mockResolvedValue({ records: [] }),
     messagesSince: jest.fn().mockResolvedValue({ records: [] }),
-    recentAcrossTournaments: jest.fn().mockResolvedValue({ records: [] }),
+    adminMessagesBefore: jest.fn().mockResolvedValue({ records: [] }),
     pruneOlderThan: jest.fn().mockResolvedValue({ deleted: 0 }),
   };
 
@@ -161,19 +161,51 @@ describe('TmxGateway chat persistence', () => {
     expect(socket.emit).toHaveBeenCalledWith('chatHistory', expect.objectContaining({ gap: true }));
   });
 
-  it('backfills cross-tournament history when an admin joins the monitor', async () => {
+  it('backfills the most-recent cross-tournament page when an admin joins the monitor', async () => {
     const { gateway, chatStorage } = buildGateway();
-    chatStorage.recentAcrossTournaments.mockResolvedValue({
+    chatStorage.adminMessagesBefore.mockResolvedValue({
       records: [{ seq: 7, tournamentId: 't9', providerId: 'p', providerAbbr: 'ACME', tournamentName: 'Open', userName: 'x', message: 'hey', isAdmin: false, createdAt: new Date(0).toISOString() }],
     });
     const socket = makeSocket({ user: { email: 'admin@test.com', roles: ['superadmin'] } });
 
     await gateway.joinChatMonitor(socket as any);
 
+    // Opens with the most-recent page (no beforeSeq), flagged as not-older.
+    expect(chatStorage.adminMessagesBefore).toHaveBeenCalledWith({});
     expect(socket.emit).toHaveBeenCalledWith(
       'adminChatHistory',
-      expect.objectContaining({ messages: [expect.objectContaining({ seq: 7, providerAbbr: 'ACME', tournamentName: 'Open' })] }),
+      expect.objectContaining({
+        older: false,
+        messages: [expect.objectContaining({ seq: 7, providerAbbr: 'ACME', tournamentName: 'Open' })],
+      }),
     );
+  });
+
+  it('pages older cross-tournament history on adminChatLoadOlder (older: true)', async () => {
+    const { gateway, chatStorage } = buildGateway();
+    chatStorage.adminMessagesBefore.mockResolvedValue({
+      records: [{ seq: 3, tournamentId: 't9', providerAbbr: 'ACME', tournamentName: 'Open', userName: 'x', message: 'older', isAdmin: false, createdAt: new Date(0).toISOString() }],
+    });
+    const socket = makeSocket({ user: { email: 'admin@test.com', roles: ['superadmin'] } });
+    socket.rooms.add('admin:chatMonitor');
+
+    await gateway.adminChatLoadOlder({ beforeSeq: 7 }, socket as any);
+
+    expect(chatStorage.adminMessagesBefore).toHaveBeenCalledWith({ beforeSeq: 7 });
+    expect(socket.emit).toHaveBeenCalledWith(
+      'adminChatHistory',
+      expect.objectContaining({ older: true, messages: [expect.objectContaining({ seq: 3 })] }),
+    );
+  });
+
+  it('ignores adminChatLoadOlder when the socket is not in the monitor room', async () => {
+    const { gateway, chatStorage } = buildGateway();
+    const socket = makeSocket({ user: { email: 'admin@test.com', roles: ['superadmin'] } });
+
+    await gateway.adminChatLoadOlder({ beforeSeq: 7 }, socket as any);
+
+    expect(chatStorage.adminMessagesBefore).not.toHaveBeenCalled();
+    expect(socket.emit).not.toHaveBeenCalled();
   });
 });
 

--- a/src/modules/messaging/tmx/tmx.gateway.ts
+++ b/src/modules/messaging/tmx/tmx.gateway.ts
@@ -396,9 +396,28 @@ export class TmxGateway implements OnGatewayConnection, OnGatewayDisconnect, OnG
     await client.join(ADMIN_CHAT_MONITOR_ROOM);
     this.logger.log(`[chat-monitor] ${client.id} joined admin chat monitor`);
 
-    // Backfill the cross-tournament history so the monitor opens populated.
-    const { records } = await this.chatStorage.recentAcrossTournaments({});
-    client.emit('adminChatHistory', { messages: (records ?? []).map(toAdminFeed) });
+    // Backfill the most-recent cross-tournament page so the monitor opens
+    // populated regardless of how recent the last activity was. The client
+    // can page further back via `adminChatLoadOlder` to the 30d retention edge.
+    const { records } = await this.chatStorage.adminMessagesBefore({});
+    client.emit('adminChatHistory', { messages: (records ?? []).map(toAdminFeed), older: false });
+  }
+
+  /**
+   * Super-admin pages back through cross-tournament history. Returns the page
+   * of messages immediately older than `beforeSeq` (the oldest seq the client
+   * currently holds). An empty `messages` array signals the retention edge —
+   * the client disables its "load older" affordance.
+   */
+  @SubscribeMessage('adminChatLoadOlder')
+  @Roles([SUPER_ADMIN])
+  async adminChatLoadOlder(@MessageBody() data: any, @ConnectedSocket() client: Socket): Promise<void> {
+    if (!client.rooms.has(ADMIN_CHAT_MONITOR_ROOM)) return;
+    const beforeSeq = Number(data?.beforeSeq);
+    if (!Number.isFinite(beforeSeq)) return;
+
+    const { records } = await this.chatStorage.adminMessagesBefore({ beforeSeq });
+    client.emit('adminChatHistory', { messages: (records ?? []).map(toAdminFeed), older: true });
   }
 
   @SubscribeMessage('leaveChatMonitor')

--- a/src/storage/interfaces/chat-storage.interface.ts
+++ b/src/storage/interfaces/chat-storage.interface.ts
@@ -46,10 +46,14 @@ export interface IChatStorage {
     limit?: number;
   }): Promise<{ records?: ChatMessageRecord[]; error?: string }>;
 
-  /** Admin monitor backfill: most-recent messages across ALL tournaments
-   *  within `sinceMs` (default 24h), capped by `limit`, ascending seq. */
-  recentAcrossTournaments(params: {
-    sinceMs?: number;
+  /** Admin monitor page: most-recent messages across ALL tournaments, capped
+   *  by `limit`, returned in ascending seq order. When `beforeSeq` is given,
+   *  returns the page immediately older than it (for "load older"). No time
+   *  window — the retention prune (CHAT_RETENTION_DAYS, default 30d) is the
+   *  natural floor for how far back paging reaches. An empty result means the
+   *  retention edge was reached. */
+  adminMessagesBefore(params: {
+    beforeSeq?: number;
     limit?: number;
   }): Promise<{ records?: ChatMessageRecord[]; error?: string }>;
 

--- a/src/storage/postgres/postgres-chat.storage.spec.ts
+++ b/src/storage/postgres/postgres-chat.storage.spec.ts
@@ -53,6 +53,24 @@ describe('PostgresChatStorage', () => {
     expect(pool.query).toHaveBeenCalledWith(expect.stringContaining('seq > $2'), ['t1', 42, expect.any(Number)]);
   });
 
+  it('adminMessagesBefore (no beforeSeq) fetches the most-recent page, no seq filter', async () => {
+    const pool = makePool([dbRow({ seq: '3' }), dbRow({ seq: '5' })]);
+    const storage = new PostgresChatStorage(pool);
+    const { records } = await storage.adminMessagesBefore({});
+    expect(records!.map((r) => r.seq)).toEqual([3, 5]);
+    const [sql, params] = pool.query.mock.calls[0];
+    expect(sql).not.toContain('seq <');
+    expect(params).toEqual([expect.any(Number)]); // just the limit
+  });
+
+  it('adminMessagesBefore (beforeSeq) pages older with a seq < filter', async () => {
+    const pool = makePool([dbRow({ seq: '1' }), dbRow({ seq: '2' })]);
+    const storage = new PostgresChatStorage(pool);
+    const { records } = await storage.adminMessagesBefore({ beforeSeq: 3 });
+    expect(records!.map((r) => r.seq)).toEqual([1, 2]);
+    expect(pool.query).toHaveBeenCalledWith(expect.stringContaining('seq < $1'), [3, expect.any(Number)]);
+  });
+
   it('pruneOlderThan returns the deleted count', async () => {
     const pool = makePool([], 9);
     const storage = new PostgresChatStorage(pool);

--- a/src/storage/postgres/postgres-chat.storage.ts
+++ b/src/storage/postgres/postgres-chat.storage.ts
@@ -90,25 +90,38 @@ export class PostgresChatStorage implements IChatStorage {
     }
   }
 
-  async recentAcrossTournaments(params: {
-    sinceMs?: number;
+  async adminMessagesBefore(params: {
+    beforeSeq?: number;
     limit?: number;
   }): Promise<{ records?: ChatMessageRecord[]; error?: string }> {
-    const sinceMs = params.sinceMs ?? DEFAULT_BACKFILL_MS;
     const limit = params.limit ?? ADMIN_DEFAULT_LIMIT;
+    const beforeSeq = params.beforeSeq;
     try {
-      const result = await this.pool.query(
-        `SELECT * FROM (
-           SELECT ${SELECT_COLS} FROM chat_messages
-           WHERE created_at > now() - ($1::bigint * interval '1 millisecond')
-           ORDER BY seq DESC
-           LIMIT $2
-         ) recent ORDER BY seq ASC`,
-        [sinceMs, limit],
-      );
+      // Take the most-recent `limit` (DESC), optionally older than `beforeSeq`,
+      // then re-order ascending so the client renders oldest→newest. No time
+      // window: paging reaches back to wherever the retention prune has cut.
+      const result =
+        beforeSeq && Number.isFinite(beforeSeq)
+          ? await this.pool.query(
+              `SELECT * FROM (
+                 SELECT ${SELECT_COLS} FROM chat_messages
+                 WHERE seq < $1
+                 ORDER BY seq DESC
+                 LIMIT $2
+               ) page ORDER BY seq ASC`,
+              [beforeSeq, limit],
+            )
+          : await this.pool.query(
+              `SELECT * FROM (
+                 SELECT ${SELECT_COLS} FROM chat_messages
+                 ORDER BY seq DESC
+                 LIMIT $1
+               ) page ORDER BY seq ASC`,
+              [limit],
+            );
       return { records: result.rows.map(mapRow) };
     } catch (err: any) {
-      return { error: err?.message ?? 'recentAcrossTournaments failed' };
+      return { error: err?.message ?? 'adminMessagesBefore failed' };
     }
   }
 


### PR DESCRIPTION
## What

Replaces the 24h-only admin chat-monitor backfill with a seq-paged query so a super-admin can page back through the full `CHAT_RETENTION_DAYS` (default 30d) window across all tournaments and providers.

## Why

The super-admin chat monitor backfilled only the last 24h / 400 messages (`recentAcrossTournaments({})`) even though messages are retained 30 days — so days 2–30 existed in the DB but were never visible. This closes that gap and backs the new console chat-monitor page (CourtHive/courthive-ams#feat/console-chat-monitor).

## Changes

- `IChatStorage.adminMessagesBefore({ beforeSeq?, limit })` replaces `recentAcrossTournaments`. No time window — the retention prune is the natural floor for paging.
- `joinChatMonitor` now opens with the most-recent page (any age) instead of the last 24h.
- New `adminChatLoadOlder` gateway handler (`@Roles([SUPER_ADMIN])`, gated to the monitor room) pages older by seq; an empty page signals the retention edge.
- Storage + gateway specs updated and extended.

## Tests

Full jest suite green (1161 tests); 5 new/updated chat specs. Lint + type-check clean.