### PR TITLE
chore(deps): consume published @courthive/i18n ^0.4.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -85,7 +85,7 @@
     "tods-tmx-classic-converter": "3.0.5",
     "tslib": "^2.6.2",
     "@courthive/provider-config": "^0.9.0",
-    "@courthive/i18n": "link:../courthive-i18n",
+    "@courthive/i18n": "^0.4.0",
     "courthive-ingest": "link:../courthive-ingest"
   },
   "devDependencies": {


### PR DESCRIPTION
Bumps CFS's `@courthive/i18n` dependency from a `package.json` `link:` to the real published version **^0.4.0** (published minutes ago with the full translated locale set).

Aligns with the canonical sibling-dep pattern already used for `tods-competition-factory` (`6.0.2`) and `@courthive/provider-config` (`^0.9.0`): real version in `package.json`, `link:../` retained only in the `pnpm-workspace.yaml` override for local dev. Lockfile is unchanged (the override forces the local link, same as provider-config).

After deploy, CFS serves the updated `/i18n/*` bundle; TMX and courthive-public pick up the translations at runtime — no rebuild of those consumers needed.