### PR TITLE
chore(deps): bump tods-competition-factory to 6.0.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -81,7 +81,7 @@
     "reflect-metadata": "0.2.2",
     "rxjs": "7.8.2",
     "socket.io": "4.8.3",
-    "tods-competition-factory": "6.0.0",
+    "tods-competition-factory": "6.0.2",
     "tods-tmx-classic-converter": "3.0.5",
     "tslib": "^2.6.2",
     "@courthive/provider-config": "^0.9.0",


### PR DESCRIPTION
Bump tods-competition-factory to 6.0.2 (latest — bug fixes).