### PR TITLE
feat(factory): attach participant-privacy policy on create + apply-to-existing

### DIFF
--- a/package.json
+++ b/package.json
@@ -84,7 +84,7 @@
     "tods-competition-factory": "6.0.0",
     "tods-tmx-classic-converter": "3.0.5",
     "tslib": "^2.6.2",
-    "@courthive/provider-config": "^0.8.0",
+    "@courthive/provider-config": "^0.9.0",
     "@courthive/i18n": "link:../courthive-i18n",
     "courthive-ingest": "link:../courthive-ingest"
   },

--- a/src/modules/factory/dto/applyPrivacyPolicy.dto.ts
+++ b/src/modules/factory/dto/applyPrivacyPolicy.dto.ts
@@ -1,0 +1,12 @@
+import { ApiProperty } from '@nestjs/swagger';
+
+export class ApplyPrivacyPolicyDto {
+  @ApiProperty({ description: 'Provider whose participant-privacy policy is applied to its existing tournaments.' })
+  providerId!: string;
+
+  @ApiProperty({
+    required: false,
+    description: 'Also apply to in-progress tournaments. Completed tournaments are never touched.',
+  })
+  includeInProgress?: boolean;
+}

--- a/src/modules/factory/factory.controller.ts
+++ b/src/modules/factory/factory.controller.ts
@@ -11,9 +11,10 @@ import { ExecutionQueueDto } from './dto/executionQueue.dto';
 import { GetEventDataDto } from './dto/getEventData.dto';
 import { GetMatchUpsDto } from './dto/getMatchUps.dto';
 
-import { Controller, Get, Post, HttpCode, HttpStatus, Body, UseGuards, Inject, Param, Logger, Req } from '@nestjs/common';
+import { Controller, Get, Post, HttpCode, HttpStatus, Body, UseGuards, Inject, Param, Logger, Req, ForbiddenException } from '@nestjs/common';
 import { TournamentBroadcastService } from '../messaging/broadcast/tournament-broadcast.service';
-import { ADMIN, CLIENT, GENERATE, SCORE, SUPER_ADMIN } from 'src/common/constants/roles';
+import { ADMIN, CLIENT, GENERATE, PROVIDER_ADMIN, SCORE, SUPER_ADMIN } from 'src/common/constants/roles';
+import { ApplyPrivacyPolicyDto } from './dto/applyPrivacyPolicy.dto';
 import { Audience } from 'src/modules/account/auth/decorators/audience.decorator';
 import { Public } from 'src/modules/account/auth/decorators/public.decorator';
 import { Roles } from 'src/modules/account/auth/decorators/roles.decorator';
@@ -321,6 +322,23 @@ export class FactoryController {
     @UserCtx() userContext?: UserContext,
   ) {
     return this.factoryService.saveTournamentRecords(std, user, userContext);
+  }
+
+  // Apply the provider's selected participant-privacy policy to its existing
+  // tournaments (upcoming always; in-progress on opt-in; never completed).
+  // Provider-scoped: only a PROVIDER_ADMIN of the target provider (or a
+  // super-admin) may run it.
+  @Post('apply-privacy-policy')
+  @Roles([CLIENT, ADMIN, SUPER_ADMIN])
+  @HttpCode(HttpStatus.OK)
+  applyPrivacyPolicy(@Body() dto: ApplyPrivacyPolicyDto, @UserCtx() ctx?: UserContext) {
+    const { providerId, includeInProgress } = dto ?? ({} as ApplyPrivacyPolicyDto);
+    if (!providerId) return { error: 'providerId required' };
+    const isProviderAdmin = ctx?.providerRoles?.[providerId] === PROVIDER_ADMIN;
+    if (!ctx?.isSuperAdmin && !isProviderAdmin) {
+      throw new ForbiddenException('PROVIDER_ADMIN role required');
+    }
+    return this.factoryService.applyParticipantPrivacyToExisting({ providerId, includeInProgress }, ctx);
   }
 
   @Get('save-status/:saveId')

--- a/src/modules/factory/factory.service.ts
+++ b/src/modules/factory/factory.service.ts
@@ -87,7 +87,7 @@ export class FactoryService {
     const provider: any = await this.providerStorage.getProvider(providerId);
     if (!provider) return { error: 'Provider not found' };
 
-    const policy = computeEffectiveConfig(provider?.caps, provider?.settings)?.participantPrivacyPolicy;
+    const policy = computeEffectiveConfig(provider?.providerConfigCaps, provider?.providerConfigSettings)?.participantPrivacyPolicy;
     if (!policy || !Object.keys(policy).length) {
       return { error: 'NO_PRIVACY_POLICY', policyConfigured: false };
     }
@@ -119,9 +119,13 @@ export class FactoryService {
         this.providerStorage,
       ).catch((err) => ({ error: err?.message ?? String(err) }));
 
+      // Factory error constants are objects ({ code, message }); the executionQueue
+      // result surfaces the error as an object or a bare string. Normalise both to
+      // a code for comparison.
+      const existingCode = (EXISTING_POLICY_TYPE as any)?.code ?? EXISTING_POLICY_TYPE;
       const errorCode = res?.error?.code ?? res?.error;
       if (res?.success) attached.push(tournamentId);
-      else if (errorCode === EXISTING_POLICY_TYPE) alreadyAttached.push(tournamentId);
+      else if (errorCode === existingCode) alreadyAttached.push(tournamentId);
       else failed.push({ tournamentId, error: errorCode ?? 'attach failed' });
     }
 

--- a/src/modules/factory/factory.service.ts
+++ b/src/modules/factory/factory.service.ts
@@ -14,10 +14,11 @@ import { checkEngineError } from '../../common/errors/engineError';
 import { AssignmentsService } from './assignments.service';
 import { AuditService } from '../audit/audit.service';
 import { checkProvider } from './helpers/checkProvider';
-import { askEngine } from 'tods-competition-factory';
+import { attachProviderPrivacyOnCreate } from './helpers/attachProviderPrivacyOnCreate';
 import { BadRequestException, Inject, Injectable, Optional, Logger } from '@nestjs/common';
 import { checkUser } from './helpers/checkUser';
 import publicQueries from './functions/public';
+import { askEngine } from 'tods-competition-factory';
 
 // types and interfaces
 import type { UserContext } from 'src/modules/account/auth/decorators/user-context.decorator';
@@ -42,7 +43,14 @@ export class FactoryService {
   }
 
   async executionQueue(params, services) {
-    const result = await eq(params, services, this.tournamentStorageService, this.auditService, this.tournamentProvisionerStorage);
+    const result = await eq(
+      params,
+      services,
+      this.tournamentStorageService,
+      this.auditService,
+      this.tournamentProvisionerStorage,
+      this.providerStorage,
+    );
     checkEngineError(result);
 
     // Fire-and-forget: mirror successful mutations to upstream
@@ -209,6 +217,19 @@ export class FactoryService {
           return { error: `User not allowed to modify tournament ${tid}` };
         }
       }
+    }
+
+    // PRIVACY ATTACH (creation only): on the first save of a provider-owned
+    // tournament (the TMX UI create path — sendTournament → /factory/save),
+    // attach the provider's selected participant-privacy policy so public
+    // reads (getParticipants) honor it. Mirrors the executionQueue create
+    // hook for the API/provisioner path. Runs before validation so the
+    // attached extension is validated too. Fail-soft.
+    for (const record of Object.values(tournamentRecords)) {
+      await attachProviderPrivacyOnCreate(record, {
+        tournamentStorageService: this.tournamentStorageService,
+        providerStorage: this.providerStorage,
+      }).catch((err) => Logger.error(`Privacy attach on save failed: ${err.message}`, 'FactoryService'));
     }
 
     // L2 validation gate. Records under the byte threshold are validated

--- a/src/modules/factory/factory.service.ts
+++ b/src/modules/factory/factory.service.ts
@@ -15,10 +15,15 @@ import { AssignmentsService } from './assignments.service';
 import { AuditService } from '../audit/audit.service';
 import { checkProvider } from './helpers/checkProvider';
 import { attachProviderPrivacyOnCreate } from './helpers/attachProviderPrivacyOnCreate';
+import { selectPrivacyApplyTargets } from './helpers/selectPrivacyApplyTargets';
 import { BadRequestException, Inject, Injectable, Optional, Logger } from '@nestjs/common';
+import { computeEffectiveConfig } from '@courthive/provider-config';
 import { checkUser } from './helpers/checkUser';
 import publicQueries from './functions/public';
-import { askEngine } from 'tods-competition-factory';
+import { askEngine, factoryConstants } from 'tods-competition-factory';
+
+const POLICY_TYPE_PARTICIPANT = factoryConstants.policyConstants.POLICY_TYPE_PARTICIPANT;
+const EXISTING_POLICY_TYPE = factoryConstants.errorConditionConstants.EXISTING_POLICY_TYPE;
 
 // types and interfaces
 import type { UserContext } from 'src/modules/account/auth/decorators/user-context.decorator';
@@ -63,6 +68,76 @@ export class FactoryService {
     }
 
     return result;
+  }
+
+  /**
+   * Apply the provider's selected participant-privacy policy to its EXISTING
+   * tournaments. UPCOMING tournaments are always targeted; IN-PROGRESS ones
+   * only when `includeInProgress` is set; COMPLETED tournaments are never
+   * touched (confirmed decision — never force a privacy change on a finished
+   * event). Each attach runs through the full executionQueue mutation path
+   * (per-tournament lock + save + audit + broadcast); `attachPolicies` is
+   * idempotent, so a tournament that already carries the policy is reported
+   * as `alreadyAttached` rather than re-written.
+   */
+  async applyParticipantPrivacyToExisting(
+    { providerId, includeInProgress }: { providerId: string; includeInProgress?: boolean },
+    userContext?: UserContext,
+  ) {
+    const provider: any = await this.providerStorage.getProvider(providerId);
+    if (!provider) return { error: 'Provider not found' };
+
+    const policy = computeEffectiveConfig(provider?.caps, provider?.settings)?.participantPrivacyPolicy;
+    if (!policy || !Object.keys(policy).length) {
+      return { error: 'NO_PRIVACY_POLICY', policyConfigured: false };
+    }
+
+    const tournaments = await this.tournamentStorageService.listProviderTournaments({ providerId });
+    const today = new Date().toISOString().split('T')[0];
+    const targets = selectPrivacyApplyTargets(tournaments, { includeInProgress: !!includeInProgress, today });
+
+    const attached: string[] = [];
+    const alreadyAttached: string[] = [];
+    const failed: Array<{ tournamentId: string; error: any }> = [];
+
+    for (const tournamentId of targets.selected) {
+      const params = {
+        methods: [{ method: 'attachPolicies', params: { policyDefinitions: { [POLICY_TYPE_PARTICIPANT]: policy }, tournamentId } }],
+        tournamentIds: [tournamentId],
+        userId: userContext?.userId,
+        source: 'ams-apply-privacy',
+      };
+      // Call the private mutation path directly (not this.executionQueue) so a
+      // per-tournament EXISTING_POLICY_TYPE result is inspected, not thrown by
+      // checkEngineError.
+      const res: any = await eq(
+        params,
+        undefined,
+        this.tournamentStorageService,
+        this.auditService,
+        this.tournamentProvisionerStorage,
+        this.providerStorage,
+      ).catch((err) => ({ error: err?.message ?? String(err) }));
+
+      const errorCode = res?.error?.code ?? res?.error;
+      if (res?.success) attached.push(tournamentId);
+      else if (errorCode === EXISTING_POLICY_TYPE) alreadyAttached.push(tournamentId);
+      else failed.push({ tournamentId, error: errorCode ?? 'attach failed' });
+    }
+
+    return {
+      success: true,
+      policyConfigured: true,
+      attached,
+      alreadyAttached,
+      failed,
+      counts: {
+        upcoming: targets.upcoming.length,
+        inProgress: targets.inProgress.length,
+        completed: targets.completed.length,
+        selected: targets.selected.length,
+      },
+    };
   }
 
   async score(params, cacheManager) {

--- a/src/modules/factory/functions/private/executionQueue.spec.ts
+++ b/src/modules/factory/functions/private/executionQueue.spec.ts
@@ -5,8 +5,10 @@ import fileStorage from '../../../../services/fileSystem';
 import { testTournamentId } from '../../../../common/constants/test';
 
 const tournamentId = testTournamentId(__filename);
-import { executionQueue } from './executionQueue';
+import { executionQueue, attachProviderPolicies } from './executionQueue';
 import 'dotenv/config';
+
+const POLICY_TYPE_PARTICIPANT = factoryConstants.policyConstants.POLICY_TYPE_PARTICIPANT;
 
 import type { TournamentStorageService } from 'src/storage/tournament-storage.service';
 
@@ -99,5 +101,118 @@ describe('executionQueue', () => {
     expect(typeof recorded.errorCode).toBe('string');
     expect(recorded.errorCode).not.toBe('[object Object]');
     expect(recorded.errorCode.startsWith('ERR_')).toBe(true);
+  });
+});
+
+describe('attachProviderPolicies (privacy attach hook)', () => {
+  const PROVIDER_ID = 'priv-provider-1';
+  const privacyPolicy = { policyName: 'Test Privacy', participant: { person: { addresses: false } } };
+
+  // A provider whose effective config exposes the selected privacy policy.
+  const providerStorage: any = {
+    getProvider: jest.fn().mockResolvedValue({
+      caps: {},
+      settings: { participantPrivacyPolicy: privacyPolicy },
+    }),
+  };
+
+  // Minimal mutationEngine stub: state carries one provider-owned record;
+  // executionQueue records the methods it is asked to apply.
+  function makeEngine(record: any) {
+    const applied: any[] = [];
+    return {
+      applied,
+      getState: () => ({ tournamentRecords: { [tournamentId]: record } }),
+      executionQueue: jest.fn(async (methods: any[]) => {
+        applied.push(...methods);
+        return { success: true };
+      }),
+    };
+  }
+
+  const newTournamentMethods = [{ method: 'newTournamentRecord', params: {} }];
+
+  beforeEach(() => jest.clearAllMocks());
+
+  it('attaches the provider privacy policy on new-tournament creation and returns the method for client replay', async () => {
+    const engine = makeEngine({ tournamentId, parentOrganisation: { organisationId: PROVIDER_ID } });
+    const applied = await attachProviderPolicies({
+      methods: newTournamentMethods,
+      tournamentIds: [tournamentId],
+      mutationEngine: engine,
+      providerStorage,
+    });
+
+    expect(providerStorage.getProvider).toHaveBeenCalledWith(PROVIDER_ID);
+    expect(applied).toHaveLength(1);
+    expect(applied[0].method).toBe('attachPolicies');
+    expect(applied[0].params.tournamentId).toBe(tournamentId);
+    expect(applied[0].params.policyDefinitions[POLICY_TYPE_PARTICIPANT]).toEqual(privacyPolicy);
+    // The engine was actually asked to apply the attach (persisted before save).
+    expect(engine.executionQueue).toHaveBeenCalledTimes(1);
+  });
+
+  it('is a no-op when the batch contains no newTournamentRecord', async () => {
+    const engine = makeEngine({ tournamentId, parentOrganisation: { organisationId: PROVIDER_ID } });
+    const applied = await attachProviderPolicies({
+      methods: [{ method: 'setTournamentDates', params: {} }],
+      tournamentIds: [tournamentId],
+      mutationEngine: engine,
+      providerStorage,
+    });
+    expect(applied).toEqual([]);
+    expect(providerStorage.getProvider).not.toHaveBeenCalled();
+    expect(engine.executionQueue).not.toHaveBeenCalled();
+  });
+
+  it('is a no-op when the provider has no privacy policy configured', async () => {
+    const bareProviderStorage: any = {
+      getProvider: jest.fn().mockResolvedValue({ caps: {}, settings: {} }),
+    };
+    const engine = makeEngine({ tournamentId, parentOrganisation: { organisationId: PROVIDER_ID } });
+    const applied = await attachProviderPolicies({
+      methods: newTournamentMethods,
+      tournamentIds: [tournamentId],
+      mutationEngine: engine,
+      providerStorage: bareProviderStorage,
+    });
+    expect(applied).toEqual([]);
+    expect(engine.executionQueue).not.toHaveBeenCalled();
+  });
+
+  it('skips records with no owning provider (no parentOrganisation)', async () => {
+    const engine = makeEngine({ tournamentId });
+    const applied = await attachProviderPolicies({
+      methods: newTournamentMethods,
+      tournamentIds: [tournamentId],
+      mutationEngine: engine,
+      providerStorage,
+    });
+    expect(applied).toEqual([]);
+    expect(providerStorage.getProvider).not.toHaveBeenCalled();
+  });
+
+  it('fail-soft: a provider-lookup error never throws and yields no applied methods', async () => {
+    const throwingStorage: any = { getProvider: jest.fn().mockRejectedValue(new Error('db down')) };
+    const engine = makeEngine({ tournamentId, parentOrganisation: { organisationId: PROVIDER_ID } });
+    const applied = await attachProviderPolicies({
+      methods: newTournamentMethods,
+      tournamentIds: [tournamentId],
+      mutationEngine: engine,
+      providerStorage: throwingStorage,
+    });
+    expect(applied).toEqual([]);
+    expect(engine.executionQueue).not.toHaveBeenCalled();
+  });
+
+  it('returns nothing when providerStorage is not injected', async () => {
+    const engine = makeEngine({ tournamentId, parentOrganisation: { organisationId: PROVIDER_ID } });
+    const applied = await attachProviderPolicies({
+      methods: newTournamentMethods,
+      tournamentIds: [tournamentId],
+      mutationEngine: engine,
+      providerStorage: undefined,
+    });
+    expect(applied).toEqual([]);
   });
 });

--- a/src/modules/factory/functions/private/executionQueue.spec.ts
+++ b/src/modules/factory/functions/private/executionQueue.spec.ts
@@ -111,8 +111,8 @@ describe('attachProviderPolicies (privacy attach hook)', () => {
   // A provider whose effective config exposes the selected privacy policy.
   const providerStorage: any = {
     getProvider: jest.fn().mockResolvedValue({
-      caps: {},
-      settings: { participantPrivacyPolicy: privacyPolicy },
+      providerConfigCaps: {},
+      providerConfigSettings: { participantPrivacyPolicy: privacyPolicy },
     }),
   };
 
@@ -167,7 +167,7 @@ describe('attachProviderPolicies (privacy attach hook)', () => {
 
   it('is a no-op when the provider has no privacy policy configured', async () => {
     const bareProviderStorage: any = {
-      getProvider: jest.fn().mockResolvedValue({ caps: {}, settings: {} }),
+      getProvider: jest.fn().mockResolvedValue({ providerConfigCaps: {}, providerConfigSettings: {} }),
     };
     const engine = makeEngine({ tournamentId, parentOrganisation: { organisationId: PROVIDER_ID } });
     const applied = await attachProviderPolicies({

--- a/src/modules/factory/functions/private/executionQueue.ts
+++ b/src/modules/factory/functions/private/executionQueue.ts
@@ -1,11 +1,14 @@
+import { tournamentEngineAsync, factoryConstants } from 'tods-competition-factory';
 import { withTournamentLock } from 'src/services/tournamentMutex';
 import { getMutationEngine } from '../../engines/getMutationEngine';
-import { tournamentEngineAsync } from 'tods-competition-factory';
+import { computeEffectiveConfig } from '@courthive/provider-config';
 import { Logger } from '@nestjs/common';
 
+import type { ITournamentProvisionerStorage, IProviderStorage } from 'src/storage/interfaces';
 import type { TournamentStorageService } from 'src/storage/tournament-storage.service';
-import type { ITournamentProvisionerStorage } from 'src/storage/interfaces';
 import type { AuditService } from 'src/modules/audit/audit.service';
+
+const POLICY_TYPE_PARTICIPANT = factoryConstants.policyConstants.POLICY_TYPE_PARTICIPANT;
 
 export async function executionQueue(
   payload: any,
@@ -13,6 +16,7 @@ export async function executionQueue(
   storage?: TournamentStorageService,
   auditService?: AuditService,
   tournamentProvisionerStorage?: ITournamentProvisionerStorage,
+  providerStorage?: IProviderStorage,
 ): Promise<any> {
   const { methods = [], rollbackOnError } = payload ?? {};
   const tournamentIds = payload?.tournamentIds || (payload?.tournamentId && [payload.tournamentId]) || [];
@@ -60,6 +64,17 @@ export async function executionQueue(
       mutationEngine.setState(result.tournamentRecords);
       const innerResult = await mutationEngine.executionQueue(methods, rollbackOnError);
 
+      // PRIVACY ATTACH HOOK: when a new tournament is created, attach the
+      // owning provider's selected participant-privacy policy to the record
+      // BEFORE save so public reads (getParticipants) honor it immediately.
+      // The appended methods are returned as `appliedServerMethods` so the
+      // TMX client can replay them locally and keep its state in sync — a
+      // general server-directive mechanism, not privacy-specific. Fail-soft:
+      // a resolution error never blocks the create ack.
+      const appliedServerMethods = innerResult.success
+        ? await attachProviderPolicies({ methods, tournamentIds, mutationEngine, providerStorage })
+        : [];
+
       if (innerResult.success) {
         const mutatedTournamentRecords: any = mutationEngine.getState().tournamentRecords;
         const updateResult = await storage.saveTournamentRecords({
@@ -106,7 +121,7 @@ export async function executionQueue(
         }).catch((err) => Logger.error(`Audit hook failed: ${err.message}`, 'executionQueue'));
       }
 
-      return innerResult;
+      return appliedServerMethods.length ? { ...innerResult, appliedServerMethods } : innerResult;
     });
 
     Logger.debug(`[executionQueue] publicNotices: ${publicNotices.length}`);
@@ -214,6 +229,71 @@ async function resolveMatchUpReferences(
       if (found.matchUp.eventId) params.eventId = found.matchUp.eventId;
     }
   }
+}
+
+/**
+ * On new-tournament creation, attach the owning provider's selected
+ * participant-privacy policy to each created tournamentRecord (in the
+ * already-executing mutationEngine, before save). Returns the method
+ * descriptors that were actually applied, so the caller can hand them back
+ * to the client as `appliedServerMethods` for local replay.
+ *
+ * Runs only when the batch contains a `newTournamentRecord` method. The
+ * owning provider is resolved from the created record's
+ * `parentOrganisation.organisationId` — the same field `getParticipants`
+ * uses — so the provisioner and TMX creation paths resolve identically.
+ * `attachPolicies` is idempotent per policy type (it skips a type already
+ * present), so a record that somehow already carries the policy is a no-op.
+ * Fail-soft: any provider-lookup or attach error is swallowed per-record and
+ * never blocks the create.
+ */
+export async function attachProviderPolicies({
+  methods,
+  tournamentIds,
+  mutationEngine,
+  providerStorage,
+}: {
+  methods: any[];
+  tournamentIds: string[];
+  mutationEngine: any;
+  providerStorage?: IProviderStorage;
+}): Promise<any[]> {
+  if (!providerStorage) return [];
+  const hasNewTournament = methods.some((m: any) => m?.method === 'newTournamentRecord');
+  if (!hasNewTournament) return [];
+
+  const applied: any[] = [];
+  const tournamentRecords: any = mutationEngine.getState().tournamentRecords ?? {};
+
+  for (const tournamentId of tournamentIds) {
+    const record = tournamentRecords[tournamentId];
+    const providerId = record?.parentOrganisation?.organisationId;
+    if (!providerId) continue;
+
+    let policy: Record<string, any> | undefined;
+    try {
+      const provider: any = await providerStorage.getProvider(providerId);
+      const effective = computeEffectiveConfig(provider?.caps, provider?.settings);
+      policy = effective?.participantPrivacyPolicy;
+    } catch (err: any) {
+      Logger.error(`Privacy policy resolve failed for provider ${providerId}: ${err?.message}`, 'executionQueue');
+      continue;
+    }
+    if (!policy || !Object.keys(policy).length) continue;
+
+    const attachMethod = {
+      method: 'attachPolicies',
+      params: { policyDefinitions: { [POLICY_TYPE_PARTICIPANT]: policy }, tournamentId },
+    };
+    try {
+      const res: any = await mutationEngine.executionQueue([attachMethod], false);
+      if (res?.success) applied.push(attachMethod);
+    } catch (err: any) {
+      Logger.error(`Privacy policy attach failed for ${tournamentId}: ${err?.message}`, 'executionQueue');
+    }
+  }
+
+  return applied;
 }
 
 /** Fire-and-forget: stamp tournament_provisioner table + parentOrganisation extension. */

--- a/src/modules/factory/functions/private/executionQueue.ts
+++ b/src/modules/factory/functions/private/executionQueue.ts
@@ -273,7 +273,7 @@ export async function attachProviderPolicies({
     let policy: Record<string, any> | undefined;
     try {
       const provider: any = await providerStorage.getProvider(providerId);
-      const effective = computeEffectiveConfig(provider?.caps, provider?.settings);
+      const effective = computeEffectiveConfig(provider?.providerConfigCaps, provider?.providerConfigSettings);
       policy = effective?.participantPrivacyPolicy;
     } catch (err: any) {
       Logger.error(`Privacy policy resolve failed for provider ${providerId}: ${err?.message}`, 'executionQueue');

--- a/src/modules/factory/functions/public/getParticipants.spec.ts
+++ b/src/modules/factory/functions/public/getParticipants.spec.ts
@@ -69,7 +69,9 @@ function buildTournamentStorage(record: any): ITournamentStorage {
 function buildProviderStorage(participantPrivacy?: { cityState?: boolean }): IProviderStorage {
   return {
     // participantPrivacy is provider-owned and lives on settings, not caps.
-    getProvider: async () => ({ caps: {}, settings: { participantPrivacy } }),
+    // getProvider returns the persisted shape (providerConfigCaps/Settings),
+    // which is what computeEffectiveConfig consumes.
+    getProvider: async () => ({ providerConfigCaps: {}, providerConfigSettings: { participantPrivacy } }),
     getProviders: async () => [],
     setProvider: async () => ({ success: true }),
     removeProvider: async () => ({ success: true }),

--- a/src/modules/factory/functions/public/getParticipants.ts
+++ b/src/modules/factory/functions/public/getParticipants.ts
@@ -59,7 +59,7 @@ export async function getParticipants(
   if (providerId && providerStorage) {
     try {
       const provider = await providerStorage.getProvider(providerId);
-      const effective = computeEffectiveConfig(provider?.caps, provider?.settings);
+      const effective = computeEffectiveConfig(provider?.providerConfigCaps, provider?.providerConfigSettings);
       participantPrivacy = effective.participantPrivacy;
     } catch {
       // Provider lookup failure → fall through to default-strict policy.

--- a/src/modules/factory/helpers/attachProviderPrivacyOnCreate.spec.ts
+++ b/src/modules/factory/helpers/attachProviderPrivacyOnCreate.spec.ts
@@ -22,7 +22,7 @@ const existsStorage = {
 };
 
 const providerWithPolicy = {
-  getProvider: jest.fn().mockResolvedValue({ caps: {}, settings: { participantPrivacyPolicy: privacyPolicy } }),
+  getProvider: jest.fn().mockResolvedValue({ providerConfigCaps: {}, providerConfigSettings: { participantPrivacyPolicy: privacyPolicy } }),
 };
 
 function participantPolicyOn(record: any) {
@@ -78,7 +78,7 @@ describe('attachProviderPrivacyOnCreate (REST /factory/save create path)', () =>
 
   it('does NOT attach when the provider has no privacy policy configured', async () => {
     const record = makeRecord();
-    const bareProvider = { getProvider: jest.fn().mockResolvedValue({ caps: {}, settings: {} }) };
+    const bareProvider = { getProvider: jest.fn().mockResolvedValue({ providerConfigCaps: {}, providerConfigSettings: {} }) };
     const attached = await attachProviderPrivacyOnCreate(record, {
       tournamentStorageService: notFoundStorage as any,
       providerStorage: bareProvider as any,

--- a/src/modules/factory/helpers/attachProviderPrivacyOnCreate.spec.ts
+++ b/src/modules/factory/helpers/attachProviderPrivacyOnCreate.spec.ts
@@ -1,0 +1,100 @@
+import { factoryConstants } from 'tods-competition-factory';
+import { attachProviderPrivacyOnCreate } from './attachProviderPrivacyOnCreate';
+
+const POLICY_TYPE_PARTICIPANT = factoryConstants.policyConstants.POLICY_TYPE_PARTICIPANT;
+const MISSING_TOURNAMENT_RECORD = factoryConstants.errorConditionConstants.MISSING_TOURNAMENT_RECORD;
+
+const PROVIDER_ID = 'priv-provider-1';
+const TOURNAMENT_ID = 'save-path-tournament-1';
+const privacyPolicy = { policyName: 'Test Privacy', participant: { person: { addresses: false } } };
+
+function makeRecord(overrides: any = {}) {
+  return { tournamentId: TOURNAMENT_ID, parentOrganisation: { organisationId: PROVIDER_ID }, ...overrides };
+}
+
+// storage that reports the tournament does NOT yet exist → creation
+const notFoundStorage = {
+  fetchTournamentUpdatedAt: jest.fn().mockResolvedValue({ error: MISSING_TOURNAMENT_RECORD }),
+};
+// storage that reports the tournament DOES exist → edit-save
+const existsStorage = {
+  fetchTournamentUpdatedAt: jest.fn().mockResolvedValue({ success: true, updatedAt: '2026-07-01T00:00:00Z' }),
+};
+
+const providerWithPolicy = {
+  getProvider: jest.fn().mockResolvedValue({ caps: {}, settings: { participantPrivacyPolicy: privacyPolicy } }),
+};
+
+function participantPolicyOn(record: any) {
+  const applied = record?.extensions?.find((e: any) => e.name === 'appliedPolicies')?.value;
+  return applied?.[POLICY_TYPE_PARTICIPANT];
+}
+
+describe('attachProviderPrivacyOnCreate (REST /factory/save create path)', () => {
+  beforeEach(() => jest.clearAllMocks());
+
+  it('attaches the provider privacy policy on creation (tournament not yet in storage)', async () => {
+    const record = makeRecord();
+    const attached = await attachProviderPrivacyOnCreate(record, {
+      tournamentStorageService: notFoundStorage as any,
+      providerStorage: providerWithPolicy as any,
+    });
+    expect(attached).toBe(true);
+    expect(participantPolicyOn(record)).toEqual(privacyPolicy);
+  });
+
+  it('does NOT attach on an edit-save (tournament already exists)', async () => {
+    const record = makeRecord();
+    const attached = await attachProviderPrivacyOnCreate(record, {
+      tournamentStorageService: existsStorage as any,
+      providerStorage: providerWithPolicy as any,
+    });
+    expect(attached).toBe(false);
+    expect(providerWithPolicy.getProvider).not.toHaveBeenCalled();
+    expect(participantPolicyOn(record)).toBeUndefined();
+  });
+
+  it('does NOT attach when the record already carries a participant policy (hot path — no storage call)', async () => {
+    const record = makeRecord({
+      extensions: [{ name: 'appliedPolicies', value: { [POLICY_TYPE_PARTICIPANT]: privacyPolicy } }],
+    });
+    const attached = await attachProviderPrivacyOnCreate(record, {
+      tournamentStorageService: notFoundStorage as any,
+      providerStorage: providerWithPolicy as any,
+    });
+    expect(attached).toBe(false);
+    expect(notFoundStorage.fetchTournamentUpdatedAt).not.toHaveBeenCalled();
+  });
+
+  it('skips records with no owning provider', async () => {
+    const record = makeRecord({ parentOrganisation: undefined });
+    const attached = await attachProviderPrivacyOnCreate(record, {
+      tournamentStorageService: notFoundStorage as any,
+      providerStorage: providerWithPolicy as any,
+    });
+    expect(attached).toBe(false);
+    expect(notFoundStorage.fetchTournamentUpdatedAt).not.toHaveBeenCalled();
+  });
+
+  it('does NOT attach when the provider has no privacy policy configured', async () => {
+    const record = makeRecord();
+    const bareProvider = { getProvider: jest.fn().mockResolvedValue({ caps: {}, settings: {} }) };
+    const attached = await attachProviderPrivacyOnCreate(record, {
+      tournamentStorageService: notFoundStorage as any,
+      providerStorage: bareProvider as any,
+    });
+    expect(attached).toBe(false);
+    expect(participantPolicyOn(record)).toBeUndefined();
+  });
+
+  it('does NOT attach on an uncertain existence check (non-missing storage error)', async () => {
+    const record = makeRecord();
+    const erroringStorage = { fetchTournamentUpdatedAt: jest.fn().mockResolvedValue({ error: 'DB_DOWN' }) };
+    const attached = await attachProviderPrivacyOnCreate(record, {
+      tournamentStorageService: erroringStorage as any,
+      providerStorage: providerWithPolicy as any,
+    });
+    expect(attached).toBe(false);
+    expect(providerWithPolicy.getProvider).not.toHaveBeenCalled();
+  });
+});

--- a/src/modules/factory/helpers/attachProviderPrivacyOnCreate.ts
+++ b/src/modules/factory/helpers/attachProviderPrivacyOnCreate.ts
@@ -48,7 +48,7 @@ export async function attachProviderPrivacyOnCreate(record: any, deps: Deps): Pr
   if (existing?.error !== MISSING_TOURNAMENT_RECORD) return false;
 
   const provider: any = await deps.providerStorage.getProvider(providerId);
-  const policy = computeEffectiveConfig(provider?.caps, provider?.settings)?.participantPrivacyPolicy;
+  const policy = computeEffectiveConfig(provider?.providerConfigCaps, provider?.providerConfigSettings)?.participantPrivacyPolicy;
   if (!policy || !Object.keys(policy).length) return false;
 
   const result: any = policyGovernor.attachPolicies({

--- a/src/modules/factory/helpers/attachProviderPrivacyOnCreate.ts
+++ b/src/modules/factory/helpers/attachProviderPrivacyOnCreate.ts
@@ -1,0 +1,59 @@
+import { queryGovernor, policyGovernor, factoryConstants } from 'tods-competition-factory';
+import { computeEffectiveConfig } from '@courthive/provider-config';
+
+import type { TournamentStorageService } from 'src/storage/tournament-storage.service';
+import type { IProviderStorage } from 'src/storage/interfaces';
+
+const POLICY_TYPE_PARTICIPANT = factoryConstants.policyConstants.POLICY_TYPE_PARTICIPANT;
+const MISSING_TOURNAMENT_RECORD = factoryConstants.errorConditionConstants.MISSING_TOURNAMENT_RECORD;
+
+type Deps = {
+  tournamentStorageService: Pick<TournamentStorageService, 'fetchTournamentUpdatedAt'>;
+  providerStorage: Pick<IProviderStorage, 'getProvider'>;
+};
+
+/**
+ * Attach the owning provider's participant-privacy policy to a tournament
+ * record, but ONLY on creation. Used by the TMX UI create path
+ * (sendTournament → POST /factory/save → FactoryService.saveTournamentRecords),
+ * mirroring the executionQueue create hook for the API/provisioner path.
+ *
+ * Skips (returns false) when:
+ *  - the record has no owning provider or no tournamentId,
+ *  - it already carries a participant policy (the hot path — every tournament
+ *    created after this feature already has it),
+ *  - it already exists in storage (an edit-save; never force a privacy change
+ *    on an in-flight tournament without acknowledgment), or
+ *  - the provider has no participant-privacy policy configured.
+ *
+ * Any storage error other than "missing tournament" also aborts — we never
+ * attach on an uncertain existence check. Mutates the record's APPLIED_POLICIES
+ * extension in place. Returns true iff a policy was attached.
+ */
+export async function attachProviderPrivacyOnCreate(record: any, deps: Deps): Promise<boolean> {
+  const providerId = record?.parentOrganisation?.organisationId;
+  const tournamentId = record?.tournamentId;
+  if (!providerId || !tournamentId) return false;
+
+  const existingPolicy = queryGovernor.getPolicyDefinitions({
+    tournamentRecord: record,
+    policyTypes: [POLICY_TYPE_PARTICIPANT],
+  })?.policyDefinitions?.[POLICY_TYPE_PARTICIPANT];
+  if (existingPolicy) return false;
+
+  // Creation gate: attach only when the tournament positively does not yet
+  // exist. A success (updatedAt present) means edit-save; any other error
+  // means we can't confirm creation → skip.
+  const existing: any = await deps.tournamentStorageService.fetchTournamentUpdatedAt({ tournamentId });
+  if (existing?.error !== MISSING_TOURNAMENT_RECORD) return false;
+
+  const provider: any = await deps.providerStorage.getProvider(providerId);
+  const policy = computeEffectiveConfig(provider?.caps, provider?.settings)?.participantPrivacyPolicy;
+  if (!policy || !Object.keys(policy).length) return false;
+
+  const result: any = policyGovernor.attachPolicies({
+    tournamentRecord: record,
+    policyDefinitions: { [POLICY_TYPE_PARTICIPANT]: policy },
+  });
+  return !!result?.success;
+}

--- a/src/modules/factory/helpers/selectPrivacyApplyTargets.spec.ts
+++ b/src/modules/factory/helpers/selectPrivacyApplyTargets.spec.ts
@@ -1,0 +1,48 @@
+import { selectPrivacyApplyTargets } from './selectPrivacyApplyTargets';
+
+const today = '2026-07-03';
+
+function cal(id: string, startDate: string, endDate: string) {
+  return { tournamentId: id, tournament: { startDate, endDate } };
+}
+
+const calendar = [
+  cal('past', '2026-06-01', '2026-06-10'), // completed
+  cal('ends-yesterday', '2026-06-20', '2026-07-02'), // completed (endDate < today)
+  cal('live', '2026-07-01', '2026-07-05'), // in progress (start <= today <= end)
+  cal('starts-today', '2026-07-03', '2026-07-08'), // in progress (start == today)
+  cal('ends-today', '2026-06-30', '2026-07-03'), // in progress (end == today)
+  cal('future', '2026-08-01', '2026-08-05'), // upcoming
+];
+
+describe('selectPrivacyApplyTargets', () => {
+  it('selects upcoming only by default (never completed, never in-progress)', () => {
+    const r = selectPrivacyApplyTargets(calendar, { includeInProgress: false, today });
+    expect(r.selected).toEqual(['future']);
+    expect(r.upcoming).toEqual(['future']);
+    expect(r.inProgress.sort()).toEqual(['ends-today', 'live', 'starts-today']);
+    expect(r.completed.sort()).toEqual(['ends-yesterday', 'past']);
+  });
+
+  it('includes in-progress when opted in, still excludes completed', () => {
+    const r = selectPrivacyApplyTargets(calendar, { includeInProgress: true, today });
+    expect(r.selected.sort()).toEqual(['ends-today', 'future', 'live', 'starts-today']);
+    // completed are never selected
+    expect(r.selected).not.toContain('past');
+    expect(r.selected).not.toContain('ends-yesterday');
+  });
+
+  it('drops entries with missing dates as skipped', () => {
+    const r = selectPrivacyApplyTargets(
+      [cal('ok', '2026-08-01', '2026-08-05'), { tournamentId: 'no-dates' }, { tournament: {} }],
+      { includeInProgress: true, today },
+    );
+    expect(r.selected).toEqual(['ok']);
+    expect(r.skipped).toEqual(['no-dates']);
+  });
+
+  it('handles an empty / undefined calendar', () => {
+    expect(selectPrivacyApplyTargets([], { includeInProgress: true, today }).selected).toEqual([]);
+    expect(selectPrivacyApplyTargets(undefined as any, { includeInProgress: true, today }).selected).toEqual([]);
+  });
+});

--- a/src/modules/factory/helpers/selectPrivacyApplyTargets.ts
+++ b/src/modules/factory/helpers/selectPrivacyApplyTargets.ts
@@ -1,0 +1,57 @@
+/**
+ * Classify a provider's calendar tournaments for the "apply participant-privacy
+ * policy to existing tournaments" action, per the confirmed decisions:
+ *   - UPCOMING tournaments are always selected,
+ *   - IN-PROGRESS tournaments are selected only when the caller opts in,
+ *   - COMPLETED / historical tournaments are NEVER touched.
+ *
+ * Classification is by calendar date only (date-only ISO strings compare
+ * chronologically as plain strings):
+ *   - completed:   endDate  <  today
+ *   - in-progress: startDate <= today <= endDate
+ *   - upcoming:    startDate >  today
+ *
+ * Entries with unusable dates are dropped (counted as `skipped`).
+ */
+export type CalendarTournament = {
+  tournamentId?: string;
+  tournament?: { startDate?: string; endDate?: string };
+};
+
+export type PrivacyApplyTargets = {
+  selected: string[];
+  upcoming: string[];
+  inProgress: string[];
+  completed: string[];
+  skipped: string[];
+};
+
+export function selectPrivacyApplyTargets(
+  tournaments: CalendarTournament[],
+  { includeInProgress, today }: { includeInProgress: boolean; today: string },
+): PrivacyApplyTargets {
+  const result: PrivacyApplyTargets = { selected: [], upcoming: [], inProgress: [], completed: [], skipped: [] };
+
+  for (const entry of tournaments ?? []) {
+    const tournamentId = entry?.tournamentId;
+    const startDate = entry?.tournament?.startDate;
+    const endDate = entry?.tournament?.endDate;
+    if (!tournamentId || !startDate || !endDate) {
+      if (tournamentId) result.skipped.push(tournamentId);
+      continue;
+    }
+
+    if (endDate < today) {
+      result.completed.push(tournamentId);
+    } else if (startDate > today) {
+      result.upcoming.push(tournamentId);
+      result.selected.push(tournamentId);
+    } else {
+      // startDate <= today <= endDate → in progress
+      result.inProgress.push(tournamentId);
+      if (includeInProgress) result.selected.push(tournamentId);
+    }
+  }
+
+  return result;
+}

--- a/src/modules/factory/privacy-attach.e2e.spec.ts
+++ b/src/modules/factory/privacy-attach.e2e.spec.ts
@@ -1,0 +1,179 @@
+import { mocksEngine, factoryConstants, fixtures } from 'tods-competition-factory';
+import { AppModule } from 'src/modules/app/app.module';
+import { INestApplication } from '@nestjs/common';
+import { Test, TestingModule } from '@nestjs/testing';
+import bcrypt from 'bcryptjs';
+import request from 'supertest';
+
+import { PROVIDER_STORAGE, type IProviderStorage } from 'src/storage/interfaces';
+import { PG_POOL } from 'src/storage/postgres/postgres.config';
+
+const POLICY_TYPE_PARTICIPANT = factoryConstants.policyConstants.POLICY_TYPE_PARTICIPANT;
+
+// Hermetic: the spec seeds its own superadmin (below) so it needs no external
+// user fixture — only Postgres + Redis, which the app itself requires.
+const ADMIN_EMAIL = 'e2e-privacy-admin@courthive.test';
+const ADMIN_PASSWORD = 'e2e-verify-pass';
+
+const PROVIDER_ID = 'e2e-privacy-provider';
+const PROVIDER_ABBR = 'E2EPRIV';
+const tid = (suffix: string) => `test-privacy-e2e-${suffix}`;
+
+// A realistic participant-privacy policy (inner value shape, as stored in
+// settings.participantPrivacyPolicy), tagged so we can assert it round-tripped.
+const basePrivacy: any = fixtures.policies.POLICY_PRIVACY_DEFAULT[POLICY_TYPE_PARTICIPANT];
+const privacyPolicy = { ...basePrivacy, policyName: 'E2E Privacy' };
+
+function participantPolicyOn(record: any) {
+  const applied = record?.extensions?.find((e: any) => e.name === 'appliedPolicies')?.value;
+  return applied?.[POLICY_TYPE_PARTICIPANT];
+}
+
+function ownedTournament(tournamentId: string, startDate: string, endDate: string) {
+  const { tournamentRecord } = mocksEngine.generateTournamentRecord({
+    tournamentAttributes: { tournamentId, startDate, endDate },
+    drawProfiles: [{ drawSize: 4 }],
+  });
+  // mocksEngine derives its own dates from the draw schedule, so pin the
+  // tournament dates explicitly — the provider calendar (and apply-to-existing
+  // classification) reads tournamentRecord.startDate/endDate.
+  tournamentRecord.startDate = startDate;
+  tournamentRecord.endDate = endDate;
+  tournamentRecord.parentOrganisation = { organisationId: PROVIDER_ID };
+  return tournamentRecord;
+}
+
+// Live-stack verification for Part A (privacy-policy attachment). Boots the real
+// Nest app against Postgres + Redis and exercises the real HTTP endpoints — this
+// is what catches storage-shape bugs the unit mocks can't (e.g. providerConfig*
+// vs caps/settings). Seeds + tears down its own provider and tournaments.
+describe('participant-privacy attachment (e2e)', () => {
+  let app: INestApplication;
+  let token: string;
+  let server: any;
+  let pool: any;
+
+  const auth = () => ({ Authorization: `Bearer ${token}` });
+  const fetchRecord = async (tournamentId: string) => {
+    const res = await request(server).post('/factory/fetch').set(auth()).send({ tournamentIds: [tournamentId] });
+    return res.body?.tournamentRecords?.[tournamentId];
+  };
+
+  // Dates relative to "today" so classification is stable regardless of run date.
+  const iso = (offsetDays: number) => {
+    const base = Date.parse('2026-07-03T00:00:00Z') + offsetDays * 86400000;
+    return new Date(base).toISOString().split('T')[0];
+  };
+
+  beforeAll(async () => {
+    const moduleRef: TestingModule = await Test.createTestingModule({ imports: [AppModule] }).compile();
+    app = moduleRef.createNestApplication();
+    await app.init();
+    server = app.getHttpServer();
+    pool = app.get(PG_POOL);
+
+    // Seed a self-contained superadmin (bcrypt hash, verified, no forced change).
+    const passwordHash = await bcrypt.hash(ADMIN_PASSWORD, 10);
+    await pool.query(
+      `INSERT INTO users (email, password, roles, permissions, data, must_change_password, email_verified_at, updated_at)
+       VALUES ($1, $2, $3, '{}'::jsonb, '{}'::jsonb, false, NOW(), NOW())
+       ON CONFLICT (email) DO UPDATE SET
+         password = EXCLUDED.password, roles = EXCLUDED.roles,
+         must_change_password = false, email_verified_at = NOW()`,
+      [ADMIN_EMAIL, passwordHash, JSON.stringify(['superadmin', 'admin', 'client'])],
+    );
+
+    const loginReq = await request(server).post('/auth/login').send({ email: ADMIN_EMAIL, password: ADMIN_PASSWORD });
+    token = loginReq.body.token;
+    expect(token).toBeTruthy();
+
+    // Start from a clean slate (defends against leftovers from an aborted run).
+    await pool.query(`DELETE FROM tournaments WHERE tournament_id LIKE 'test-privacy-e2e-%'`).catch(() => {});
+    await pool.query(`DELETE FROM calendars WHERE provider_abbr = $1`, [PROVIDER_ABBR]).catch(() => {});
+
+    // Seed the test provider WITHOUT a privacy policy initially.
+    const providerStorage = app.get<IProviderStorage>(PROVIDER_STORAGE);
+    await providerStorage.setProvider(PROVIDER_ID, {
+      organisationAbbreviation: PROVIDER_ABBR,
+      organisationName: 'E2E Privacy Provider',
+    });
+    await providerStorage.updateProviderSettings(PROVIDER_ID, {});
+  });
+
+  afterAll(async () => {
+    // Clean up test rows regardless of assertions.
+    await pool.query(`DELETE FROM tournaments WHERE tournament_id LIKE 'test-privacy-e2e-%'`).catch(() => {});
+    await pool.query(`DELETE FROM calendars WHERE provider_abbr = $1`, [PROVIDER_ABBR]).catch(() => {});
+    await pool.query(`DELETE FROM providers WHERE provider_id = $1`, [PROVIDER_ID]).catch(() => {});
+    await pool.query(`DELETE FROM users WHERE email = $1`, [ADMIN_EMAIL]).catch(() => {});
+    await app.close();
+  });
+
+  it('does NOT attach on creation when the provider has no privacy policy', async () => {
+    // Create both an upcoming and a completed tournament while the provider has
+    // no policy configured, so both go into apply-to-existing policy-less.
+    // (Creation attaches the CURRENT policy regardless of dates, so a policy-less
+    // completed tournament can only exist if created before the policy is set.)
+    await request(server)
+      .post('/factory/save')
+      .set(auth())
+      .send({ tournamentRecord: ownedTournament(tid('upcoming'), iso(10), iso(15)) })
+      .expect(200);
+    await request(server)
+      .post('/factory/save')
+      .set(auth())
+      .send({ tournamentRecord: ownedTournament(tid('completed'), iso(-30), iso(-20)) })
+      .expect(200);
+
+    expect(participantPolicyOn(await fetchRecord(tid('upcoming')))).toBeUndefined();
+    expect(participantPolicyOn(await fetchRecord(tid('completed')))).toBeUndefined();
+  });
+
+  it('attaches the provider privacy policy on creation via /factory/save (REST create path)', async () => {
+    // Configure the provider's privacy policy, then create a new tournament.
+    const providerStorage = app.get<IProviderStorage>(PROVIDER_STORAGE);
+    await providerStorage.updateProviderSettings(PROVIDER_ID, { participantPrivacyPolicy: privacyPolicy });
+
+    await request(server)
+      .post('/factory/save')
+      .set(auth())
+      .send({ tournamentRecord: ownedTournament(tid('created'), iso(20), iso(25)) })
+      .expect(200);
+
+    const record = await fetchRecord(tid('created'));
+    const attached = participantPolicyOn(record);
+    expect(attached).toBeTruthy();
+    expect(attached.policyName).toBe('E2E Privacy');
+  });
+
+  it('apply-to-existing attaches to upcoming, reports already-attached, and never touches completed', async () => {
+    // Going in: 'upcoming' + 'completed' are policy-less (created before the
+    // policy); 'created' already carries it (attached on creation).
+    const res = await request(server)
+      .post('/factory/apply-privacy-policy')
+      .set(auth())
+      .send({ providerId: PROVIDER_ID, includeInProgress: false })
+      .expect(200);
+
+    const body = res.body;
+    expect(body.success).toBe(true);
+    // 'upcoming' had no policy → freshly attached; 'created' already had it.
+    expect(body.attached).toContain(tid('upcoming'));
+    expect(body.alreadyAttached).toContain(tid('created'));
+    // Completed is never selected.
+    expect(body.attached).not.toContain(tid('completed'));
+    expect(body.alreadyAttached).not.toContain(tid('completed'));
+
+    // Verify persisted state matches the report.
+    expect(participantPolicyOn(await fetchRecord(tid('upcoming')))?.policyName).toBe('E2E Privacy');
+    expect(participantPolicyOn(await fetchRecord(tid('completed')))).toBeUndefined();
+  });
+
+  it('rejects apply-to-existing for a non-provider-admin, non-superadmin caller', async () => {
+    // No auth header → 401 from the guard (proves the endpoint is protected).
+    await request(server)
+      .post('/factory/apply-privacy-policy')
+      .send({ providerId: PROVIDER_ID })
+      .expect(401);
+  });
+});

--- a/src/storage/tournament-storage.service.ts
+++ b/src/storage/tournament-storage.service.ts
@@ -300,6 +300,18 @@ export class TournamentStorageService {
     return this.updateCalendar({ provider, tournaments: updatedEntries });
   }
 
+  /**
+   * Public: list a provider's calendar tournament entries (each with
+   * tournamentId + tournament.startDate/endDate). Used by the "apply
+   * participant-privacy policy to existing tournaments" action to enumerate
+   * and classify a provider's tournaments without loading full records.
+   */
+  async listProviderTournaments({ providerId }: { providerId: string }): Promise<any[]> {
+    const result: any = await this.getProviderCalendar({ providerId });
+    if (result?.error) return [];
+    return result.tournaments ?? [];
+  }
+
   // --- Private helpers ---
 
   private async getProviderCalendar({ providerId }: { providerId: string }) {


### PR DESCRIPTION
Part A of the privacy-policy workstream (server). Attaches the owning provider's participant-privacy policy to tournamentRecords on creation (executionQueue API/provisioner path via appliedServerMethods ack, and REST /factory/save path), plus POST /factory/apply-privacy-policy to apply it to existing tournaments (upcoming always; in-progress on opt-in; never completed). Includes a hermetic live-stack e2e (Postgres+Redis) that caught two real bugs now fixed (provider config field shape; EXISTING_POLICY_TYPE object comparison). 22 unit + 4 e2e tests.