### PR TITLE
feat(projection): subscribe deleted-matchup-ids to delete individual match_ups rows

### DIFF
--- a/src/modules/factory/engines/getMutationEngine.ts
+++ b/src/modules/factory/engines/getMutationEngine.ts
@@ -4,6 +4,7 @@ import {
   recordAddDraw,
   recordAddMatchUps,
   recordDeleteDraw,
+  recordDeleteMatchUps,
   recordDeleteParticipants,
   recordDeleteEventsFromAudit,
   recordDeleteVenue,
@@ -260,6 +261,7 @@ export function getMutationEngine(services?, publicNotices?: any[], deltaBuffer?
       [topicConstants.MODIFY_VENUE]: (params) => recordVenue(deltaBuffer, params),
       [topicConstants.DELETE_VENUE]: (params) => recordDeleteVenue(deltaBuffer, params),
       [topicConstants.DELETED_DRAW_IDS]: (params) => recordDeleteDraw(deltaBuffer, params),
+      [topicConstants.DELETED_MATCHUP_IDS]: (params) => recordDeleteMatchUps(deltaBuffer, params),
       [topicConstants.DELETE_PARTICIPANTS]: (params) => recordDeleteParticipants(deltaBuffer, params),
     },
   });

--- a/src/modules/factory/projection/buildProjectionDeltas.spec.ts
+++ b/src/modules/factory/projection/buildProjectionDeltas.spec.ts
@@ -120,6 +120,42 @@ describe('buildProjectionDeltas', () => {
     expect(deltas.find((d) => d.table === 'entries')).toMatchObject({ op: 'upsert', row: { participant_id: 'p1', person_id: '1001' } });
   });
 
+  it('deleteMatchUps intent → a match_ups delete per matchUpId (competitors cascade)', async () => {
+    const deltas = await build([{ kind: 'deleteMatchUps', tournamentId: 't-1', matchUpIds: ['m1', 'm2'] }]);
+    const deletes = deltas.filter((d) => d.op === 'delete');
+    expect(deletes).toEqual([
+      { tournamentId: 't-1', op: 'delete', table: 'match_ups', key: { match_up_id: 'm1' }, topic: 'deletedMatchUpIds' },
+      { tournamentId: 't-1', op: 'delete', table: 'match_ups', key: { match_up_id: 'm2' }, topic: 'deletedMatchUpIds' },
+    ]);
+  });
+
+  it('does NOT delete a matchUp that was also (re)built this cycle — draw-replace hazard guard', async () => {
+    // A draw replace fires delete(old ids) + flatten(new ids) for the SAME matchUpId.
+    // The flatten upsert must win; the delete (emitted last) must be skipped.
+    const flattenDraw = jest.fn().mockResolvedValue([singlesMatchUp('m1', 'd1')]);
+    const deltas = await build(
+      [
+        { kind: 'flattenDraw', tournamentId: 't-1', drawId: 'd1' },
+        { kind: 'deleteMatchUps', tournamentId: 't-1', matchUpIds: ['m1'] },
+      ],
+      flattenDraw,
+    );
+    expect(deltas.some((d) => d.op === 'delete' && d.key?.match_up_id === 'm1')).toBe(false);
+    expect(deltas.some((d) => d.op === 'upsert' && d.table === 'match_ups' && d.key?.match_up_id === 'm1')).toBe(true);
+  });
+
+  it('deleteMatchUps still deletes a matchUp that was NOT rebuilt this cycle', async () => {
+    const flattenDraw = jest.fn().mockResolvedValue([singlesMatchUp('m1', 'd1')]);
+    const deltas = await build(
+      [
+        { kind: 'flattenDraw', tournamentId: 't-1', drawId: 'd1' },
+        { kind: 'deleteMatchUps', tournamentId: 't-1', matchUpIds: ['m9'] }, // m9 not flattened
+      ],
+      flattenDraw,
+    );
+    expect(deltas.some((d) => d.op === 'delete' && d.key?.match_up_id === 'm9')).toBe(true);
+  });
+
   it('entries intent → entries upserts WITHOUT forcing a tournaments upsert', async () => {
     const records = {
       't-1': {

--- a/src/modules/factory/projection/buildProjectionDeltas.ts
+++ b/src/modules/factory/projection/buildProjectionDeltas.ts
@@ -45,6 +45,7 @@ interface Grouped {
   venues: Map<string, { tournamentId: string; venue: any }>; // venueId → venue
   deleteVenues: { tournamentId: string; venueId: string }[];
   deleteDraws: { tournamentId: string; drawId: string }[];
+  deleteMatchUps: Map<string, string>; // matchUpId → tournamentId
   deleteEvents: { tournamentId: string; eventId: string }[];
   deleteParticipants: { tournamentId: string; participantIds: string[] }[];
   claims: Map<string, { tournamentId: string; participantId: string; personId: string }>; // participantId → claim
@@ -63,6 +64,7 @@ function group(intents: ProjectionIntent[], records: Record<string, any>): Group
     venues: new Map(),
     deleteVenues: [],
     deleteDraws: [],
+    deleteMatchUps: new Map(),
     deleteEvents: [],
     deleteParticipants: [],
     claims: new Map(),
@@ -104,6 +106,9 @@ function group(intents: ProjectionIntent[], records: Record<string, any>): Group
         break;
       case 'deleteDraw':
         g.deleteDraws.push(intent);
+        break;
+      case 'deleteMatchUps':
+        for (const matchUpId of intent.matchUpIds) g.deleteMatchUps.set(matchUpId, intent.tournamentId);
         break;
       case 'deleteEvent':
         g.deleteEvents.push(intent);
@@ -244,6 +249,7 @@ function resultDeltas(g: Grouped, records: Record<string, any>, coveredMatchUpId
   for (const { tournamentId, matchUp } of g.matchUpResults.values()) {
     if (coveredMatchUpIds.has(matchUp.matchUpId)) continue; // already fully built by a flatten
     const row = matchUpResultRow(matchUp, tournamentId, providerIdOf(records, tournamentId));
+    coveredMatchUpIds.add(row.match_up_id); // a re-scored matchUp must not be deleted this cycle
     deltas.push(upsert(tournamentId, TABLE_MATCH_UPS, { match_up_id: row.match_up_id }, row, 'modifyMatchUp'));
   }
   return deltas;
@@ -296,7 +302,7 @@ function venueDeltas(g: Grouped): ProjectionDelta[] {
   return deltas;
 }
 
-function deleteDeltas(g: Grouped): ProjectionDelta[] {
+function deleteDeltas(g: Grouped, coveredMatchUpIds: Set<string>): ProjectionDelta[] {
   const deltas: ProjectionDelta[] = [];
   for (const { tournamentId, venueId } of g.deleteVenues) {
     deltas.push(
@@ -305,6 +311,13 @@ function deleteDeltas(g: Grouped): ProjectionDelta[] {
   }
   for (const { tournamentId, drawId } of g.deleteDraws) {
     deltas.push(del(tournamentId, TABLE_MATCH_UPS, { draw_id: drawId }, 'deleteDraw')); // competitors cascade
+  }
+  // Individual matchUp removals. A matchUp that was ALSO (re)built this cycle is in
+  // coveredMatchUpIds — skip it, else the delete (emitted last) would undo the upsert
+  // for a draw replace that reuses the same matchUpIds. Competitors cascade on the FK.
+  for (const [matchUpId, tournamentId] of g.deleteMatchUps) {
+    if (coveredMatchUpIds.has(matchUpId)) continue;
+    deltas.push(del(tournamentId, TABLE_MATCH_UPS, { match_up_id: matchUpId }, 'deletedMatchUpIds'));
   }
   for (const { tournamentId, eventId } of g.deleteEvents) {
     deltas.push(del(tournamentId, TABLE_MATCH_UPS, { event_id: eventId }, 'deleteEvent'));
@@ -344,6 +357,6 @@ export async function buildProjectionDeltas(args: BuildDeltasArgs): Promise<Proj
     ...resultDeltas(g, args.tournamentRecords, coveredMatchUpIds),
     ...entryDeltas(g, args.tournamentRecords),
     ...claimDeltas(g),
-    ...deleteDeltas(g),
+    ...deleteDeltas(g, coveredMatchUpIds),
   ];
 }

--- a/src/modules/factory/projection/deltaBuffer.spec.ts
+++ b/src/modules/factory/projection/deltaBuffer.spec.ts
@@ -3,6 +3,7 @@ import {
   recordAddDraw,
   recordAddMatchUps,
   recordDeleteDraw,
+  recordDeleteMatchUps,
   recordEntries,
   recordMatchUpResult,
   recordParticipants,
@@ -71,6 +72,19 @@ describe('deltaBuffer recorders', () => {
 
   it('recordEntries is a no-op when the buffer is undefined (feature off)', () => {
     expect(() => recordEntries(undefined, [{ tournamentId: 't-1', eventId: 'e1' }])).not.toThrow();
+  });
+
+  it('recordDeleteMatchUps records a deleteMatchUps intent carrying the matchUpIds', () => {
+    const buffer = createDeltaBuffer(['t-1']);
+    recordDeleteMatchUps(buffer, [{ tournamentId: 't-1', matchUpIds: ['m1', 'm2'] }]);
+    expect(buffer.intents).toContainEqual({ kind: 'deleteMatchUps', tournamentId: 't-1', matchUpIds: ['m1', 'm2'] });
+  });
+
+  it('recordDeleteMatchUps skips a notice with no matchUpIds and is a no-op when the buffer is off', () => {
+    const buffer = createDeltaBuffer(['t-1']);
+    recordDeleteMatchUps(buffer, [{ tournamentId: 't-1', matchUpIds: [] }]);
+    expect(buffer.intents).toHaveLength(0);
+    expect(() => recordDeleteMatchUps(undefined, [{ tournamentId: 't-1', matchUpIds: ['m1'] }])).not.toThrow();
   });
 
   it('recordPersonClaims records a claim only for a participant carrying the CANONICAL_PERSON stamp', () => {

--- a/src/modules/factory/projection/deltaBuffer.ts
+++ b/src/modules/factory/projection/deltaBuffer.ts
@@ -183,6 +183,20 @@ export function recordDeleteDraw(buffer: DeltaBuffer | undefined, params: any[])
   }
 }
 
+/** DELETED_MATCHUP_IDS: `{ matchUpIds, tournamentId, eventId }`. Individual
+ *  matchUp removals that are NOT a whole-draw delete (structure/round removal,
+ *  ad-hoc matchUp removal). A whole-draw delete is handled by DELETED_DRAW_IDS.
+ *  The build guards against deleting a matchUp that was ALSO (re)built this cycle
+ *  (e.g. a draw replace fires delete + add for the same ids). */
+export function recordDeleteMatchUps(buffer: DeltaBuffer | undefined, params: any[]): void {
+  if (!buffer || !Array.isArray(params)) return;
+  for (const item of params) {
+    const tournamentId = tidOf(buffer, item?.tournamentId);
+    const matchUpIds = item?.matchUpIds ?? [];
+    if (tournamentId && matchUpIds.length) push(buffer, { kind: 'deleteMatchUps', tournamentId, matchUpIds });
+  }
+}
+
 /** DELETE_PARTICIPANTS: `{ participantIds, tournamentId }`. */
 export function recordDeleteParticipants(buffer: DeltaBuffer | undefined, params: any[]): void {
   if (!buffer || !Array.isArray(params)) return;

--- a/src/modules/factory/projection/projectionTypes.ts
+++ b/src/modules/factory/projection/projectionTypes.ts
@@ -15,6 +15,7 @@ export type ProjectionIntent =
   | { kind: 'venue'; tournamentId: string; venue: any }
   | { kind: 'deleteVenue'; tournamentId: string; venueId: string }
   | { kind: 'deleteDraw'; tournamentId: string; drawId: string }
+  | { kind: 'deleteMatchUps'; tournamentId: string; matchUpIds: string[] }
   | { kind: 'deleteEvent'; tournamentId: string; eventId: string }
   | { kind: 'deleteParticipants'; tournamentId: string; participantIds: string[] };
 


### PR DESCRIPTION
## What

Subscribes the factory **deleted-matchup-ids** notice into the read-model projection so an individual matchUp removal deletes its `match_ups` row.

> **Stacked on #852** (entries slice). Base is `feat/entries-projection-subscription`; retarget to `main` once #852 merges.

## Why

Only whole-draw deletes removed `match_ups` rows (`deleted-draw-ids` → delete by `draw_id`). An individual matchUp removal that did **not** delete the draw — structure/round removal, ad-hoc matchUp removal — left a stale row in the read model.

## Change

- `deleteMatchUps` projection intent + `recordDeleteMatchUps` recorder.
- `buildProjectionDeltas`: deletes each `match_up_id` (competitors cascade on the FK).
- **Ordering-hazard guard:** a draw replace fires `delete(old ids)` + `flatten(new ids)` for the same matchUpId, and deletes are emitted **last**, so a naive delete would undo the flatten upsert. Any matchUp (re)built this cycle is tracked in `coveredMatchUpIds` — now including slim result upserts — and the delete skips it.
- Subscribes `DELETED_MATCHUP_IDS` in `getMutationEngine`.

## Test

Factory module suite 193 → 198. Projection specs 24 → 29 (incl. the guard test: a matchUp both flattened and deleted this cycle is upserted, not deleted; a matchUp deleted but not rebuilt is still deleted). check-types + lint clean.

Additive + flag-gated (no-op when the delta buffer is absent).