### PR TITLE
feat(projection): project a seeds read-model table from modify-seed-assignments

### DIFF
--- a/src/modules/factory/engines/getMutationEngine.ts
+++ b/src/modules/factory/engines/getMutationEngine.ts
@@ -16,6 +16,7 @@ import {
   recordPersonClaims,
   recordPositionAssignments,
   recordRepublishEvent,
+  recordSeeds,
   recordTouchTournament,
   recordVenue,
 } from '../projection/deltaBuffer';
@@ -264,6 +265,7 @@ export function getMutationEngine(services?, publicNotices?: any[], deltaBuffer?
       [topicConstants.DELETE_EVENT]: (params) => recordDeleteEvent(deltaBuffer, params),
       [topicConstants.MODIFY_EVENT_ENTRIES]: (params) => recordEntries(deltaBuffer, params),
       [topicConstants.MODIFY_DRAW_ENTRIES]: (params) => recordEntries(deltaBuffer, params),
+      [topicConstants.MODIFY_SEED_ASSIGNMENTS]: (params) => recordSeeds(deltaBuffer, params),
       [topicConstants.ADD_VENUE]: (params) => recordVenue(deltaBuffer, params),
       [topicConstants.MODIFY_VENUE]: (params) => recordVenue(deltaBuffer, params),
       [topicConstants.DELETE_VENUE]: (params) => recordDeleteVenue(deltaBuffer, params),

--- a/src/modules/factory/projection/buildProjectionDeltas.spec.ts
+++ b/src/modules/factory/projection/buildProjectionDeltas.spec.ts
@@ -167,7 +167,68 @@ describe('buildProjectionDeltas', () => {
         key: { tournament_id: 't-1', event_id: 'e1' },
         topic: 'deleteEvent',
       },
+      { tournamentId: 't-1', op: 'delete', table: 'seeds', key: { event_id: 'e1' }, topic: 'deleteEvent' },
     ]);
+  });
+
+  it('seeds intent → delete-by-structure THEN one upsert per participant-holding assignment', async () => {
+    const records = {
+      't-1': {
+        ...RECORD,
+        events: [
+          {
+            eventId: 'e1',
+            drawDefinitions: [
+              {
+                drawId: 'd1',
+                structures: [
+                  {
+                    structureId: 's1',
+                    seedAssignments: [
+                      { seedNumber: 1, participantId: 'p1', seedValue: 1 },
+                      { seedNumber: 2, participantId: 'p2', seedValue: 2 },
+                      { seedNumber: 3 }, // no participant → skipped
+                    ],
+                  },
+                ],
+              },
+            ],
+          },
+        ],
+      },
+    };
+    const deltas = await buildProjectionDeltas({
+      intents: [{ kind: 'seeds', tournamentId: 't-1', structureId: 's1' }],
+      tournamentRecords: records,
+      flattenDraw: jest.fn(),
+    });
+    const seedOps = deltas.filter((d) => d.table === 'seeds');
+    // delete-by-structure first, then the two participant-holding upserts (order matters)
+    expect(seedOps[0]).toMatchObject({ op: 'delete', key: { structure_id: 's1' } });
+    expect(seedOps.slice(1).map((d) => d.key)).toEqual([
+      { structure_id: 's1', seed_number: 1 },
+      { structure_id: 's1', seed_number: 2 },
+    ]);
+    expect(seedOps[1].row).toMatchObject({ participant_id: 'p1', seed_value: '1', draw_id: 'd1', event_id: 'e1' });
+  });
+
+  it('a seeds intent for a structure that no longer exists emits only the delete', async () => {
+    const deltas = await build([{ kind: 'seeds', tournamentId: 't-1', structureId: 'gone' }]);
+    const seedOps = deltas.filter((d) => d.table === 'seeds');
+    expect(seedOps).toEqual([
+      { tournamentId: 't-1', op: 'delete', table: 'seeds', key: { structure_id: 'gone' }, topic: 'seeds' },
+    ]);
+  });
+
+  it('deleteDraw also deletes the draw’s seeds (no structures table to cascade from)', async () => {
+    const deltas = await build([{ kind: 'deleteDraw', tournamentId: 't-1', drawId: 'd1' }]);
+    expect(deltas).toContainEqual({
+      tournamentId: 't-1',
+      op: 'delete',
+      table: 'seeds',
+      key: { draw_id: 'd1' },
+      topic: 'deleteDraw',
+    });
   });
 
   it('deleteMatchUps intent → a match_ups delete per matchUpId (competitors cascade)', async () => {

--- a/src/modules/factory/projection/buildProjectionDeltas.ts
+++ b/src/modules/factory/projection/buildProjectionDeltas.ts
@@ -6,6 +6,7 @@ import { ProjectionIntent } from './projectionTypes';
 import {
   TABLE_TOURNAMENTS,
   TABLE_EVENTS,
+  TABLE_SEEDS,
   TABLE_MATCH_UPS,
   TABLE_MATCH_UP_COMPETITORS,
   TABLE_ENTRIES,
@@ -20,6 +21,7 @@ import {
 const {
   entryRows,
   eventRow,
+  seedRow,
   matchUpResultRow,
   matchUpRowSet,
   tournamentRow,
@@ -44,6 +46,7 @@ interface Grouped {
   touched: Set<string>; // tournamentIds needing a tournaments upsert
   participants: Set<string>; // tournamentIds needing an entries refresh
   events: Set<string>; // tournamentIds needing an events refresh
+  seeds: Map<string, string>; // structureId → tournamentId (seeds re-project per structure)
   matchUpResults: Map<string, { tournamentId: string; matchUp: any }>; // matchUpId → latest
   venues: Map<string, { tournamentId: string; venue: any }>; // venueId → venue
   deleteVenues: { tournamentId: string; venueId: string }[];
@@ -64,6 +67,7 @@ function group(intents: ProjectionIntent[], records: Record<string, any>): Group
     touched: new Set(),
     participants: new Set(),
     events: new Set(),
+    seeds: new Map(),
     matchUpResults: new Map(),
     venues: new Map(),
     deleteVenues: [],
@@ -103,6 +107,9 @@ function group(intents: ProjectionIntent[], records: Record<string, any>): Group
         break;
       case 'events':
         g.events.add(intent.tournamentId);
+        break;
+      case 'seeds':
+        g.seeds.set(intent.structureId, intent.tournamentId);
         break;
       case 'venue':
         g.venues.set(intent.venue.venueId, { tournamentId: intent.tournamentId, venue: intent.venue });
@@ -292,6 +299,49 @@ function eventDeltas(g: Grouped, records: Record<string, any>): ProjectionDelta[
   return deltas;
 }
 
+// Locate a structure + its owning event/draw in the final record (for a seeds
+// re-projection, the intent carries only the structureId).
+function findStructureContext(
+  record: any,
+  structureId: string,
+): { eventId: string; drawId: string; structure: any } | undefined {
+  for (const event of record?.events ?? []) {
+    for (const draw of event.drawDefinitions ?? []) {
+      for (const structure of draw.structures ?? []) {
+        if (structure?.structureId === structureId) {
+          return { eventId: event.eventId, drawId: draw.drawId, structure };
+        }
+      }
+    }
+  }
+  return undefined;
+}
+
+// Seeds re-project PER STRUCTURE as delete-by-structure THEN re-insert: a seed set
+// can SHRINK (a cleared seed), which an upsert-only refresh would leave stale. The
+// delete is emitted before its upserts (array order = apply order), so on a rebuild
+// (empty table) it is a harmless no-op and the net equals cast().
+function seedDeltas(g: Grouped, records: Record<string, any>): ProjectionDelta[] {
+  const deltas: ProjectionDelta[] = [];
+  for (const [structureId, tournamentId] of g.seeds) {
+    const record = records?.[tournamentId];
+    if (!record) continue;
+    deltas.push(del(tournamentId, TABLE_SEEDS, { structure_id: structureId }, 'seeds'));
+    const found = findStructureContext(record, structureId);
+    if (!found) continue; // structure gone (its draw was deleted) → the delete stands alone
+    const providerId = providerIdOf(records, tournamentId);
+    for (const assignment of found.structure.seedAssignments ?? []) {
+      if (!assignment?.participantId) continue;
+      const ctx = { tournamentId, eventId: found.eventId, drawId: found.drawId, structureId, providerId };
+      const row = seedRow(assignment, ctx);
+      deltas.push(
+        upsert(tournamentId, TABLE_SEEDS, { structure_id: row.structure_id, seed_number: row.seed_number }, row, 'seeds'),
+      );
+    }
+  }
+  return deltas;
+}
+
 function entryDeltas(g: Grouped, records: Record<string, any>): ProjectionDelta[] {
   const deltas: ProjectionDelta[] = [];
   for (const tournamentId of g.participants) {
@@ -337,6 +387,7 @@ function deleteDeltas(g: Grouped, coveredMatchUpIds: Set<string>): ProjectionDel
   }
   for (const { tournamentId, drawId } of g.deleteDraws) {
     deltas.push(del(tournamentId, TABLE_MATCH_UPS, { draw_id: drawId }, 'deleteDraw')); // competitors cascade
+    deltas.push(del(tournamentId, TABLE_SEEDS, { draw_id: drawId }, 'deleteDraw')); // no structures table to cascade from
   }
   // Individual matchUp removals. A matchUp that was ALSO (re)built this cycle is in
   // coveredMatchUpIds — skip it, else the delete (emitted last) would undo the upsert
@@ -349,6 +400,7 @@ function deleteDeltas(g: Grouped, coveredMatchUpIds: Set<string>): ProjectionDel
     deltas.push(del(tournamentId, TABLE_EVENTS, { event_id: eventId }, 'deleteEvent'));
     deltas.push(del(tournamentId, TABLE_MATCH_UPS, { event_id: eventId }, 'deleteEvent'));
     deltas.push(del(tournamentId, TABLE_ENTRIES, { tournament_id: tournamentId, event_id: eventId }, 'deleteEvent'));
+    deltas.push(del(tournamentId, TABLE_SEEDS, { event_id: eventId }, 'deleteEvent'));
   }
   for (const { tournamentId, participantIds } of g.deleteParticipants) {
     for (const participantId of participantIds) {
@@ -380,6 +432,7 @@ export async function buildProjectionDeltas(args: BuildDeltasArgs): Promise<Proj
   return [
     ...tournamentDeltas(g, args.tournamentRecords),
     ...eventDeltas(g, args.tournamentRecords),
+    ...seedDeltas(g, args.tournamentRecords),
     ...venueDeltas(g),
     ...flatten,
     ...resultDeltas(g, args.tournamentRecords, coveredMatchUpIds),

--- a/src/modules/factory/projection/deltaBuffer.spec.ts
+++ b/src/modules/factory/projection/deltaBuffer.spec.ts
@@ -7,6 +7,7 @@ import {
   recordDeleteMatchUps,
   recordEntries,
   recordEvents,
+  recordSeeds,
   recordMatchUpResult,
   recordParticipants,
   recordPersonClaims,
@@ -96,6 +97,19 @@ describe('deltaBuffer recorders', () => {
       recordEvents(undefined, [{ tournamentId: 't-1' }]);
       recordDeleteEvent(undefined, [{ tournamentId: 't-1', eventIds: ['e1'] }]);
     }).not.toThrow();
+  });
+
+  it('recordSeeds records a seeds intent per structure (falls back to sole tournamentId)', () => {
+    const buffer = createDeltaBuffer(['t-1']);
+    recordSeeds(buffer, [{ drawId: 'd1', structureId: 's1' }]); // payload omits tournamentId
+    expect(buffer.intents).toContainEqual({ kind: 'seeds', tournamentId: 't-1', structureId: 's1' });
+  });
+
+  it('recordSeeds skips a notice with no structureId and is a no-op when the buffer is off', () => {
+    const buffer = createDeltaBuffer(['t-1']);
+    recordSeeds(buffer, [{ tournamentId: 't-1' }]);
+    expect(buffer.intents).toHaveLength(0);
+    expect(() => recordSeeds(undefined, [{ tournamentId: 't-1', structureId: 's1' }])).not.toThrow();
   });
 
   it('recordDeleteMatchUps records a deleteMatchUps intent carrying the matchUpIds', () => {

--- a/src/modules/factory/projection/deltaBuffer.ts
+++ b/src/modules/factory/projection/deltaBuffer.ts
@@ -117,6 +117,18 @@ export function recordEntries(buffer: DeltaBuffer | undefined, params: any[]): v
   }
 }
 
+/** MODIFY_SEED_ASSIGNMENTS: `{ tournamentId, eventId, drawId, structureId, seedAssignments }`.
+ *  A structure's seeds changed → re-project the seeds fact for that structure. Keyed
+ *  by structureId so the builder does a delete-by-structure + re-insert (a cleared
+ *  seed must not leave a stale row). */
+export function recordSeeds(buffer: DeltaBuffer | undefined, params: any[]): void {
+  if (!buffer || !Array.isArray(params)) return;
+  for (const item of params) {
+    const tournamentId = tidOf(buffer, item?.tournamentId);
+    if (tournamentId && item?.structureId) push(buffer, { kind: 'seeds', tournamentId, structureId: item.structureId });
+  }
+}
+
 /** ADD_EVENT / MODIFY_EVENT / PUBLISH_EVENT / UNPUBLISH_EVENT: an event was added
  *  or its attributes / publish state changed → re-project the event rows for the
  *  tournament. Payloads vary ({ event, tournamentId } / { eventId, tournamentId } /

--- a/src/modules/factory/projection/projection-conformance.spec.ts
+++ b/src/modules/factory/projection/projection-conformance.spec.ts
@@ -11,6 +11,7 @@ import { ProjectionDelta } from 'src/storage/interfaces/projection-outbox-storag
 const PK: Record<string, string[]> = {
   tournaments: ['tournament_id'],
   events: ['event_id'],
+  seeds: ['structure_id', 'seed_number'],
   match_ups: ['match_up_id'],
   match_up_competitors: ['match_up_id', 'side_number', 'competitor_index'],
   entries: ['tournament_id', 'event_id', 'participant_id'],
@@ -188,7 +189,7 @@ describe('projection conformance — incremental path ≡ rebuild path (byte-ide
   it('CFS rebuild ≡ factory cast() (single source of truth, no divergence)', async () => {
     const { tournamentRecord } = mocksEngine.generateTournamentRecord({
       drawProfiles: [
-        { drawSize: 8, eventName: 'Singles' },
+        { drawSize: 8, seedsCount: 4, eventName: 'Singles' },
         {
           drawSize: 2,
           eventType: factoryConstants.eventConstants.TEAM,
@@ -217,6 +218,7 @@ describe('projection conformance — incremental path ≡ rebuild path (byte-ide
     for (const table of [
       'tournaments',
       'events',
+      'seeds',
       'match_ups',
       'match_up_competitors',
       'entries',
@@ -225,6 +227,7 @@ describe('projection conformance — incremental path ≡ rebuild path (byte-ide
     ]) {
       expect(snapshot(rebuilt, table)).toEqual(castSnapshot(table));
     }
+    expect(castSnapshot('seeds').length).toBeGreaterThan(0); // seedsCount:4 above must produce rows
     expect(castSnapshot('match_ups').length).toBeGreaterThan(0);
     expect(castSnapshot('tournament_venues')).toEqual([{ tournament_id: tournamentId, venue_id: 'v1' }]);
   });

--- a/src/modules/factory/projection/projectionConstants.ts
+++ b/src/modules/factory/projection/projectionConstants.ts
@@ -2,6 +2,7 @@
 // in 001-read-model-tables.sql). row_data keys mirror those column names.
 export const TABLE_TOURNAMENTS = 'tournaments';
 export const TABLE_EVENTS = 'events';
+export const TABLE_SEEDS = 'seeds';
 export const TABLE_MATCH_UPS = 'match_ups';
 export const TABLE_MATCH_UP_COMPETITORS = 'match_up_competitors';
 export const TABLE_ENTRIES = 'entries';

--- a/src/modules/factory/projection/projectionTypes.ts
+++ b/src/modules/factory/projection/projectionTypes.ts
@@ -13,6 +13,7 @@ export type ProjectionIntent =
   | { kind: 'participants'; tournamentId: string }
   | { kind: 'entries'; tournamentId: string }
   | { kind: 'events'; tournamentId: string }
+  | { kind: 'seeds'; tournamentId: string; structureId: string }
   | { kind: 'venue'; tournamentId: string; venue: any }
   | { kind: 'deleteVenue'; tournamentId: string; venueId: string }
   | { kind: 'deleteDraw'; tournamentId: string; drawId: string }

--- a/src/modules/factory/projection/rebuild.ts
+++ b/src/modules/factory/projection/rebuild.ts
@@ -27,6 +27,9 @@ export function buildRebuildIntents(record: any): ProjectionIntent[] {
   for (const event of record?.events ?? []) {
     for (const draw of event?.drawDefinitions ?? []) {
       if (draw?.drawId) intents.push({ kind: 'flattenDraw', tournamentId, drawId: draw.drawId });
+      for (const structure of draw?.structures ?? []) {
+        if (structure?.structureId) intents.push({ kind: 'seeds', tournamentId, structureId: structure.structureId });
+      }
     }
   }
 


### PR DESCRIPTION
## What

Adds a **seeds** dimension to the read model (one row per participant-holding seed assignment), fed by the `MODIFY_SEED_ASSIGNMENTS` topic. Continues "consume all subscriptions / complete the Query model".

> **Stacked on #854** (events) → #853 → #852. Retarget down as the stack merges.
> **Depends on a factory release** exposing `readModel.seedRow` + the seeds `cast()` table (factory master `107f230fe`).

## Change

- `seeds` projection intent (per structureId) + `recordSeeds` recorder.
- `seedDeltas` re-projects **per structure** as **delete-by-structure THEN re-insert** — a seed set can *shrink* (a cleared seed), which an upsert-only refresh would leave stale. The delete precedes its upserts in array/apply order, so on a rebuild (empty table) it is a no-op and the net equals `cast()`. Rows via the factory `readModel.seedRow` builder → byte-identical to a rebuild.
- `deleteDraw` / `deleteEvent` also drop the structure's seeds (no structures table to cascade from; seeds carry `draw_id`/`event_id`).
- Subscribes `MODIFY_SEED_ASSIGNMENTS`; `buildRebuildIntents` emits a seeds intent per structure.

## Test

The **conformance capstone now asserts `seeds`** (seedsCount:4 on the singles draw → non-empty) — CFS rebuild ≡ factory `cast()` across all **8** tables. Factory module suite 203 → 208; projection specs 34 → 39. check-types + lint clean. Additive + flag-gated.

## Companion

courthive-query PR: `query_seeds` migration + tableMeta.