### PR TITLE
refactor: move CANONICAL_PERSON to a neutral constant

### DIFF
--- a/src/common/constants/canonicalPerson.ts
+++ b/src/common/constants/canonicalPerson.ts
@@ -1,0 +1,14 @@
+/**
+ * Neutral CFS constant — the organisationId stamped on
+ * `Participant.person.personOtherIds[]` when a TODS Participant is linked to
+ * the canonical Person record produced by the registry. The literal value is
+ * intentionally `'CANONICAL_PERSON'` — NOT `'courthive-persons'` — so factory +
+ * TODS records stay neutral to which canonical registry produced the identifier
+ * (USTA, ITA, HTS, CTS, any federation, or this one).
+ *
+ * Lives here (not in `account/auth/hiveid.constants`) so the STAY tournament-
+ * admin surfaces (registrations, declarations) do NOT import from the account
+ * tree that lifts out to the HiveID IdP — the Phase-3 re-parenting prerequisite
+ * (Mentat/planning/ACCOUNT_SERVICE_BOUNDARY.md, ACCOUNT_MOVE_PHASE2_3_PLAN.md §2c).
+ */
+export const CANONICAL_PERSON = 'CANONICAL_PERSON';

--- a/src/modules/account/auth/hiveid.constants.ts
+++ b/src/modules/account/auth/hiveid.constants.ts
@@ -1,15 +1,8 @@
-/**
- * CFS-side organisation key stamped on `Participant.person.personOtherIds[]`
- * when linking a TODS Participant to the canonical Person record produced
- * by the registry. The literal value is intentionally `'CANONICAL_PERSON'`
- * — NOT `'courthive-persons'` — so factory + TODS records stay neutral to
- * which canonical registry produced the identifier (USTA, ITA, HTS, CTS,
- * any federation, or this one).
- *
- * Consumed by the PR-J claim handler (courthive-public) via the
- * `addPersonOtherId` factory mutation (PR-K).
- */
-export const CANONICAL_PERSON = 'CANONICAL_PERSON';
+// CANONICAL_PERSON moved to the neutral `src/common/constants/canonicalPerson`
+// so the STAY tournament-admin surfaces (registrations, declarations) don't
+// import from the account tree that lifts out to the IdP (Phase-3 re-parenting).
+// Re-exported here for the hiveid MOVE-side callers that still reference it.
+export { CANONICAL_PERSON } from 'src/common/constants/canonicalPerson';
 
 /** Prefix on magic-link codes that yield a HiveID-audience session. */
 export const HIVEID_MAGIC_LINK_PREFIX = 'hmlk_';

--- a/src/modules/account/declarations/availability-pull.helpers.ts
+++ b/src/modules/account/declarations/availability-pull.helpers.ts
@@ -6,7 +6,7 @@
  */
 import { translateAvailabilityToPersonRequests } from 'tods-competition-factory';
 
-import { CANONICAL_PERSON } from '../auth/hiveid.constants';
+import { CANONICAL_PERSON } from 'src/common/constants/canonicalPerson';
 
 // A tournament realistically spans days, not years. Cap enumeration so a
 // malformed date range can never produce a runaway loop.

--- a/src/modules/account/registrations/registrations.service.ts
+++ b/src/modules/account/registrations/registrations.service.ts
@@ -20,7 +20,7 @@ import { type RegistrationEntry } from 'src/storage/interfaces';
 import { TournamentStorageService } from 'src/storage/tournament-storage.service';
 import { AssignmentsService } from '../../factory/assignments.service';
 import { AuditService } from '../../audit/audit.service';
-import { CANONICAL_PERSON } from '../auth/hiveid.constants';
+import { CANONICAL_PERSON } from 'src/common/constants/canonicalPerson';
 import { canMutateTournament } from '../../factory/helpers/checkTournamentAccess';
 import { executionQueue as runExecutionQueue } from '../../factory/functions/private/executionQueue';
 import { SanctioningClient, SanctioningRecordSnapshot } from '../sanctioning/sanctioning-client.service';


### PR DESCRIPTION
Phase-3 prerequisite: CANONICAL_PERSON → src/common/constants/canonicalPerson so the STAY surfaces (registrations/declarations) don't import the account tree. Behavior-preserving; suites green.