### PR TITLE
feat: sign SPLIT tournament tokens via the hiveid IdP mint

### DIFF
--- a/src/modules/account/auth/auth.module.ts
+++ b/src/modules/account/auth/auth.module.ts
@@ -13,6 +13,7 @@ import { AuthMiddleware } from './auth.middleware';
 import { AuthGuard } from './guards/auth.guard';
 import { AuthService } from './auth.service';
 import { RefreshTokenService } from 'src/services/refresh-token.service';
+import { SplitTokenSigner } from 'src/services/split-token-signer.service';
 import { JwksController } from './crypto/jwks.controller';
 import { ConfigService } from '@nestjs/config';
 import { APP_GUARD } from '@nestjs/core';
@@ -45,6 +46,7 @@ const expiresIn: any = rawValidity && isValidJwtExpiresIn(rawValidity) ? rawVali
     HiveIDService,
     TrackerTokenService,
     RefreshTokenService,
+    SplitTokenSigner,
     {
       provide: APP_GUARD,
       useClass: AuthGuard,

--- a/src/modules/account/auth/tracker-token.service.spec.ts
+++ b/src/modules/account/auth/tracker-token.service.spec.ts
@@ -10,6 +10,7 @@
 import { BadRequestException, ForbiddenException, NotFoundException } from '@nestjs/common';
 import { JwtService } from '@nestjs/jwt';
 
+import { SplitTokenSigner } from 'src/services/split-token-signer.service';
 import { TrackerTokenService } from './tracker-token.service';
 
 jest.mock('src/common/constants/feature-flags', () => ({
@@ -63,7 +64,9 @@ describe('TrackerTokenService', () => {
     mockAuditService = {
       recordTrackerTokenIssued: jest.fn().mockResolvedValue(undefined),
     };
-    service = new TrackerTokenService(mockJwtService, mockTournamentStorage, mockAuditService);
+    // HIVEID_BASE_URL unset → SplitTokenSigner mints locally via mockJwtService,
+    // so the token shape + assertions below are identical to pre-Increment-4.
+    service = new TrackerTokenService(mockJwtService, mockTournamentStorage, mockAuditService, new SplitTokenSigner());
   });
 
   // Sentinel: if a future change puts `exp` directly into the JWT

--- a/src/modules/account/auth/tracker-token.service.ts
+++ b/src/modules/account/auth/tracker-token.service.ts
@@ -17,7 +17,7 @@
  * mint here AND has a non-expired signature there will be accepted.
  */
 import { ForbiddenException, Injectable, NotFoundException, BadRequestException, Logger } from '@nestjs/common';
-import { signJwt } from 'src/common/auth/signJwt';
+import { SplitTokenSigner } from 'src/services/split-token-signer.service';
 import { JwtService } from '@nestjs/jwt';
 
 import { AuditService } from '../../audit/audit.service';
@@ -81,6 +81,7 @@ export class TrackerTokenService {
     private readonly jwtService: JwtService,
     private readonly tournamentStorageService: TournamentStorageService,
     private readonly auditService: AuditService,
+    private readonly splitTokenSigner: SplitTokenSigner,
   ) {}
 
   async mintTrackerToken(
@@ -111,12 +112,14 @@ export class TrackerTokenService {
     // options. The AuthModule registers a global signOptions.expiresIn
     // ('2h' from JWT_VALIDITY env), so we MUST NOT put `exp` in the
     // payload — instead override expiresIn at the call site with our
-    // variable TTL. `expiresAt` in the response is derived from our
-    // own `exp` value, which matches what jsonwebtoken will stamp.
-    const token = await signJwt(this.jwtService, 
-      { sub, aud: 'score', tournamentId, iat: now },
-      { expiresIn: ttlSeconds },
-    );
+    // variable TTL. `expiresAt` in the response is derived from our own
+    // `exp` value. Signing is delegated to SplitTokenSigner: local (dev/
+    // pre-cutover) it signs in-process; post-cutover it calls the IdP mint.
+    const token = await this.splitTokenSigner.mint(this.jwtService, {
+      claims: { sub, tournamentId, iat: now },
+      audience: 'score',
+      expiresInSeconds: ttlSeconds,
+    });
 
     const expiresAt = new Date(exp * 1000).toISOString();
 
@@ -175,10 +178,9 @@ export class TrackerTokenService {
     const sub = user.providerId ? `provider:${user.providerId}` : user.userId ?? 'unknown';
     const now = Math.floor(Date.now() / 1000);
     const exp = now + ttlSeconds;
-    const token = await signJwt(this.jwtService, 
-      {
+    const token = await this.splitTokenSigner.mint(this.jwtService, {
+      claims: {
         sub,
-        aud: 'provider',
         tournamentId,
         providerId: user.providerId,
         personId,
@@ -186,8 +188,9 @@ export class TrackerTokenService {
         email_verified: params.verified === true,
         iat: now,
       },
-      { expiresIn: ttlSeconds },
-    );
+      audience: 'provider',
+      expiresInSeconds: ttlSeconds,
+    });
     const expiresAt = new Date(exp * 1000).toISOString();
 
     try {
@@ -232,10 +235,9 @@ export class TrackerTokenService {
     const sub = identity.userId ?? 'unknown';
     const now = Math.floor(Date.now() / 1000);
     const exp = now + ttlSeconds;
-    const token = await signJwt(this.jwtService, 
-      {
+    const token = await this.splitTokenSigner.mint(this.jwtService, {
+      claims: {
         sub,
-        aud: 'score',
         tournamentId,
         matchUpId,
         personId,
@@ -243,8 +245,9 @@ export class TrackerTokenService {
         email_verified: identity.verified === true,
         iat: now,
       },
-      { expiresIn: ttlSeconds },
-    );
+      audience: 'score',
+      expiresInSeconds: ttlSeconds,
+    });
     const expiresAt = new Date(exp * 1000).toISOString();
 
     try {

--- a/src/modules/provisioner/provisioner.module.ts
+++ b/src/modules/provisioner/provisioner.module.ts
@@ -8,6 +8,7 @@ import { SsoTokenService } from './sso-token.service';
 import { SsoController } from './sso.controller';
 import { AuditModule } from '../audit/audit.module';
 import { RefreshTokenService } from 'src/services/refresh-token.service';
+import { SplitTokenSigner } from 'src/services/split-token-signer.service';
 
 @Module({
   imports: [AuditModule],
@@ -20,7 +21,8 @@ import { RefreshTokenService } from 'src/services/refresh-token.service';
   // RefreshTokenService is a stateless helper over the global
   // REFRESH_TOKEN_STORAGE; providing it here (rather than importing AuthModule,
   // which configures middleware) avoids cross-module middleware coupling.
-  providers: [ProvisionerService, SsoTokenService, RefreshTokenService],
+  // SplitTokenSigner is the keyless IdP mint client the SSO handoff signs through.
+  providers: [ProvisionerService, SsoTokenService, RefreshTokenService, SplitTokenSigner],
 })
 export class ProvisionerModule implements NestModule {
   configure(consumer: MiddlewareConsumer): void {

--- a/src/modules/provisioner/sso.controller.spec.ts
+++ b/src/modules/provisioner/sso.controller.spec.ts
@@ -1,3 +1,4 @@
+import { SplitTokenSigner } from 'src/services/split-token-signer.service';
 import { SsoController } from './sso.controller';
 
 function makeMockSsoTokenService() {
@@ -69,10 +70,13 @@ describe('SsoController', () => {
     const provisionerProviderStorage: any = { findByProvisioner: jest.fn().mockResolvedValue([]) };
     const refreshTokenService: any = { issue: jest.fn().mockResolvedValue('rtok_sso') };
 
+    // HIVEID_BASE_URL unset → SplitTokenSigner signs locally via the mock
+    // jwtService (returns 'mock-jwt-token'), so accessToken assertions are unchanged.
     controller = new SsoController(
       ssoTokenService as any,
       jwtService as any,
       refreshTokenService,
+      new SplitTokenSigner(),
       ssoIdentityStorage as any,
       userStorage as any,
       userProviderStorage as any,

--- a/src/modules/provisioner/sso.controller.ts
+++ b/src/modules/provisioner/sso.controller.ts
@@ -1,6 +1,6 @@
 import { Body, Controller, HttpCode, HttpStatus, Inject, Logger, Post, Req, UseGuards } from '@nestjs/common';
+import { SplitTokenSigner } from 'src/services/split-token-signer.service';
 import { Public } from '../account/auth/decorators/public.decorator';
-import { signJwt } from 'src/common/auth/signJwt';
 import { RefreshTokenService } from 'src/services/refresh-token.service';
 import { ProvisionerGuard } from './provisioner.guard';
 import { SsoTokenService } from './sso-token.service';
@@ -28,6 +28,7 @@ export class SsoController {
     private readonly ssoTokenService: SsoTokenService,
     private readonly jwtService: JwtService,
     private readonly refreshTokenService: RefreshTokenService,
+    private readonly splitTokenSigner: SplitTokenSigner,
     @Inject(SSO_IDENTITY_STORAGE) private readonly ssoIdentityStorage: ISsoIdentityStorage,
     @Inject(USER_STORAGE) private readonly userStorage: IUserStorage,
     @Inject(USER_PROVIDER_STORAGE) private readonly userProviderStorage: IUserProviderStorage,
@@ -109,11 +110,18 @@ export class SsoController {
     const userDetails = { ...user };
     delete userDetails.password;
     const jwtPayload = { ...userDetails, providerIds: userContext.providerIds, providerRoles: userContext.providerRoles };
-    // Match the direct-login access-token lifetime (auth.service.ts ACCESS_TOKEN_TTL).
-    // Without this override the SSO session would inherit the JwtModule default
-    // (JWT_VALIDITY, '2h' in prod). The short lifetime is fine because the
-    // refresh token below keeps the session alive silently.
-    const accessToken = await signJwt(this.jwtService, jwtPayload, { expiresIn: '4h' });
+    // Match the direct-login access-token lifetime (auth.service.ts ACCESS_TOKEN_TTL
+    // = 4h) and its `aud: 'admin'` session audience — a bare session token is
+    // treated as 'admin' at every verifier, so this is behaviorally identical and
+    // more explicit. Signing is delegated to the IdP via SplitTokenSigner (local
+    // in-process pre-cutover): the SSO handoff is the second session-issuer flagged
+    // in ACCOUNT_SERVICE_BOUNDARY, now keyless like every other mint site. The
+    // refresh token below keeps the session alive silently past the 4h access TTL.
+    const accessToken = await this.splitTokenSigner.mint(this.jwtService, {
+      claims: jwtPayload,
+      audience: 'admin',
+      expiresInSeconds: 14400,
+    });
 
     // Mint a rotating refresh token so SSO-handoff sessions refresh silently
     // just like password logins (POST /auth/refresh) instead of forcing a new

--- a/src/services/split-token-signer.service.spec.ts
+++ b/src/services/split-token-signer.service.spec.ts
@@ -1,0 +1,110 @@
+/**
+ * SplitTokenSigner — unit tests for the two modes:
+ *  - local (HIVEID_BASE_URL unset): signs via the passed JwtService (current behavior)
+ *  - remote (HIVEID_BASE_URL set): POSTs to the IdP /internal/mint, fails closed
+ */
+import { JwtService } from '@nestjs/jwt';
+
+import { SplitTokenSigner } from './split-token-signer.service';
+
+const savedEnv = { ...process.env };
+
+function decode(token: string): Record<string, any> {
+  return JSON.parse(Buffer.from(token.split('.')[1], 'base64url').toString('utf8'));
+}
+
+describe('SplitTokenSigner', () => {
+  afterEach(() => {
+    process.env = { ...savedEnv };
+    jest.restoreAllMocks();
+  });
+
+  describe('local mode (HIVEID_BASE_URL unset)', () => {
+    beforeEach(() => {
+      delete process.env.HIVEID_BASE_URL;
+      delete process.env.JWT_SIGN_ES256;
+    });
+
+    it('is not remote and signs locally with the passed JwtService', async () => {
+      const jwt = new JwtService({ secret: 'test-secret', signOptions: { expiresIn: '1d' } });
+      const signer = new SplitTokenSigner();
+      expect(signer.isRemote()).toBe(false);
+
+      const token = await signer.mint(jwt, {
+        claims: { sub: 'provider:BOBOCA', tournamentId: 't-1', iat: Math.floor(Date.now() / 1000) },
+        audience: 'score',
+        expiresInSeconds: 3600,
+      });
+      const payload = decode(token);
+      expect(payload).toMatchObject({ sub: 'provider:BOBOCA', tournamentId: 't-1', aud: 'score' });
+      expect(payload.exp - payload.iat).toBe(3600);
+      // A locally-signed token the same JwtService verifies.
+      await expect(jwt.verifyAsync(token)).resolves.toMatchObject({ aud: 'score' });
+    });
+
+    it('does not call fetch in local mode', async () => {
+      const jwt = new JwtService({ secret: 'test-secret', signOptions: { expiresIn: '1d' } });
+      const fetchSpy = jest.spyOn(globalThis, 'fetch' as any);
+      await new SplitTokenSigner().mint(jwt, { claims: { sub: 'u' }, audience: 'admin', expiresInSeconds: 60 });
+      expect(fetchSpy).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('remote mode (HIVEID_BASE_URL set)', () => {
+    beforeEach(() => {
+      process.env.HIVEID_BASE_URL = 'http://idp.local:3140';
+      process.env.HIVEID_SIGNER_TOKEN = 'signer-secret';
+    });
+
+    it('is remote and POSTs the mint request with the service token, returning the IdP token', async () => {
+      const jwt = new JwtService({ secret: 'test-secret' });
+      const fetchSpy = jest
+        .spyOn(globalThis, 'fetch' as any)
+        .mockResolvedValue({ ok: true, json: async () => ({ token: 'idp.signed.token' }) } as any);
+
+      const signer = new SplitTokenSigner();
+      expect(signer.isRemote()).toBe(true);
+
+      const token = await signer.mint(jwt, { claims: { sub: 'u', tournamentId: 't' }, audience: 'provider', expiresInSeconds: 120 });
+      expect(token).toBe('idp.signed.token');
+
+      const [url, init] = fetchSpy.mock.calls[0];
+      expect(url).toBe('http://idp.local:3140/internal/mint');
+      expect((init as any).headers['x-service-token']).toBe('signer-secret');
+      expect(JSON.parse((init as any).body)).toEqual({
+        claims: { sub: 'u', tournamentId: 't' },
+        audience: 'provider',
+        expiresIn: 120,
+      });
+    });
+
+    it('fails closed when the IdP rejects (non-2xx) — never falls back to a local key', async () => {
+      const jwt = new JwtService({ secret: 'test-secret' });
+      jest.spyOn(globalThis, 'fetch' as any).mockResolvedValue({ ok: false, status: 503 } as any);
+      await expect(
+        new SplitTokenSigner().mint(jwt, { claims: { sub: 'u' }, audience: 'score', expiresInSeconds: 60 }),
+      ).rejects.toThrow('token signer unavailable');
+    });
+
+    it('fails closed when the IdP is unreachable', async () => {
+      const jwt = new JwtService({ secret: 'test-secret' });
+      jest.spyOn(globalThis, 'fetch' as any).mockRejectedValue(new Error('ECONNREFUSED'));
+      await expect(
+        new SplitTokenSigner().mint(jwt, { claims: { sub: 'u' }, audience: 'score', expiresInSeconds: 60 }),
+      ).rejects.toThrow('token signer unavailable');
+    });
+
+    it('fails closed when the IdP returns no token', async () => {
+      const jwt = new JwtService({ secret: 'test-secret' });
+      jest.spyOn(globalThis, 'fetch' as any).mockResolvedValue({ ok: true, json: async () => ({}) } as any);
+      await expect(
+        new SplitTokenSigner().mint(jwt, { claims: { sub: 'u' }, audience: 'score', expiresInSeconds: 60 }),
+      ).rejects.toThrow('token signer unavailable');
+    });
+
+    it('treats HIVEID_BASE_URL=disabled as local (explicit override)', async () => {
+      process.env.HIVEID_BASE_URL = 'disabled';
+      expect(new SplitTokenSigner().isRemote()).toBe(false);
+    });
+  });
+});

--- a/src/services/split-token-signer.service.ts
+++ b/src/services/split-token-signer.service.ts
@@ -1,0 +1,82 @@
+/**
+ * SplitTokenSigner — CFS-side client that signs the SPLIT tournament tokens via
+ * the HiveID IdP's internal /internal/mint endpoint (Increment 4 of the account
+ * move; plan §2b, decision Q1-B).
+ *
+ * CFS keeps the SPLIT controllers + tournament/provisioner AUTHORIZATION (it owns
+ * the data + `canMutateTournament`) but delegates SIGNING to the IdP, which alone
+ * holds the private key. Mirrors DeclarationsClient / PersonsClient: Node native
+ * fetch, base URL + shared service token from env, no new npm deps.
+ *
+ * INERT UNTIL POINTED AT THE IdP (matches the ES256 signer-flip pattern): with
+ * `HIVEID_BASE_URL` unset the signer mints LOCALLY via signJwt — byte-identical
+ * to the pre-Increment-4 call sites — so the code ships with zero behavior change
+ * and the cutover is a single env toggle (reversible). `HIVEID_BASE_URL=disabled`
+ * is an explicit local override for deployments without the IdP.
+ *
+ * Remote mode fails CLOSED (architectural-standards A3): if the IdP is
+ * unreachable or rejects, the mint throws rather than falling back to a local
+ * key — post-cutover CFS holds no key, so a local fallback would only mint HS256
+ * tokens every verifier now rejects. One signer, everywhere.
+ */
+import { Injectable, Logger } from '@nestjs/common';
+import { JwtService } from '@nestjs/jwt';
+
+import { signJwt } from 'src/common/auth/signJwt';
+
+const DEFAULT_HIVEID_BASE_URL = 'http://localhost:3140';
+
+export type MintAudience = 'score' | 'provider' | 'admin';
+
+export interface SplitMintArgs {
+  /** Already-authorized claims to sign (e.g. sub, tournamentId, personId). `aud` is set from `audience`. */
+  claims: Record<string, unknown>;
+  audience: MintAudience;
+  /** Token lifetime in seconds. The IdP additionally clamps to its own max TTL. */
+  expiresInSeconds: number;
+}
+
+@Injectable()
+export class SplitTokenSigner {
+  private readonly logger = new Logger(SplitTokenSigner.name);
+  private readonly baseUrl: string;
+  private readonly serviceToken: string;
+  private readonly remote: boolean;
+
+  constructor() {
+    this.baseUrl = process.env.HIVEID_BASE_URL ?? DEFAULT_HIVEID_BASE_URL;
+    this.serviceToken = process.env.HIVEID_SIGNER_TOKEN ?? '';
+    this.remote = !!process.env.HIVEID_BASE_URL && this.baseUrl.trim().toLowerCase() !== 'disabled';
+  }
+
+  /** True when tokens are minted remotely via the IdP (post-cutover); false = local signing. */
+  isRemote(): boolean {
+    return this.remote;
+  }
+
+  async mint(jwtService: JwtService, args: SplitMintArgs): Promise<string> {
+    if (!this.remote) {
+      // Local signing (dev / test / pre-cutover). Output is identical to the
+      // pre-Increment-4 call sites: {...claims, aud} signed with expiresIn.
+      return signJwt(jwtService, { ...args.claims, aud: args.audience }, { expiresIn: args.expiresInSeconds });
+    }
+    return this.mintRemote(args);
+  }
+
+  private async mintRemote(args: SplitMintArgs): Promise<string> {
+    try {
+      const res = await fetch(`${this.baseUrl}/internal/mint`, {
+        method: 'POST',
+        headers: { 'x-service-token': this.serviceToken, 'Content-Type': 'application/json' },
+        body: JSON.stringify({ claims: args.claims, audience: args.audience, expiresIn: args.expiresInSeconds }),
+      });
+      if (!res.ok) throw new Error(`IdP mint rejected: HTTP ${res.status}`);
+      const body = (await res.json()) as { token?: string };
+      if (!body?.token) throw new Error('IdP mint returned no token');
+      return body.token;
+    } catch (err) {
+      this.logger.error(`SPLIT ${args.audience} token mint via IdP failed: ${(err as Error).message}`);
+      throw new Error('token signer unavailable');
+    }
+  }
+}


### PR DESCRIPTION
Increment 4 (Q1-B): SplitTokenSigner routes the 4 SPLIT mint sites (tracker/scorer/provider-scoring + provisioner SSO) through the hiveid IdP /internal/mint. Inert until HIVEID_BASE_URL is set (local signing = current behavior); remote fails closed. Full suite 1261 green. Deploys deferred per plan.