### PR TITLE
feat(rankings): provider-scoped recompute (republish + snapshots)

### DIFF
--- a/src/modules/rankings-webhook/provider-rankings.e2e.spec.ts
+++ b/src/modules/rankings-webhook/provider-rankings.e2e.spec.ts
@@ -1,0 +1,155 @@
+import { createServer, type Server } from 'http';
+import { AddressInfo } from 'net';
+
+import { mocksEngine } from 'tods-competition-factory';
+import { AppModule } from 'src/modules/app/app.module';
+import { INestApplication } from '@nestjs/common';
+import { Test, TestingModule } from '@nestjs/testing';
+import bcrypt from 'bcryptjs';
+import request from 'supertest';
+
+import { PROVIDER_STORAGE, type IProviderStorage } from 'src/storage/interfaces';
+import { PG_POOL } from 'src/storage/postgres/postgres.config';
+
+// Hermetic: seeds its own superadmin + provider + tournaments, and stands up a
+// stub "rankings pipeline" (records ingest + snapshot POSTs) so the FULL CFS
+// orchestration is exercised against the real app + Postgres without the real
+// courthive-rankings service. RANKINGS_PIPELINE_URL is read at service
+// construction, so the stub must be listening + the env set BEFORE app boot.
+const ADMIN_EMAIL = 'e2e-rankings-admin@courthive.test';
+const ADMIN_PASSWORD = 'e2e-verify-pass';
+const PROVIDER_ID = 'e2e-rankings-provider';
+const PROVIDER_ABBR = 'E2ERANK';
+const tid = (s: string) => `test-rankings-e2e-${s}`;
+
+describe('provider rankings recompute (e2e)', () => {
+  let app: INestApplication;
+  let server: any;
+  let pool: any;
+  let token: string;
+  let stub: Server;
+  const ingestCalls: any[] = [];
+  const snapshotCalls: any[] = [];
+
+  const auth = () => ({ Authorization: `Bearer ${token}` });
+
+  function ownedTournament(tournamentId: string) {
+    const { tournamentRecord } = mocksEngine.generateTournamentRecord({
+      tournamentAttributes: { tournamentId },
+      drawProfiles: [{ drawSize: 4 }],
+    });
+    tournamentRecord.startDate = '2026-07-10';
+    tournamentRecord.endDate = '2026-07-12';
+    tournamentRecord.parentOrganisation = { organisationId: PROVIDER_ID };
+    return tournamentRecord;
+  }
+
+  beforeAll(async () => {
+    // Stub rankings pipeline — records POSTs, returns canned bodies.
+    stub = createServer((req, res) => {
+      let raw = '';
+      req.on('data', (c) => (raw += c));
+      req.on('end', () => {
+        const body = raw ? JSON.parse(raw) : {};
+        if (req.url === '/tournaments/ingest') {
+          ingestCalls.push(body);
+          res.writeHead(202, { 'content-type': 'application/json' });
+          res.end(JSON.stringify({ ingestionRunId: `run-${ingestCalls.length}`, awardCount: 7 }));
+        } else if (req.url === '/rankings/snapshots') {
+          snapshotCalls.push(body);
+          res.writeHead(201, { 'content-type': 'application/json' });
+          res.end(JSON.stringify({ snapshotId: `snap-${snapshotCalls.length}` }));
+        } else {
+          res.writeHead(404);
+          res.end();
+        }
+      });
+    });
+    await new Promise<void>((resolve) => stub.listen(0, '127.0.0.1', resolve));
+    const port = (stub.address() as AddressInfo).port;
+    process.env.RANKINGS_PIPELINE_URL = `http://127.0.0.1:${port}`;
+
+    const moduleRef: TestingModule = await Test.createTestingModule({ imports: [AppModule] }).compile();
+    app = moduleRef.createNestApplication();
+    await app.init();
+    server = app.getHttpServer();
+    pool = app.get(PG_POOL);
+
+    const passwordHash = await bcrypt.hash(ADMIN_PASSWORD, 10);
+    await pool.query(
+      `INSERT INTO users (email, password, roles, permissions, data, must_change_password, email_verified_at, updated_at)
+       VALUES ($1, $2, $3, '{}'::jsonb, '{}'::jsonb, false, NOW(), NOW())
+       ON CONFLICT (email) DO UPDATE SET password = EXCLUDED.password, roles = EXCLUDED.roles,
+         must_change_password = false, email_verified_at = NOW()`,
+      [ADMIN_EMAIL, passwordHash, JSON.stringify(['superadmin', 'admin', 'client'])],
+    );
+    token = (await request(server).post('/auth/login').send({ email: ADMIN_EMAIL, password: ADMIN_PASSWORD })).body.token;
+    expect(token).toBeTruthy();
+
+    // Clean slate + seed provider (needs an abbreviation for calendar + policy routing).
+    await pool.query(`DELETE FROM tournaments WHERE tournament_id LIKE 'test-rankings-e2e-%'`).catch(() => {});
+    await pool.query(`DELETE FROM calendars WHERE provider_abbr = $1`, [PROVIDER_ABBR]).catch(() => {});
+    const providerStorage = app.get<IProviderStorage>(PROVIDER_STORAGE);
+    await providerStorage.setProvider(PROVIDER_ID, {
+      organisationAbbreviation: PROVIDER_ABBR,
+      organisationName: 'E2E Rankings Provider',
+    });
+
+    // Create two provider-owned tournaments (land them in the provider calendar).
+    for (const s of ['a', 'b']) {
+      await request(server).post('/factory/save').set(auth()).send({ tournamentRecord: ownedTournament(tid(s)) }).expect(200);
+    }
+  });
+
+  afterAll(async () => {
+    await pool.query(`DELETE FROM tournaments WHERE tournament_id LIKE 'test-rankings-e2e-%'`).catch(() => {});
+    await pool.query(`DELETE FROM calendars WHERE provider_abbr = $1`, [PROVIDER_ABBR]).catch(() => {});
+    await pool.query(`DELETE FROM providers WHERE provider_id = $1`, [PROVIDER_ID]).catch(() => {});
+    await pool.query(`DELETE FROM users WHERE email = $1`, [ADMIN_EMAIL]).catch(() => {});
+    await app.close();
+    await new Promise<void>((resolve) => stub.close(() => resolve()));
+    delete process.env.RANKINGS_PIPELINE_URL;
+  });
+
+  it('rejects an unauthenticated caller', async () => {
+    await request(server).post(`/admin/rankings-webhook/republish-provider/${PROVIDER_ID}`).send({}).expect(401);
+  });
+
+  it('republishes every provider tournament and generates M/F snapshots, returning a summary', async () => {
+    ingestCalls.length = 0;
+    snapshotCalls.length = 0;
+
+    const res = await request(server)
+      .post(`/admin/rankings-webhook/republish-provider/${PROVIDER_ID}`)
+      .set(auth())
+      .send({})
+      .expect(200);
+
+    // Both tournaments were pushed to the stub ingest endpoint.
+    expect(ingestCalls).toHaveLength(2);
+    const ingestedIds = ingestCalls.map((c) => c.tournamentRecord?.tournamentId).sort();
+    expect(ingestedIds).toEqual([tid('a'), tid('b')]);
+
+    // All-ages M + F snapshots, each carrying the provider abbr for policy routing.
+    expect(snapshotCalls).toHaveLength(2);
+    expect(snapshotCalls.map((c) => c.gender).sort()).toEqual(['FEMALE', 'MALE']);
+    for (const c of snapshotCalls) {
+      expect(c.tournamentRecord?.unifiedTournamentId?.organisation?.organisationId).toBe(PROVIDER_ABBR);
+    }
+
+    expect(res.body.counts).toMatchObject({ tournaments: 2, republishedOk: 2, snapshotsOk: 2 });
+  });
+
+  it('expands snapshots across requested age categories × gender', async () => {
+    snapshotCalls.length = 0;
+    const res = await request(server)
+      .post(`/admin/rankings-webhook/republish-provider/${PROVIDER_ID}`)
+      .set(auth())
+      .send({ ageCategoryCodes: ['OPEN', 'U18'] })
+      .expect(200);
+
+    // 2 categories × 2 genders = 4 snapshots.
+    expect(snapshotCalls).toHaveLength(4);
+    expect(res.body.counts.snapshotsOk).toBe(4);
+  });
+});

--- a/src/modules/rankings-webhook/provider-rankings.service.spec.ts
+++ b/src/modules/rankings-webhook/provider-rankings.service.spec.ts
@@ -1,0 +1,71 @@
+import { ProviderRankingsService } from './provider-rankings.service';
+
+const PROVIDER_ID = 'prov-1';
+const ABBR = 'PROV';
+
+function build(overrides: { enabled?: boolean } = {}) {
+  const webhook: any = {
+    isEnabled: jest.fn().mockReturnValue(overrides.enabled ?? true),
+    publish: jest.fn().mockResolvedValue({ ok: true, responseBody: { awardCount: 12 } }),
+    generateSnapshot: jest.fn().mockResolvedValue({ ok: true, responseBody: { snapshotId: 'snap-x' } }),
+  };
+  const tournamentStorage: any = {
+    listProviderTournaments: jest.fn().mockResolvedValue([{ tournamentId: 't1' }, { tournamentId: 't2' }]),
+    fetchTournamentRecords: jest.fn().mockImplementation(({ tournamentIds }: any) => {
+      const id = tournamentIds[0];
+      return Promise.resolve({ tournamentRecords: { [id]: { tournamentId: id } } });
+    }),
+  };
+  const providerStorage: any = {
+    getProvider: jest.fn().mockResolvedValue({ organisationAbbreviation: ABBR }),
+  };
+  const service = new ProviderRankingsService(webhook, tournamentStorage, providerStorage);
+  return { service, webhook, tournamentStorage, providerStorage };
+}
+
+describe('ProviderRankingsService.recompute', () => {
+  beforeEach(() => jest.clearAllMocks());
+
+  it('is a no-op when the rankings pipeline is not configured', async () => {
+    const { service, webhook, tournamentStorage } = build({ enabled: false });
+    const res = await service.recompute({ providerId: PROVIDER_ID });
+    expect(res.skipped).toBe(true);
+    expect(res.reason).toContain('RANKINGS_PIPELINE_URL');
+    expect(webhook.publish).not.toHaveBeenCalled();
+    expect(tournamentStorage.listProviderTournaments).not.toHaveBeenCalled();
+  });
+
+  it('republishes every provider tournament and generates M/F snapshots (all-ages by default)', async () => {
+    const { service, webhook } = build();
+    const res = await service.recompute({ providerId: PROVIDER_ID, asOfDate: '2026-07-04' });
+
+    expect(webhook.publish).toHaveBeenCalledTimes(2);
+    expect(res.counts.tournaments).toBe(2);
+    expect(res.counts.republishedOk).toBe(2);
+    expect(res.republished[0]).toMatchObject({ tournamentId: 't1', ok: true, awardCount: 12 });
+
+    // 1 (all-ages) × 2 genders = 2 snapshots, each passing the provider abbr.
+    expect(webhook.generateSnapshot).toHaveBeenCalledTimes(2);
+    expect(webhook.generateSnapshot).toHaveBeenCalledWith(
+      expect.objectContaining({ asOfDate: '2026-07-04', ageCategoryCode: undefined, gender: 'MALE', providerAbbr: ABBR }),
+    );
+    expect(res.counts.snapshotsOk).toBe(2);
+  });
+
+  it('expands snapshots across ageCategoryCodes × gender', async () => {
+    const { service, webhook } = build();
+    const res = await service.recompute({ providerId: PROVIDER_ID, ageCategoryCodes: ['OPEN', 'U18'] });
+    // 2 age categories × 2 genders = 4 snapshots.
+    expect(webhook.generateSnapshot).toHaveBeenCalledTimes(4);
+    expect(res.snapshots).toHaveLength(4);
+    expect(res.snapshots.map((s) => s.ageCategoryCode).sort()).toEqual(['OPEN', 'OPEN', 'U18', 'U18']);
+  });
+
+  it('records a per-tournament error when the record cannot be fetched', async () => {
+    const { service, tournamentStorage } = build();
+    tournamentStorage.fetchTournamentRecords.mockResolvedValueOnce({ tournamentRecords: {} });
+    const res = await service.recompute({ providerId: PROVIDER_ID });
+    expect(res.republished[0]).toMatchObject({ tournamentId: 't1', ok: false, error: 'record not found' });
+    expect(res.counts.republishedOk).toBe(1); // t2 still succeeds
+  });
+});

--- a/src/modules/rankings-webhook/provider-rankings.service.ts
+++ b/src/modules/rankings-webhook/provider-rankings.service.ts
@@ -1,0 +1,119 @@
+import { Inject, Injectable, Logger } from '@nestjs/common';
+
+import { PROVIDER_STORAGE, type IProviderStorage } from 'src/storage/interfaces';
+import { TournamentStorageService } from 'src/storage/tournament-storage.service';
+import { RankingsWebhookService } from './rankings-webhook.service';
+
+// Standard men's / women's ranking lists. A person's points from MIXED events
+// still flow into the live /bundle (which buckets by person sex); these gendered
+// snapshots are the formal per-list artifacts, filtered by award (event) gender.
+const SNAPSHOT_GENDERS = ['MALE', 'FEMALE'];
+
+export interface RecomputeResult {
+  skipped?: boolean;
+  reason?: string;
+  providerId: string;
+  republished: Array<{ tournamentId: string; ok: boolean; skipped?: boolean; awardCount?: number; error?: string }>;
+  snapshots: Array<{ ageCategoryCode?: string; gender: string; ok: boolean; snapshotId?: string; error?: string }>;
+  counts: { tournaments: number; republishedOk: number; snapshotsOk: number };
+}
+
+/**
+ * Provider-scoped rankings recompute: republish every one of a provider's
+ * tournaments to the rankings pipeline (which refreshes the live /bundle the
+ * public rankings page reads), then regenerate formal ranking snapshots for
+ * each requested age category × gender. Synchronous — returns a per-item
+ * summary. The whole thing is a no-op ({ skipped }) when the rankings pipeline
+ * is not configured (RANKINGS_PIPELINE_URL unset).
+ */
+@Injectable()
+export class ProviderRankingsService {
+  private readonly logger = new Logger(ProviderRankingsService.name);
+
+  constructor(
+    private readonly webhook: RankingsWebhookService,
+    private readonly tournamentStorage: TournamentStorageService,
+    @Inject(PROVIDER_STORAGE) private readonly providerStorage: IProviderStorage,
+  ) {}
+
+  async recompute(args: {
+    providerId: string;
+    ageCategoryCodes?: string[];
+    asOfDate?: string;
+  }): Promise<RecomputeResult> {
+    const { providerId } = args;
+    const republished: RecomputeResult['republished'] = [];
+    const snapshots: RecomputeResult['snapshots'] = [];
+
+    if (!this.webhook.isEnabled()) {
+      return {
+        skipped: true,
+        reason: 'RANKINGS_PIPELINE_URL not set',
+        providerId,
+        republished,
+        snapshots,
+        counts: { tournaments: 0, republishedOk: 0, snapshotsOk: 0 },
+      };
+    }
+
+    const provider: any = await this.providerStorage.getProvider(providerId);
+    const providerAbbr = provider?.organisationAbbreviation;
+
+    // 1. Republish every provider tournament (refreshes point_awards → live bundle).
+    const tournaments = await this.tournamentStorage.listProviderTournaments({ providerId });
+    for (const entry of tournaments) {
+      const tournamentId = entry?.tournamentId;
+      if (!tournamentId) continue;
+      try {
+        const fetched: any = await this.tournamentStorage.fetchTournamentRecords({ tournamentIds: [tournamentId] });
+        const record = fetched?.tournamentRecords?.[tournamentId];
+        if (!record) {
+          republished.push({ tournamentId, ok: false, error: 'record not found' });
+          continue;
+        }
+        const res = await this.webhook.publish(record, { source: 'cfs-event', sourceRef: `provider-recompute:${providerId}` });
+        republished.push({
+          tournamentId,
+          ok: !!res.ok,
+          skipped: res.skipped,
+          awardCount: (res.responseBody as any)?.awardCount,
+          error: res.error,
+        });
+      } catch (err: any) {
+        republished.push({ tournamentId, ok: false, error: err?.message ?? String(err) });
+      }
+    }
+
+    // 2. Regenerate formal snapshots per age category × gender. An empty/absent
+    //    ageCategoryCodes list means one all-ages snapshot per gender.
+    const ageCategoryCodes = args.ageCategoryCodes?.length ? args.ageCategoryCodes : [undefined];
+    const asOfDate = args.asOfDate ?? new Date().toISOString().split('T')[0];
+    for (const ageCategoryCode of ageCategoryCodes) {
+      for (const gender of SNAPSHOT_GENDERS) {
+        try {
+          const res = await this.webhook.generateSnapshot({ asOfDate, ageCategoryCode, gender, providerAbbr });
+          snapshots.push({
+            ageCategoryCode,
+            gender,
+            ok: !!res.ok,
+            snapshotId: (res.responseBody as any)?.snapshotId,
+            error: res.error,
+          });
+        } catch (err: any) {
+          snapshots.push({ ageCategoryCode, gender, ok: false, error: err?.message ?? String(err) });
+        }
+      }
+    }
+
+    const counts = {
+      tournaments: republished.length,
+      republishedOk: republished.filter((r) => r.ok).length,
+      snapshotsOk: snapshots.filter((s) => s.ok).length,
+    };
+    this.logger.log(
+      `provider-recompute provider=${providerId} tournaments=${counts.tournaments} ok=${counts.republishedOk} snapshots=${counts.snapshotsOk}`,
+    );
+
+    return { providerId, republished, snapshots, counts };
+  }
+}

--- a/src/modules/rankings-webhook/rankings-webhook.controller.ts
+++ b/src/modules/rankings-webhook/rankings-webhook.controller.ts
@@ -14,9 +14,11 @@
 // can call this endpoint to backfill specific tournaments; deeper
 // auto-publish integration is a follow-up.
 
-import { Controller, HttpCode, HttpStatus, NotFoundException, Param, Post, UseGuards } from '@nestjs/common';
+import { Body, Controller, ForbiddenException, HttpCode, HttpStatus, NotFoundException, Param, Post, UseGuards } from '@nestjs/common';
 
-import { ADMIN, SUPER_ADMIN } from 'src/common/constants/roles';
+import { ADMIN, CLIENT, PROVIDER_ADMIN, SUPER_ADMIN } from 'src/common/constants/roles';
+import { UserCtx, type UserContext } from '../account/auth/decorators/user-context.decorator';
+import { ProviderRankingsService } from './provider-rankings.service';
 import { RankingsWebhookService } from './rankings-webhook.service';
 import { Roles } from '../account/auth/decorators/roles.decorator';
 import { RolesGuard } from '../account/auth/guards/role.guard';
@@ -27,8 +29,29 @@ import { TournamentStorageService } from 'src/storage/tournament-storage.service
 export class RankingsWebhookController {
   constructor(
     private readonly webhook: RankingsWebhookService,
+    private readonly providerRankings: ProviderRankingsService,
     private readonly tournamentStorage: TournamentStorageService,
   ) {}
+
+  // Provider-scoped recompute: republish all of a provider's tournaments to the
+  // rankings pipeline (refreshing the live rankings page) + regenerate formal
+  // snapshots per age-category × gender. Only a PROVIDER_ADMIN of the target
+  // provider (or a super-admin) may run it.
+  @Post('republish-provider/:providerId')
+  @Roles([CLIENT, ADMIN, SUPER_ADMIN])
+  @HttpCode(HttpStatus.OK)
+  async republishProvider(
+    @Param('providerId') providerId: string,
+    @Body() body: { ageCategoryCodes?: string[] },
+    @UserCtx() ctx?: UserContext,
+  ) {
+    if (!providerId) return { error: 'providerId required' };
+    const isProviderAdmin = ctx?.providerRoles?.[providerId] === PROVIDER_ADMIN;
+    if (!ctx?.isSuperAdmin && !isProviderAdmin) {
+      throw new ForbiddenException('PROVIDER_ADMIN role required');
+    }
+    return this.providerRankings.recompute({ providerId, ageCategoryCodes: body?.ageCategoryCodes });
+  }
 
   @Post('republish/:tournamentId')
   @Roles([ADMIN, SUPER_ADMIN])

--- a/src/modules/rankings-webhook/rankings-webhook.module.ts
+++ b/src/modules/rankings-webhook/rankings-webhook.module.ts
@@ -2,10 +2,11 @@ import { Module } from '@nestjs/common';
 
 import { RankingsWebhookController } from './rankings-webhook.controller';
 import { RankingsWebhookService } from './rankings-webhook.service';
+import { ProviderRankingsService } from './provider-rankings.service';
 
 @Module({
   controllers: [RankingsWebhookController],
-  providers: [RankingsWebhookService],
-  exports: [RankingsWebhookService],
+  providers: [RankingsWebhookService, ProviderRankingsService],
+  exports: [RankingsWebhookService, ProviderRankingsService],
 })
 export class RankingsWebhookModule {}

--- a/src/modules/rankings-webhook/rankings-webhook.service.ts
+++ b/src/modules/rankings-webhook/rankings-webhook.service.ts
@@ -85,6 +85,54 @@ export class RankingsWebhookService {
     return { ok: false, error: lastError, attempts: this.maxRetries };
   }
 
+  /**
+   * Generate a ranking snapshot in the pipeline (POST /rankings/snapshots).
+   * The pipeline resolves the provider's ranking policy from the passed
+   * tournamentRecord's organisation abbreviation, so we send a minimal stub
+   * carrying only `unifiedTournamentId.organisation.organisationId`. Single
+   * attempt (snapshots are idempotent-ish and cheap to re-request).
+   */
+  async generateSnapshot(args: {
+    asOfDate: string;
+    ageCategoryCode?: string;
+    gender?: string;
+    providerAbbr?: string;
+  }): Promise<WebhookResult> {
+    if (!this.isEnabled()) return { skipped: true };
+
+    const body = JSON.stringify({
+      asOfDate: args.asOfDate,
+      ageCategoryCode: args.ageCategoryCode,
+      gender: args.gender,
+      tournamentRecord: args.providerAbbr
+        ? { unifiedTournamentId: { organisation: { organisationId: args.providerAbbr } } }
+        : undefined,
+    });
+
+    const controller = new AbortController();
+    const timeout = setTimeout(() => controller.abort(), this.timeoutMs);
+    try {
+      const response = await fetch(`${this.rankingsUrl}/rankings/snapshots`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body,
+        signal: controller.signal,
+      });
+      const text = await response.text().catch(() => '');
+      let parsed: unknown = text;
+      try {
+        parsed = text ? JSON.parse(text) : undefined;
+      } catch {
+        // non-JSON body — keep raw text
+      }
+      return { ok: response.ok, status: response.status, responseBody: parsed };
+    } catch (err: any) {
+      return { ok: false, error: err?.message ?? String(err) };
+    } finally {
+      clearTimeout(timeout);
+    }
+  }
+
   private async attemptPost(body: string): Promise<{ ok: boolean; status?: number; responseBody?: unknown }> {
     const controller = new AbortController();
     const timeout = setTimeout(() => controller.abort(), this.timeoutMs);


### PR DESCRIPTION
Part B (server). PROVIDER_ADMIN-scoped POST /admin/rankings-webhook/republish-provider/:providerId — republishes all of a provider's tournaments to the rankings pipeline (refreshing the live /bundle) + regenerates snapshots per age-category × gender. No-op when RANKINGS_PIPELINE_URL unset. 10 unit + 3 e2e; additionally live-verified end-to-end against a real courthive-rankings on :3110 (real point_awards written, bundle populated).