### PR TITLE
feat(factory): authenticated schedule-projection endpoint for shared-facility view

### DIFF
--- a/src/modules/factory/dto/getScheduleProjection.dto.ts
+++ b/src/modules/factory/dto/getScheduleProjection.dto.ts
@@ -1,0 +1,16 @@
+import { ApiPropertyOptional } from '@nestjs/swagger';
+
+/**
+ * Request for the authenticated, operational shared-facility schedule projection.
+ * Returns slim `ScheduleCell[]` (unpublished — `usePublishState: false`) for the requested
+ * tournaments the caller is authorized to view, optionally filtered to `venueIds`.
+ * `tournamentIds` is required at runtime (validated in the service) but declared optional to
+ * match the repo DTO convention and strict property-initialization.
+ */
+export class GetScheduleProjectionDto {
+  @ApiPropertyOptional({ type: [String] })
+  tournamentIds?: string[];
+
+  @ApiPropertyOptional({ type: [String] })
+  venueIds?: string[];
+}

--- a/src/modules/factory/factory.controller.ts
+++ b/src/modules/factory/factory.controller.ts
@@ -4,6 +4,7 @@ import { RemoveTournamentRecordsDto } from './dto/removeTournamentRecords.dto';
 import { FetchTournamentRecordsDto } from './dto/fetchTournamentRecords.dto';
 import { QueryTournamentRecordsDto } from './dto/queryTournamentRecords.dto';
 import { SaveTournamentRecordsDto } from './dto/saveTournamentRecords.dto';
+import { GetScheduleProjectionDto } from './dto/getScheduleProjection.dto';
 import { GetTournamentInfoDto } from './dto/getTournamentInfo.dto';
 import { SetMatchUpStatusDto } from './dto/setMatchUpStatus.dto';
 import { GetParticipantsDto } from './dto/getParticipants.dto';
@@ -192,6 +193,20 @@ export class FactoryController {
   async getMatchUps(@Body() gmr: GetMatchUpsDto) {
     const key = `gmr|${gmr.tournamentId}`;
     return await this.cacheFx(key, (params) => this.factoryService.getMatchUps(params), gmr);
+  }
+
+  // Operational shared-facility schedule projection: slim, UNPUBLISHED ScheduleCell[] for the
+  // requested tournaments the caller is authorized to view (per-tournament canViewTournament gate
+  // inside the service). Not cached — the result is access-gated per user.
+  @Post('schedule-projection')
+  @Roles([CLIENT, SUPER_ADMIN])
+  @HttpCode(HttpStatus.OK)
+  getScheduleProjection(
+    @Body() dto: GetScheduleProjectionDto,
+    @User() user?: any,
+    @UserCtx() userContext?: UserContext,
+  ) {
+    return this.factoryService.getScheduleProjection(dto, user, userContext);
   }
 
   @Post('score')

--- a/src/modules/factory/factory.service.ts
+++ b/src/modules/factory/factory.service.ts
@@ -20,7 +20,7 @@ import { BadRequestException, Inject, Injectable, Optional, Logger } from '@nest
 import { computeEffectiveConfig } from '@courthive/provider-config';
 import { checkUser } from './helpers/checkUser';
 import publicQueries from './functions/public';
-import { askEngine, factoryConstants } from 'tods-competition-factory';
+import { askEngine, factoryConstants, queryGovernor } from 'tods-competition-factory';
 
 const POLICY_TYPE_PARTICIPANT = factoryConstants.policyConstants.POLICY_TYPE_PARTICIPANT;
 const EXISTING_POLICY_TYPE = factoryConstants.errorConditionConstants.EXISTING_POLICY_TYPE;
@@ -157,6 +157,39 @@ export class FactoryService {
 
   async getMatchUps(params) {
     return await allTournamentMatchUps(params, this.tournamentStorage);
+  }
+
+  /**
+   * Operational shared-facility schedule projection. Returns slim `ScheduleCell[]` (unpublished —
+   * the factory transform applies no publish-state gating, per INV-6) for the requested tournaments
+   * the caller is authorized to view, optionally filtered to `venueIds`.
+   *
+   * Reuses `fetchTournamentRecords` for the per-tournament `canViewTournament` gate; if any
+   * requested id is filtered out (not viewable) the request is rejected rather than silently
+   * returning a partial view. Not cached — the result is access-gated per user.
+   */
+  async getScheduleProjection(dto: { tournamentIds?: string[]; venueIds?: string[] }, user, userContext?: UserContext) {
+    const tournamentIds = dto?.tournamentIds;
+    const venueIds = dto?.venueIds;
+    if (!Array.isArray(tournamentIds) || !tournamentIds.length) return { error: 'Missing tournamentIds' };
+
+    const fetchResult: any = await this.fetchTournamentRecords({ tournamentIds }, user, userContext);
+    if (fetchResult.error) return fetchResult;
+
+    const tournamentRecords = fetchResult.tournamentRecords ?? {};
+    const viewableIds = Object.keys(tournamentRecords);
+    const forbidden = tournamentIds.filter((tournamentId) => !viewableIds.includes(tournamentId));
+    if (forbidden.length) return { error: 'User not allowed', forbiddenTournamentIds: forbidden };
+
+    const scheduleCells: any[] = [];
+    for (const tournamentId of viewableIds) {
+      const projection: any = queryGovernor.getScheduleProjection({
+        tournamentRecord: tournamentRecords[tournamentId],
+        venueIds,
+      });
+      if (projection?.scheduleCells) scheduleCells.push(...projection.scheduleCells);
+    }
+    return { scheduleCells };
   }
 
   async fetchTournamentRecords(params, user, userContext?: UserContext) {

--- a/src/modules/factory/getScheduleProjection.spec.ts
+++ b/src/modules/factory/getScheduleProjection.spec.ts
@@ -1,0 +1,40 @@
+import { FactoryService } from './factory.service';
+
+// Infra-free unit test of the access/aggregation logic added to FactoryService.getScheduleProjection.
+// fetchTournamentRecords (the canViewTournament gate) is stubbed; queryGovernor.getScheduleProjection
+// runs for real against a trivial record (no events → empty cells).
+describe('FactoryService.getScheduleProjection', () => {
+  function makeService(fetchImpl: any): any {
+    const service: any = Object.create(FactoryService.prototype);
+    service.fetchTournamentRecords = fetchImpl;
+    return service;
+  }
+
+  it('rejects a missing or empty tournamentIds', async () => {
+    const service = makeService(async () => ({ tournamentRecords: {} }));
+    expect((await service.getScheduleProjection({}, undefined)).error).toBe('Missing tournamentIds');
+    expect((await service.getScheduleProjection({ tournamentIds: [] }, undefined)).error).toBe('Missing tournamentIds');
+  });
+
+  it('propagates a fetch error', async () => {
+    const service = makeService(async () => ({ error: 'boom' }));
+    const result = await service.getScheduleProjection({ tournamentIds: ['t1'] }, undefined);
+    expect(result.error).toBe('boom');
+  });
+
+  it('rejects when a requested tournament is not viewable (filtered out by the access gate)', async () => {
+    // gate returns only t1 → t2 was not viewable
+    const service = makeService(async () => ({ tournamentRecords: { t1: { tournamentId: 't1' } } }));
+    const result = await service.getScheduleProjection({ tournamentIds: ['t1', 't2'] }, undefined);
+    expect(result.error).toBe('User not allowed');
+    expect(result.forbiddenTournamentIds).toEqual(['t2']);
+  });
+
+  it('aggregates schedule cells for viewable tournaments', async () => {
+    const service = makeService(async () => ({ tournamentRecords: { t1: { tournamentId: 't1' } } }));
+    const result = await service.getScheduleProjection({ tournamentIds: ['t1'] }, undefined);
+    // trivial record has no scheduled matchUps → empty, but the aggregation path ran without error
+    expect(result.scheduleCells).toEqual([]);
+    expect(result.error).toBeUndefined();
+  });
+});


### PR DESCRIPTION
## Summary

Phase 1 server side of the **Linked Tournaments & Shared-Facility Scheduling** workstream (Mentat planning: `LINKED_TOURNAMENTS_AND_SHARED_FACILITY_SCHEDULING.md`).

Adds an authenticated endpoint that returns the **operational** (unpublished) shared-facility schedule as slim `ScheduleCell[]`, so a TMX client can overlay linked peers' court claims without loading their full tournament records.

## Endpoint

`POST /factory/schedule-projection` — `@Roles([CLIENT, SUPER_ADMIN])`

Body: `{ tournamentIds: string[], venueIds?: string[] }` → `{ scheduleCells: ScheduleCell[] }`

- **Per-tournament access gate:** reuses `factoryService.fetchTournamentRecords`, which applies `canViewTournament` for each id. Any requested id the caller cannot view causes a rejection (`{ error: 'User not allowed', forbiddenTournamentIds }`) rather than a silent partial result.
- **Operational, not published (INV-6):** wraps `queryGovernor.getScheduleProjection`, which applies no publish-state gating — co-located directors see real draft court claims (a publish-gated read would return an empty peer grid and invite double-booking).
- **Not cached:** the result is access-gated per user, so `cacheFx` (shared across callers) is deliberately not used.

## Testing

- `src/modules/factory/getScheduleProjection.spec.ts` — infra-free unit spec: missing-ids rejection, fetch-error propagation, forbidden-id rejection, and aggregation. 4 passing.
- `pnpm check-types`, `pnpm lint`, `pnpm build` all clean.

## Dependency

Requires the factory `getScheduleProjection` export — **competition-factory#4487** must merge + publish before this can build in CI (locally resolved via the `link:../factory` override). Bump `tods-competition-factory` to the published version alongside merge.
