### PR TITLE
feat(projection): project an events read-model table from the event topics

### DIFF
--- a/src/modules/factory/engines/getMutationEngine.ts
+++ b/src/modules/factory/engines/getMutationEngine.ts
@@ -4,11 +4,13 @@ import {
   recordAddDraw,
   recordAddMatchUps,
   recordDeleteDraw,
+  recordDeleteEvent,
   recordDeleteMatchUps,
   recordDeleteParticipants,
   recordDeleteEventsFromAudit,
   recordDeleteVenue,
   recordEntries,
+  recordEvents,
   recordMatchUpResult,
   recordParticipants,
   recordPersonClaims,
@@ -103,6 +105,7 @@ export function getMutationEngine(services?, publicNotices?: any[], deltaBuffer?
       },
       [topicConstants.PUBLISH_EVENT]: (params) => {
         if (Array.isArray(params)) {
+          recordEvents(deltaBuffer, params); // event.published flag on the events row
           for (const item of params) {
             const eventId = item.eventData?.eventInfo?.eventId;
             if (item.tournamentId && eventId) {
@@ -125,6 +128,7 @@ export function getMutationEngine(services?, publicNotices?: any[], deltaBuffer?
         }
       },
       [topicConstants.UNPUBLISH_EVENT]: (params) => {
+        recordEvents(deltaBuffer, params); // event.published flag on the events row
         for (const item of params) {
           if (item.tournamentId && item.eventId) {
             const eventDataKey = `ged|${item.tournamentId}|${item.eventId}`;
@@ -255,6 +259,9 @@ export function getMutationEngine(services?, publicNotices?: any[], deltaBuffer?
         recordParticipants(deltaBuffer, params);
         recordPersonClaims(deltaBuffer, params, CANONICAL_PERSON);
       },
+      [topicConstants.ADD_EVENT]: (params) => recordEvents(deltaBuffer, params),
+      [topicConstants.MODIFY_EVENT]: (params) => recordEvents(deltaBuffer, params),
+      [topicConstants.DELETE_EVENT]: (params) => recordDeleteEvent(deltaBuffer, params),
       [topicConstants.MODIFY_EVENT_ENTRIES]: (params) => recordEntries(deltaBuffer, params),
       [topicConstants.MODIFY_DRAW_ENTRIES]: (params) => recordEntries(deltaBuffer, params),
       [topicConstants.ADD_VENUE]: (params) => recordVenue(deltaBuffer, params),

--- a/src/modules/factory/projection/buildProjectionDeltas.spec.ts
+++ b/src/modules/factory/projection/buildProjectionDeltas.spec.ts
@@ -120,6 +120,56 @@ describe('buildProjectionDeltas', () => {
     expect(deltas.find((d) => d.table === 'entries')).toMatchObject({ op: 'upsert', row: { participant_id: 'p1', person_id: '1001' } });
   });
 
+  it('events intent → one events upsert per event (after tournaments, its FK parent)', async () => {
+    const records = {
+      't-1': {
+        ...RECORD,
+        events: [
+          { eventId: 'e1', eventName: 'Singles', eventType: 'SINGLES', gender: 'MALE' },
+          { eventId: 'e2', eventName: 'Doubles', eventType: 'DOUBLES' },
+        ],
+      },
+    };
+    const deltas = await buildProjectionDeltas({
+      intents: [{ kind: 'events', tournamentId: 't-1' }],
+      tournamentRecords: records,
+      flattenDraw: jest.fn(),
+    });
+    const eventDeltas = deltas.filter((d) => d.table === 'events');
+    expect(eventDeltas.map((d) => d.key)).toEqual([{ event_id: 'e1' }, { event_id: 'e2' }]);
+    expect(eventDeltas[0].row).toMatchObject({
+      event_id: 'e1',
+      tournament_id: 't-1',
+      provider_id: 'BOBOCA',
+      event_name: 'Singles',
+      event_type: 'SINGLES',
+      published: false,
+    });
+    // tournaments (FK parent) must be ordered before events
+    expect(deltas.findIndex((d) => d.table === 'tournaments')).toBeLessThan(
+      deltas.findIndex((d) => d.table === 'events'),
+    );
+  });
+
+  it('deleteEvent intent → events + match_ups + entries deletes (deduped by eventId)', async () => {
+    const deltas = await build([
+      { kind: 'deleteEvent', tournamentId: 't-1', eventId: 'e1' },
+      { kind: 'deleteEvent', tournamentId: 't-1', eventId: 'e1' }, // duplicate (AUDIT + DELETE_EVENT)
+    ]);
+    const deletes = deltas.filter((d) => d.op === 'delete');
+    expect(deletes).toEqual([
+      { tournamentId: 't-1', op: 'delete', table: 'events', key: { event_id: 'e1' }, topic: 'deleteEvent' },
+      { tournamentId: 't-1', op: 'delete', table: 'match_ups', key: { event_id: 'e1' }, topic: 'deleteEvent' },
+      {
+        tournamentId: 't-1',
+        op: 'delete',
+        table: 'entries',
+        key: { tournament_id: 't-1', event_id: 'e1' },
+        topic: 'deleteEvent',
+      },
+    ]);
+  });
+
   it('deleteMatchUps intent → a match_ups delete per matchUpId (competitors cascade)', async () => {
     const deltas = await build([{ kind: 'deleteMatchUps', tournamentId: 't-1', matchUpIds: ['m1', 'm2'] }]);
     const deletes = deltas.filter((d) => d.op === 'delete');

--- a/src/modules/factory/projection/buildProjectionDeltas.ts
+++ b/src/modules/factory/projection/buildProjectionDeltas.ts
@@ -5,6 +5,7 @@ import { ProjectionDelta } from 'src/storage/interfaces/projection-outbox-storag
 import { ProjectionIntent } from './projectionTypes';
 import {
   TABLE_TOURNAMENTS,
+  TABLE_EVENTS,
   TABLE_MATCH_UPS,
   TABLE_MATCH_UP_COMPETITORS,
   TABLE_ENTRIES,
@@ -18,6 +19,7 @@ import {
 // incremental producer stays per-draw; it just reuses the same row logic.
 const {
   entryRows,
+  eventRow,
   matchUpResultRow,
   matchUpRowSet,
   tournamentRow,
@@ -41,12 +43,13 @@ interface Grouped {
   flattenDraws: Map<string, { tournamentId: string; drawId: string }>; // key tid::drawId
   touched: Set<string>; // tournamentIds needing a tournaments upsert
   participants: Set<string>; // tournamentIds needing an entries refresh
+  events: Set<string>; // tournamentIds needing an events refresh
   matchUpResults: Map<string, { tournamentId: string; matchUp: any }>; // matchUpId → latest
   venues: Map<string, { tournamentId: string; venue: any }>; // venueId → venue
   deleteVenues: { tournamentId: string; venueId: string }[];
   deleteDraws: { tournamentId: string; drawId: string }[];
   deleteMatchUps: Map<string, string>; // matchUpId → tournamentId
-  deleteEvents: { tournamentId: string; eventId: string }[];
+  deleteEvents: Map<string, string>; // eventId → tournamentId (dedups AUDIT + DELETE_EVENT)
   deleteParticipants: { tournamentId: string; participantIds: string[] }[];
   claims: Map<string, { tournamentId: string; participantId: string; personId: string }>; // participantId → claim
 }
@@ -60,12 +63,13 @@ function group(intents: ProjectionIntent[], records: Record<string, any>): Group
     flattenDraws: new Map(),
     touched: new Set(),
     participants: new Set(),
+    events: new Set(),
     matchUpResults: new Map(),
     venues: new Map(),
     deleteVenues: [],
     deleteDraws: [],
     deleteMatchUps: new Map(),
-    deleteEvents: [],
+    deleteEvents: new Map(),
     deleteParticipants: [],
     claims: new Map(),
   };
@@ -97,6 +101,9 @@ function group(intents: ProjectionIntent[], records: Record<string, any>): Group
         // not alter the tournaments row, so it does not force a tournaments upsert.
         g.participants.add(intent.tournamentId);
         break;
+      case 'events':
+        g.events.add(intent.tournamentId);
+        break;
       case 'venue':
         g.venues.set(intent.venue.venueId, { tournamentId: intent.tournamentId, venue: intent.venue });
         g.touched.add(intent.tournamentId);
@@ -111,7 +118,7 @@ function group(intents: ProjectionIntent[], records: Record<string, any>): Group
         for (const matchUpId of intent.matchUpIds) g.deleteMatchUps.set(matchUpId, intent.tournamentId);
         break;
       case 'deleteEvent':
-        g.deleteEvents.push(intent);
+        g.deleteEvents.set(intent.eventId, intent.tournamentId);
         break;
       case 'deleteParticipants':
         g.deleteParticipants.push(intent);
@@ -266,6 +273,25 @@ function tournamentDeltas(g: Grouped, records: Record<string, any>): ProjectionD
   return deltas;
 }
 
+// One `events` row per event of each touched tournament. `published` is resolved
+// the SAME way cast() does (`!!getEventPublishStatus`) so the incremental rows are
+// byte-identical to a rebuild. provider_id comes from the record's parentOrganisation.
+function eventDeltas(g: Grouped, records: Record<string, any>): ProjectionDelta[] {
+  const deltas: ProjectionDelta[] = [];
+  for (const tournamentId of g.events) {
+    const record = records?.[tournamentId];
+    if (!record) continue;
+    const providerId = providerIdOf(records, tournamentId);
+    for (const event of record.events ?? []) {
+      if (!event?.eventId) continue;
+      const published = !!getEventPublishStatus({ event });
+      const row = eventRow(event, tournamentId, providerId, published);
+      deltas.push(upsert(tournamentId, TABLE_EVENTS, { event_id: row.event_id }, row, 'events'));
+    }
+  }
+  return deltas;
+}
+
 function entryDeltas(g: Grouped, records: Record<string, any>): ProjectionDelta[] {
   const deltas: ProjectionDelta[] = [];
   for (const tournamentId of g.participants) {
@@ -319,7 +345,8 @@ function deleteDeltas(g: Grouped, coveredMatchUpIds: Set<string>): ProjectionDel
     if (coveredMatchUpIds.has(matchUpId)) continue;
     deltas.push(del(tournamentId, TABLE_MATCH_UPS, { match_up_id: matchUpId }, 'deletedMatchUpIds'));
   }
-  for (const { tournamentId, eventId } of g.deleteEvents) {
+  for (const [eventId, tournamentId] of g.deleteEvents) {
+    deltas.push(del(tournamentId, TABLE_EVENTS, { event_id: eventId }, 'deleteEvent'));
     deltas.push(del(tournamentId, TABLE_MATCH_UPS, { event_id: eventId }, 'deleteEvent'));
     deltas.push(del(tournamentId, TABLE_ENTRIES, { tournament_id: tournamentId, event_id: eventId }, 'deleteEvent'));
   }
@@ -352,6 +379,7 @@ export async function buildProjectionDeltas(args: BuildDeltasArgs): Promise<Proj
 
   return [
     ...tournamentDeltas(g, args.tournamentRecords),
+    ...eventDeltas(g, args.tournamentRecords),
     ...venueDeltas(g),
     ...flatten,
     ...resultDeltas(g, args.tournamentRecords, coveredMatchUpIds),

--- a/src/modules/factory/projection/deltaBuffer.spec.ts
+++ b/src/modules/factory/projection/deltaBuffer.spec.ts
@@ -3,8 +3,10 @@ import {
   recordAddDraw,
   recordAddMatchUps,
   recordDeleteDraw,
+  recordDeleteEvent,
   recordDeleteMatchUps,
   recordEntries,
+  recordEvents,
   recordMatchUpResult,
   recordParticipants,
   recordPersonClaims,
@@ -72,6 +74,28 @@ describe('deltaBuffer recorders', () => {
 
   it('recordEntries is a no-op when the buffer is undefined (feature off)', () => {
     expect(() => recordEntries(undefined, [{ tournamentId: 't-1', eventId: 'e1' }])).not.toThrow();
+  });
+
+  it('recordEvents records one events intent per tournament and de-dupes', () => {
+    const buffer = createDeltaBuffer(['t-1']);
+    recordEvents(buffer, [{ tournamentId: 't-1', event: { eventId: 'e1' } }, { tournamentId: 't-1' }]);
+    expect(buffer.intents.filter((i) => i.kind === 'events')).toEqual([{ kind: 'events', tournamentId: 't-1' }]);
+  });
+
+  it('recordDeleteEvent records a deleteEvent intent per eventId', () => {
+    const buffer = createDeltaBuffer(['t-1']);
+    recordDeleteEvent(buffer, [{ tournamentId: 't-1', eventIds: ['e1', 'e2'] }]);
+    expect(buffer.intents.filter((i) => i.kind === 'deleteEvent')).toEqual([
+      { kind: 'deleteEvent', tournamentId: 't-1', eventId: 'e1' },
+      { kind: 'deleteEvent', tournamentId: 't-1', eventId: 'e2' },
+    ]);
+  });
+
+  it('recordEvents / recordDeleteEvent are no-ops when the buffer is undefined (feature off)', () => {
+    expect(() => {
+      recordEvents(undefined, [{ tournamentId: 't-1' }]);
+      recordDeleteEvent(undefined, [{ tournamentId: 't-1', eventIds: ['e1'] }]);
+    }).not.toThrow();
   });
 
   it('recordDeleteMatchUps records a deleteMatchUps intent carrying the matchUpIds', () => {

--- a/src/modules/factory/projection/deltaBuffer.ts
+++ b/src/modules/factory/projection/deltaBuffer.ts
@@ -117,6 +117,36 @@ export function recordEntries(buffer: DeltaBuffer | undefined, params: any[]): v
   }
 }
 
+/** ADD_EVENT / MODIFY_EVENT / PUBLISH_EVENT / UNPUBLISH_EVENT: an event was added
+ *  or its attributes / publish state changed → re-project the event rows for the
+ *  tournament. Payloads vary ({ event, tournamentId } / { eventId, tournamentId } /
+ *  { eventData, tournamentId }) but all carry (or fall back to) tournamentId. */
+export function recordEvents(buffer: DeltaBuffer | undefined, params: any[]): void {
+  if (!buffer || !Array.isArray(params)) return;
+  const seen = new Set<string>();
+  for (const item of params) {
+    const tournamentId = tidOf(buffer, item?.tournamentId);
+    if (tournamentId && !seen.has(tournamentId)) {
+      seen.add(tournamentId);
+      push(buffer, { kind: 'events', tournamentId });
+    }
+  }
+}
+
+/** DELETE_EVENT: `{ eventIds, tournamentId }`. Delete the event row + cascade its
+ *  match_ups / entries. Deduped by eventId with the AUDIT-derived deleteEvent path
+ *  in buildProjectionDeltas (both push a `deleteEvent` intent for the same id). */
+export function recordDeleteEvent(buffer: DeltaBuffer | undefined, params: any[]): void {
+  if (!buffer || !Array.isArray(params)) return;
+  for (const item of params) {
+    const tournamentId = tidOf(buffer, item?.tournamentId);
+    if (!tournamentId) continue;
+    for (const eventId of item?.eventIds ?? []) {
+      if (eventId) push(buffer, { kind: 'deleteEvent', tournamentId, eventId });
+    }
+  }
+}
+
 /** Person self-claim: `addPersonOtherId` stamps `CANONICAL_PERSON` on a
  *  participant's `person.personOtherIds[]` and fires MODIFY_PARTICIPANTS. Detect
  *  that stamp and record a claimPerson intent so the read model's `person_id`

--- a/src/modules/factory/projection/projection-conformance.spec.ts
+++ b/src/modules/factory/projection/projection-conformance.spec.ts
@@ -10,6 +10,7 @@ import { ProjectionDelta } from 'src/storage/interfaces/projection-outbox-storag
 // so we can compare the NET read-table state of two producer paths without a DB.
 const PK: Record<string, string[]> = {
   tournaments: ['tournament_id'],
+  events: ['event_id'],
   match_ups: ['match_up_id'],
   match_up_competitors: ['match_up_id', 'side_number', 'competitor_index'],
   entries: ['tournament_id', 'event_id', 'participant_id'],
@@ -215,6 +216,7 @@ describe('projection conformance — incremental path ≡ rebuild path (byte-ide
 
     for (const table of [
       'tournaments',
+      'events',
       'match_ups',
       'match_up_competitors',
       'entries',

--- a/src/modules/factory/projection/projectionConstants.ts
+++ b/src/modules/factory/projection/projectionConstants.ts
@@ -1,6 +1,7 @@
 // Read-model target tables (snake_case, matching the courthive-query schema
 // in 001-read-model-tables.sql). row_data keys mirror those column names.
 export const TABLE_TOURNAMENTS = 'tournaments';
+export const TABLE_EVENTS = 'events';
 export const TABLE_MATCH_UPS = 'match_ups';
 export const TABLE_MATCH_UP_COMPETITORS = 'match_up_competitors';
 export const TABLE_ENTRIES = 'entries';

--- a/src/modules/factory/projection/projectionTypes.ts
+++ b/src/modules/factory/projection/projectionTypes.ts
@@ -12,6 +12,7 @@ export type ProjectionIntent =
   | { kind: 'touchTournament'; tournamentId: string }
   | { kind: 'participants'; tournamentId: string }
   | { kind: 'entries'; tournamentId: string }
+  | { kind: 'events'; tournamentId: string }
   | { kind: 'venue'; tournamentId: string; venue: any }
   | { kind: 'deleteVenue'; tournamentId: string; venueId: string }
   | { kind: 'deleteDraw'; tournamentId: string; drawId: string }

--- a/src/modules/factory/projection/rebuild.ts
+++ b/src/modules/factory/projection/rebuild.ts
@@ -21,6 +21,7 @@ export function buildRebuildIntents(record: any): ProjectionIntent[] {
   const intents: ProjectionIntent[] = [
     { kind: 'touchTournament', tournamentId },
     { kind: 'participants', tournamentId },
+    { kind: 'events', tournamentId },
   ];
 
   for (const event of record?.events ?? []) {


### PR DESCRIPTION
## What

Adds an **events** dimension to the read model, fed by the event notice topics. Part of "consume all subscriptions / complete the Query model".

> **Stacked on #853** (which is stacked on #852). Base is `feat/deleted-matchups-projection`; retarget down to `main` as the stack merges.
> **Depends on a factory release** exposing `readModel.eventRow` + the events `cast()` table (factory master `1b8335cd2`). CFS's factory pin must bump to that release before CI/deploy builds — locally it resolves via the `link:../factory` symlink.

## Why

There was no events table: `event_id` was a bare FK column on `query_match_ups`/`query_entries` with **no event name, type, gender, category, matchUpFormat, dates or publish state** stored anywhere. `ADD_EVENT`/`MODIFY_EVENT`/`DELETE_EVENT` were dispatched by the factory but unsubscribed by CFS (dropped).

## Change

- `events` projection intent + `recordEvents` / `recordDeleteEvent` recorders.
- `eventDeltas` re-projects one row per event via the factory `readModel.eventRow` builder; `published` resolved with `getEventPublishStatus` — the **same source cast() uses** — so incremental rows are byte-identical to a rebuild.
- `deleteEvent` drops the events row (+ match_ups/entries cascade), deduped by eventId across the AUDIT-derived path and the new `DELETE_EVENT` subscription.
- Subscribes `ADD_EVENT` / `MODIFY_EVENT` / `DELETE_EVENT`; `PUBLISH_EVENT`/`UNPUBLISH_EVENT` also refresh the events row for the `published` flag.
- `buildRebuildIntents` emits an `events` intent so backfill populates the table.

## Test

The **conformance capstone now asserts `events` too** — CFS rebuild ≡ factory `cast()` byte-for-byte across all 7 tables. Factory module suite 198 → 203; projection specs 29 → 34. check-types + lint clean. Additive + flag-gated.

## Companion PR

Consumer table + allow-list: courthive-query PR (query_events migration + tableMeta). Deploy the two together (migration + allow-list in one release).