### PR TITLE
feat(factory): coordination-view schedule projection with access flag

### DIFF
--- a/src/modules/factory/dto/getScheduleProjection.dto.ts
+++ b/src/modules/factory/dto/getScheduleProjection.dto.ts
@@ -2,12 +2,18 @@ import { ApiPropertyOptional } from '@nestjs/swagger';
 
 /**
  * Request for the authenticated, operational shared-facility schedule projection.
- * Returns slim `ScheduleCell[]` (unpublished — `usePublishState: false`) for the requested
- * tournaments the caller is authorized to view, optionally filtered to `venueIds`.
- * `tournamentIds` is required at runtime (validated in the service) but declared optional to
- * match the repo DTO convention and strict property-initialization.
+ * Returns slim `ScheduleCell[]` (unpublished — `usePublishState: false`), optionally filtered to
+ * `venueIds`. Two modes:
+ *  - `tournamentId` (coordination view): the context tournament the caller AUTHORS; the service
+ *    returns projections of its server-verified linked peers, tagged `access:'author'|'view'`,
+ *    with `view` peers opaque. This is how a director sees another tournament's court occupancy.
+ *  - `tournamentIds` (legacy): slim cells for the requested tournaments the caller can view.
+ * Both are optional on the DTO; the service validates that exactly one usable form is present.
  */
 export class GetScheduleProjectionDto {
+  @ApiPropertyOptional({ type: String })
+  tournamentId?: string;
+
   @ApiPropertyOptional({ type: [String] })
   tournamentIds?: string[];
 

--- a/src/modules/factory/factory.service.ts
+++ b/src/modules/factory/factory.service.ts
@@ -29,6 +29,23 @@ const EXISTING_POLICY_TYPE = factoryConstants.errorConditionConstants.EXISTING_P
 import type { UserContext } from 'src/modules/account/auth/decorators/user-context.decorator';
 import { TOURNAMENT_STORAGE, type ITournamentStorage, TOURNAMENT_PROVISIONER_STORAGE, type ITournamentProvisionerStorage, PROVIDER_STORAGE, type IProviderStorage } from 'src/storage/interfaces';
 
+/**
+ * Reduce a ScheduleCell to court occupancy only — no participant labels, round, event or matchUp
+ * detail — for a coordination 'view' peer the caller can't author. Keeps the shared-facility view
+ * opaque (INV: reserved cells reveal that a court/time is taken, never by whom).
+ */
+function opaqueReservedCell(cell: any) {
+  return {
+    tournamentId: cell?.tournamentId,
+    venueId: cell?.venueId,
+    courtId: cell?.courtId,
+    courtOrder: cell?.courtOrder,
+    scheduledDate: cell?.scheduledDate,
+    scheduledTime: cell?.scheduledTime,
+    access: 'view',
+  };
+}
+
 @Injectable()
 export class FactoryService {
   constructor(
@@ -168,7 +185,19 @@ export class FactoryService {
    * requested id is filtered out (not viewable) the request is rejected rather than silently
    * returning a partial view. Not cached — the result is access-gated per user.
    */
-  async getScheduleProjection(dto: { tournamentIds?: string[]; venueIds?: string[] }, user, userContext?: UserContext) {
+  async getScheduleProjection(
+    dto: { tournamentId?: string; tournamentIds?: string[]; venueIds?: string[] },
+    user,
+    userContext?: UserContext,
+  ) {
+    // Coordination view: given a context tournament the caller AUTHORS, return slim projections of
+    // its server-verified linked peers — including peers the caller can't otherwise view (a
+    // different director/provider sharing the facility). Peers the caller can also author come back
+    // `access:'author'`; peers they can only coordinate around come back `access:'view'` and OPAQUE
+    // (no participant/round detail — court occupancy only).
+    if (dto?.tournamentId) return this.getCoordinationProjection(dto.tournamentId, dto.venueIds, user, userContext);
+
+    // Legacy view-gated aggregation: slim cells for the requested tournaments the caller can view.
     const tournamentIds = dto?.tournamentIds;
     const venueIds = dto?.venueIds;
     if (!Array.isArray(tournamentIds) || !tournamentIds.length) return { error: 'Missing tournamentIds' };
@@ -188,6 +217,39 @@ export class FactoryService {
         venueIds,
       });
       if (projection?.scheduleCells) scheduleCells.push(...projection.scheduleCells);
+    }
+    return { scheduleCells };
+  }
+
+  private async getCoordinationProjection(contextId: string, venueIds, user, userContext?: UserContext) {
+    // The context tournament must be view-gated (caller sees it) AND authorable (caller runs it).
+    const ctxFetch: any = await this.fetchTournamentRecords({ tournamentIds: [contextId] }, user, userContext);
+    if (ctxFetch.error) return ctxFetch;
+    const context = ctxFetch.tournamentRecords?.[contextId];
+    if (!context) return { error: 'User not allowed' };
+
+    const assignedIds = userContext
+      ? await this.assignmentsService.getAssignedTournamentIds(userContext.userId)
+      : new Set<string>();
+    if (!canMutateTournament(context, userContext, assignedIds)) return { error: 'User not allowed' };
+
+    // Peers come from the context's SERVER-STORED links (set via the access-controlled linkTournaments
+    // mutation) — the caller can't inject arbitrary ids to widen what they see.
+    const peerIds = (context.linkedTournamentIds ?? []).filter((id: string) => id && id !== contextId);
+    if (!peerIds.length) return { scheduleCells: [] };
+
+    // Fetch peers WITHOUT the view gate — that is the coordination grant. Bounded by the authored
+    // context's links, and view peers are returned opaque.
+    const peerFetch: any = await this.tournamentStorageService.fetchTournamentRecords({ tournamentIds: peerIds });
+    const peerRecords = peerFetch?.tournamentRecords ?? {};
+
+    const scheduleCells: any[] = [];
+    for (const peerId of Object.keys(peerRecords)) {
+      const access = canMutateTournament(peerRecords[peerId], userContext, assignedIds) ? 'author' : 'view';
+      const projection: any = queryGovernor.getScheduleProjection({ tournamentRecord: peerRecords[peerId], venueIds });
+      for (const cell of projection?.scheduleCells ?? []) {
+        scheduleCells.push(access === 'view' ? opaqueReservedCell(cell) : { ...cell, access });
+      }
     }
     return { scheduleCells };
   }

--- a/src/modules/factory/getScheduleProjection.spec.ts
+++ b/src/modules/factory/getScheduleProjection.spec.ts
@@ -1,4 +1,12 @@
+import { queryGovernor } from 'tods-competition-factory';
 import { FactoryService } from './factory.service';
+
+// Access is mocked so the coordination-view author/view split is deterministic without a real
+// access-scoping env: a tournamentId containing "view" is not authorable.
+jest.mock('./helpers/checkTournamentAccess', () => ({
+  canViewTournament: () => true,
+  canMutateTournament: (record: any) => !String(record?.tournamentId ?? '').includes('view'),
+}));
 
 // Infra-free unit test of the access/aggregation logic added to FactoryService.getScheduleProjection.
 // fetchTournamentRecords (the canViewTournament gate) is stubbed; queryGovernor.getScheduleProjection
@@ -36,5 +44,69 @@ describe('FactoryService.getScheduleProjection', () => {
     // trivial record has no scheduled matchUps → empty, but the aggregation path ran without error
     expect(result.scheduleCells).toEqual([]);
     expect(result.error).toBeUndefined();
+  });
+});
+
+describe('FactoryService.getScheduleProjection — coordination view', () => {
+  const userContext: any = { userId: 'u1' };
+
+  function makeCoordService(ctx: any, peers: Record<string, any>): any {
+    const service: any = Object.create(FactoryService.prototype);
+    // context fetch (view-gated) — returns ctx only when it is the one requested
+    service.fetchTournamentRecords = async ({ tournamentIds }: any) => ({
+      tournamentRecords: tournamentIds?.[0] === ctx.tournamentId ? { [ctx.tournamentId]: ctx } : {},
+    });
+    // peer fetch (ungated storage)
+    service.tournamentStorageService = { fetchTournamentRecords: async () => ({ tournamentRecords: peers }) };
+    service.assignmentsService = { getAssignedTournamentIds: async () => new Set() };
+    return service;
+  }
+
+  afterEach(() => jest.restoreAllMocks());
+
+  it('rejects when the caller cannot author the context tournament', async () => {
+    const ctx = { tournamentId: 'view-ctx', linkedTournamentIds: ['view-ctx', 'p1'] }; // "view" → not authorable
+    const service = makeCoordService(ctx, {});
+    const result = await service.getScheduleProjection({ tournamentId: 'view-ctx' }, undefined, userContext);
+    expect(result.error).toBe('User not allowed');
+  });
+
+  it('returns no cells when the authored context has no linked peers', async () => {
+    const ctx = { tournamentId: 'ctx', linkedTournamentIds: ['ctx'] };
+    const service = makeCoordService(ctx, {});
+    const result = await service.getScheduleProjection({ tournamentId: 'ctx' }, undefined, userContext);
+    expect(result.scheduleCells).toEqual([]);
+  });
+
+  it('tags author peers with full cells and view peers with opaque cells', async () => {
+    const ctx = { tournamentId: 'ctx', linkedTournamentIds: ['ctx', 'author-peer', 'view-peer'] };
+    const peers = { 'author-peer': { tournamentId: 'author-peer' }, 'view-peer': { tournamentId: 'view-peer' } };
+    const service = makeCoordService(ctx, peers);
+    jest.spyOn(queryGovernor, 'getScheduleProjection').mockImplementation(({ tournamentRecord }: any) => ({
+      scheduleCells: [
+        {
+          tournamentId: tournamentRecord.tournamentId,
+          courtId: 'c1',
+          courtOrder: 1,
+          venueId: 'v1',
+          scheduledDate: '2026-07-20',
+          scheduledTime: '10:00',
+          roundName: 'QF',
+          matchUpId: 'm1',
+          labels: ['Secret Player'],
+        },
+      ],
+    }));
+
+    const result = await service.getScheduleProjection({ tournamentId: 'ctx' }, undefined, userContext);
+    const byTournament = Object.fromEntries(result.scheduleCells.map((c: any) => [c.tournamentId, c]));
+
+    // author peer: full cell, access author, retains participant/round detail
+    expect(byTournament['author-peer']).toMatchObject({ access: 'author', labels: ['Secret Player'], roundName: 'QF' });
+    // view peer: opaque cell — court occupancy only, no labels/round/matchUpId
+    expect(byTournament['view-peer']).toMatchObject({ access: 'view', courtId: 'c1', courtOrder: 1, scheduledTime: '10:00' });
+    expect(byTournament['view-peer'].labels).toBeUndefined();
+    expect(byTournament['view-peer'].roundName).toBeUndefined();
+    expect(byTournament['view-peer'].matchUpId).toBeUndefined();
   });
 });


### PR DESCRIPTION
## What
Adds a **coordination view** to `POST /factory/schedule-projection` so a director can see another facility-sharing tournament's court occupancy as read-only reserved cells — without loading its record.

When the request carries a context `tournamentId` the caller **authors**, the service returns slim projections of that tournament's server-verified linked peers, each cell tagged `access: 'author' | 'view'`:
- **author** peers (caller can also mutate) → full cells
- **view** peers (a different director/provider sharing the facility) → **opaque** cells (court occupancy only — no participant labels / round / matchUp detail)

## Security (fail-closed)
- Caller must be able to **author** the context tournament (`canMutateTournament`)
- Peers come **only** from the context's stored `linkedTournamentIds` (set via the access-controlled `linkTournaments` mutation) — the caller can't inject ids to widen what they see
- view cells never reveal *by whom* a slot is taken
- The peer fetch bypasses the per-tournament view gate deliberately (that is the coordination grant), bounded as above
- Legacy view-gated `tournamentIds` path unchanged

## Tests
- `getScheduleProjection.spec.ts`: +3 coordination cases (author/view tagging, opaque stripping, authorization). **Factory module: 166 tests, lint 0, tsc 0**

## Ecosystem
Pairs with TMX #(shared-facility-reserved-cells), which sends the context `tournamentId` and filters `access:'view'`. Merge alongside TMX.