### PR TITLE
feat(throttle): env flag to disable HTTP rate limiting for local/CI e2e

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -3,6 +3,13 @@ APP_NAME='Competition Factory Server'
 APP_MODE='development'
 APP_PORT='8383'
 
+# Disable ALL HTTP rate limiting (per-IP login/token/global throttles). Default
+# OFF. Set ONLY for local dev / CI e2e, where a suite legitimately fires more
+# auth requests per minute than the per-IP login limit (10/min) allows — without
+# this, TMX's CFS-gated e2e journeys skip when their seed logins get 429'd.
+# NEVER set in production. See src/common/throttling/http-throttler.guard.ts.
+# DISABLE_HTTP_THROTTLE=true
+
 # URL where the TMX client app is served — used by the admin client for
 # the "Impersonate → open in TMX" handoff. Both apps must share an origin
 # for the localStorage handoff to work. Defaults to '/tmx/' which matches

--- a/src/common/throttling/http-throttler.guard.ts
+++ b/src/common/throttling/http-throttler.guard.ts
@@ -15,10 +15,16 @@ import { ThrottlerGuard } from '@nestjs/throttler';
  *
  * Everything else — anonymous and JWT-user REST — is subject to the default
  * limits configured in `ThrottlerModule.forRoot` (see app.module.ts).
+ *
+ * `DISABLE_HTTP_THROTTLE=true` disables all HTTP rate limiting for the process.
+ * Default OFF — intended ONLY for local dev / CI e2e, where a suite legitimately
+ * fires far more auth requests per minute than the per-IP login limit allows
+ * (e2e seeds + per-test logins). NEVER set in production.
  */
 @Injectable()
 export class HttpThrottlerGuard extends ThrottlerGuard {
   protected shouldSkip(context: ExecutionContext): Promise<boolean> {
+    if (process.env.DISABLE_HTTP_THROTTLE === 'true') return Promise.resolve(true);
     if (context.getType() !== 'http') return Promise.resolve(true);
     const request = context.switchToHttp().getRequest();
     return Promise.resolve(Boolean(request?.provider?.providerId || request?.provisioner));


### PR DESCRIPTION
Adds a default-OFF `DISABLE_HTTP_THROTTLE` env var. When `=true`, `HttpThrottlerGuard.shouldSkip` bypasses all per-IP HTTP rate limiting.

**Why:** the per-IP login throttle (10/min) causes TMX's CFS-gated e2e journeys (28/36/58/71/72/73/76) to silently skip — the suite's seed logins + per-test logins exceed 10/min and get 429'd, so `seeded=false` → `test.skip`. Setting this flag on a local/CI CFS lets the full CFS-gated suite run.

**Safety:** default OFF; only `=true` enables. Never set in production. Documented in `.env.example`.

Verified: with `DISABLE_HTTP_THROTTLE=true`, 20/20 rapid logins succeed (would 429 after 10 without it).