### PR TITLE
feat(projection): subscribe entries topics to refresh the entries read-model

### DIFF
--- a/src/modules/factory/engines/getMutationEngine.ts
+++ b/src/modules/factory/engines/getMutationEngine.ts
@@ -7,6 +7,7 @@ import {
   recordDeleteParticipants,
   recordDeleteEventsFromAudit,
   recordDeleteVenue,
+  recordEntries,
   recordMatchUpResult,
   recordParticipants,
   recordPersonClaims,
@@ -253,6 +254,8 @@ export function getMutationEngine(services?, publicNotices?: any[], deltaBuffer?
         recordParticipants(deltaBuffer, params);
         recordPersonClaims(deltaBuffer, params, CANONICAL_PERSON);
       },
+      [topicConstants.MODIFY_EVENT_ENTRIES]: (params) => recordEntries(deltaBuffer, params),
+      [topicConstants.MODIFY_DRAW_ENTRIES]: (params) => recordEntries(deltaBuffer, params),
       [topicConstants.ADD_VENUE]: (params) => recordVenue(deltaBuffer, params),
       [topicConstants.MODIFY_VENUE]: (params) => recordVenue(deltaBuffer, params),
       [topicConstants.DELETE_VENUE]: (params) => recordDeleteVenue(deltaBuffer, params),

--- a/src/modules/factory/projection/buildProjectionDeltas.spec.ts
+++ b/src/modules/factory/projection/buildProjectionDeltas.spec.ts
@@ -120,6 +120,26 @@ describe('buildProjectionDeltas', () => {
     expect(deltas.find((d) => d.table === 'entries')).toMatchObject({ op: 'upsert', row: { participant_id: 'p1', person_id: '1001' } });
   });
 
+  it('entries intent → entries upserts WITHOUT forcing a tournaments upsert', async () => {
+    const records = {
+      't-1': {
+        ...RECORD,
+        events: [{ eventId: 'e1', entries: [{ participantId: 'p1', entryStatus: 'ALTERNATE' }] }],
+      },
+    };
+    const deltas = await buildProjectionDeltas({
+      intents: [{ kind: 'entries', tournamentId: 't-1' }],
+      tournamentRecords: records,
+      flattenDraw: jest.fn(),
+    });
+    expect(deltas.find((d) => d.table === 'entries')).toMatchObject({
+      op: 'upsert',
+      row: { participant_id: 'p1', entry_status: 'ALTERNATE' },
+    });
+    // a pure entry change must NOT emit a tournaments upsert (unlike `participants`)
+    expect(deltas.some((d) => d.table === 'tournaments')).toBe(false);
+  });
+
   it('claimPerson → update deltas stamping person_id on competitors + entries', async () => {
     const deltas = await build([{ kind: 'claimPerson', tournamentId: 't-1', participantId: 'pa-1', personId: 'canon-9' }]);
     const updates = deltas.filter((d) => d.op === 'update');

--- a/src/modules/factory/projection/buildProjectionDeltas.ts
+++ b/src/modules/factory/projection/buildProjectionDeltas.ts
@@ -90,6 +90,11 @@ function group(intents: ProjectionIntent[], records: Record<string, any>): Group
         g.participants.add(intent.tournamentId);
         g.touched.add(intent.tournamentId);
         break;
+      case 'entries':
+        // Same entries-fact refresh as `participants`, but a pure entry change does
+        // not alter the tournaments row, so it does not force a tournaments upsert.
+        g.participants.add(intent.tournamentId);
+        break;
       case 'venue':
         g.venues.set(intent.venue.venueId, { tournamentId: intent.tournamentId, venue: intent.venue });
         g.touched.add(intent.tournamentId);

--- a/src/modules/factory/projection/deltaBuffer.spec.ts
+++ b/src/modules/factory/projection/deltaBuffer.spec.ts
@@ -3,6 +3,7 @@ import {
   recordAddDraw,
   recordAddMatchUps,
   recordDeleteDraw,
+  recordEntries,
   recordMatchUpResult,
   recordParticipants,
   recordPersonClaims,
@@ -51,6 +52,25 @@ describe('deltaBuffer recorders', () => {
     const buffer = createDeltaBuffer(['t-1']);
     recordParticipants(buffer, [{ tournamentId: 't-1' }, { tournamentId: 't-1' }]);
     expect(buffer.intents.filter((i) => i.kind === 'participants')).toHaveLength(1);
+  });
+
+  it('recordEntries records one entries intent per tournament and de-dupes', () => {
+    const buffer = createDeltaBuffer(['t-1']);
+    recordEntries(buffer, [
+      { tournamentId: 't-1', eventId: 'e1' },
+      { tournamentId: 't-1', drawId: 'd1' },
+    ]);
+    expect(buffer.intents.filter((i) => i.kind === 'entries')).toEqual([{ kind: 'entries', tournamentId: 't-1' }]);
+  });
+
+  it('recordEntries falls back to the sole mutation tournamentId when the notice omits it', () => {
+    const buffer = createDeltaBuffer(['t-9']);
+    recordEntries(buffer, [{ eventId: 'e1' }]); // no tournamentId in payload
+    expect(buffer.intents).toContainEqual({ kind: 'entries', tournamentId: 't-9' });
+  });
+
+  it('recordEntries is a no-op when the buffer is undefined (feature off)', () => {
+    expect(() => recordEntries(undefined, [{ tournamentId: 't-1', eventId: 'e1' }])).not.toThrow();
   });
 
   it('recordPersonClaims records a claim only for a participant carrying the CANONICAL_PERSON stamp', () => {

--- a/src/modules/factory/projection/deltaBuffer.ts
+++ b/src/modules/factory/projection/deltaBuffer.ts
@@ -100,6 +100,23 @@ export function recordParticipants(buffer: DeltaBuffer | undefined, params: any[
   }
 }
 
+/** MODIFY_EVENT_ENTRIES / MODIFY_DRAW_ENTRIES: `{ tournamentId, eventId, entries }` /
+ *  `{ tournamentId, eventId, drawId, drawEntries }`. Entry membership/status/position
+ *  changed WITHOUT necessarily touching a participant record — refresh the entries
+ *  fact directly. (The factory only began dispatching these topics with the
+ *  notice-completeness work; before that, entries only refreshed on ADD/MODIFY_PARTICIPANTS.) */
+export function recordEntries(buffer: DeltaBuffer | undefined, params: any[]): void {
+  if (!buffer || !Array.isArray(params)) return;
+  const seen = new Set<string>();
+  for (const item of params) {
+    const tournamentId = tidOf(buffer, item?.tournamentId);
+    if (tournamentId && !seen.has(tournamentId)) {
+      seen.add(tournamentId);
+      push(buffer, { kind: 'entries', tournamentId });
+    }
+  }
+}
+
 /** Person self-claim: `addPersonOtherId` stamps `CANONICAL_PERSON` on a
  *  participant's `person.personOtherIds[]` and fires MODIFY_PARTICIPANTS. Detect
  *  that stamp and record a claimPerson intent so the read model's `person_id`

--- a/src/modules/factory/projection/projectionTypes.ts
+++ b/src/modules/factory/projection/projectionTypes.ts
@@ -11,6 +11,7 @@ export type ProjectionIntent =
   | { kind: 'claimPerson'; tournamentId: string; participantId: string; personId: string }
   | { kind: 'touchTournament'; tournamentId: string }
   | { kind: 'participants'; tournamentId: string }
+  | { kind: 'entries'; tournamentId: string }
   | { kind: 'venue'; tournamentId: string; venue: any }
   | { kind: 'deleteVenue'; tournamentId: string; venueId: string }
   | { kind: 'deleteDraw'; tournamentId: string; drawId: string }


### PR DESCRIPTION
## What

Wires the factory **modify-event-entries** / **modify-draw-entries** notice topics into the read-model projection so the `entries` table refreshes when entries actually change.

## Why

The `entries` read-model table refreshed **only** on add/modify participants (`recordParticipants` → `participants` intent → `entryDeltas`). A pure event-entry add/remove/withdraw/reorder that did not touch a participant record left the entries table stale until a rebuild.

The factory notice-completeness work (factory master, batches 6–13) now makes `MODIFY_EVENT_ENTRIES` / `MODIFY_DRAW_ENTRIES` fire reliably for exactly those changes — but CFS never subscribed them, so the notices were dropped.

## Change

- `projectionTypes.ts` — new `entries` projection intent.
- `deltaBuffer.ts` — `recordEntries` recorder (mirrors `recordParticipants`, dedups by tournamentId).
- `buildProjectionDeltas.ts` — `group()` routes the `entries` intent to the existing entries re-projection, **without** forcing a tournaments upsert (a pure entry change does not alter the tournaments row).
- `getMutationEngine.ts` — subscribes both entries topics → `recordEntries`.
- specs — recorder + delta-builder coverage.

Additive and flag-gated: every recorder is a no-op when the delta buffer is absent (`PROJECTION_OUTBOX_ENABLED` off), so the mutation path is untouched until enabled.

## Test

Factory module suite green (193). Projection specs 20 → 24. `check-types` + lint clean.

## Scope note

This is **slice 1** of "consume all subscriptions / complete the Query model". Follow-on slices (each its own PR): DELETED_MATCHUP_IDS individual-matchUp deletes (has an ordering hazard to guard); an events read-model table (ADD/MODIFY/DELETE_EVENT + matchUpFormat); seed-assignments; courts under MODIFY_VENUE.