### PR TITLE
feat(projection): project draws + structures read-model tables

### DIFF
--- a/src/modules/factory/engines/getMutationEngine.ts
+++ b/src/modules/factory/engines/getMutationEngine.ts
@@ -9,6 +9,7 @@ import {
   recordDeleteParticipants,
   recordDeleteEventsFromAudit,
   recordDeleteVenue,
+  recordDraw,
   recordEntries,
   recordEvents,
   recordMatchUpResult,
@@ -251,7 +252,11 @@ export function getMutationEngine(services?, publicNotices?: any[], deltaBuffer?
       // topics had no prior CFS subscription; the factory only retains a notice
       // when a subscription exists, so they must be registered to be observed.
       [topicConstants.ADD_MATCHUPS]: (params) => recordAddMatchUps(deltaBuffer, params),
-      [topicConstants.ADD_DRAW_DEFINITION]: (params) => recordAddDraw(deltaBuffer, params),
+      [topicConstants.ADD_DRAW_DEFINITION]: (params) => {
+        recordAddDraw(deltaBuffer, params); // flatten matchUps
+        recordDraw(deltaBuffer, params); // draw + structures rows
+      },
+      [topicConstants.MODIFY_DRAW_DEFINITION]: (params) => recordDraw(deltaBuffer, params),
       [topicConstants.ADD_PARTICIPANTS]: (params) => {
         recordParticipants(deltaBuffer, params);
         recordPersonClaims(deltaBuffer, params, CANONICAL_PERSON);

--- a/src/modules/factory/projection/buildProjectionDeltas.spec.ts
+++ b/src/modules/factory/projection/buildProjectionDeltas.spec.ts
@@ -168,7 +168,57 @@ describe('buildProjectionDeltas', () => {
         topic: 'deleteEvent',
       },
       { tournamentId: 't-1', op: 'delete', table: 'seeds', key: { event_id: 'e1' }, topic: 'deleteEvent' },
+      { tournamentId: 't-1', op: 'delete', table: 'draws', key: { event_id: 'e1' }, topic: 'deleteEvent' },
     ]);
+  });
+
+  it('draw intent → draw upsert THEN delete-by-draw + re-insert of top-level structures', async () => {
+    const records = {
+      't-1': {
+        ...RECORD,
+        events: [
+          {
+            eventId: 'e1',
+            drawDefinitions: [
+              {
+                drawId: 'd1',
+                drawName: 'Main',
+                drawType: 'SINGLE_ELIMINATION',
+                structures: [
+                  { structureId: 's1', stage: 'MAIN' },
+                  { structureId: 's2', stage: 'CONSOLATION' },
+                ],
+              },
+            ],
+          },
+        ],
+      },
+    };
+    const deltas = await buildProjectionDeltas({
+      intents: [{ kind: 'draw', tournamentId: 't-1', drawId: 'd1' }],
+      tournamentRecords: records,
+      flattenDraw: jest.fn(),
+    });
+    const drawOps = deltas.filter((d) => d.table === 'draws');
+    const structOps = deltas.filter((d) => d.table === 'structures');
+    expect(drawOps).toHaveLength(1);
+    expect(drawOps[0]).toMatchObject({ op: 'upsert', key: { draw_id: 'd1' }, row: { draw_name: 'Main', draw_type: 'SINGLE_ELIMINATION' } });
+    // delete-by-draw first, then the two structure upserts (order matters)
+    expect(structOps[0]).toMatchObject({ op: 'delete', key: { draw_id: 'd1' } });
+    expect(structOps.slice(1).map((d) => d.key)).toEqual([{ structure_id: 's1' }, { structure_id: 's2' }]);
+    // draw upserted before structures (FK parent)
+    expect(deltas.findIndex((d) => d.table === 'draws')).toBeLessThan(deltas.findIndex((d) => d.table === 'structures'));
+  });
+
+  it('deleteDraw also deletes the draw row (structures cascade via the draws FK)', async () => {
+    const deltas = await build([{ kind: 'deleteDraw', tournamentId: 't-1', drawId: 'd1' }]);
+    expect(deltas).toContainEqual({
+      tournamentId: 't-1',
+      op: 'delete',
+      table: 'draws',
+      key: { draw_id: 'd1' },
+      topic: 'deleteDraw',
+    });
   });
 
   it('seeds intent → delete-by-structure THEN one upsert per participant-holding assignment', async () => {

--- a/src/modules/factory/projection/buildProjectionDeltas.ts
+++ b/src/modules/factory/projection/buildProjectionDeltas.ts
@@ -6,6 +6,8 @@ import { ProjectionIntent } from './projectionTypes';
 import {
   TABLE_TOURNAMENTS,
   TABLE_EVENTS,
+  TABLE_DRAWS,
+  TABLE_STRUCTURES,
   TABLE_SEEDS,
   TABLE_MATCH_UPS,
   TABLE_MATCH_UP_COMPETITORS,
@@ -21,6 +23,8 @@ import {
 const {
   entryRows,
   eventRow,
+  drawRow,
+  structureRow,
   seedRow,
   matchUpResultRow,
   matchUpRowSet,
@@ -46,6 +50,7 @@ interface Grouped {
   touched: Set<string>; // tournamentIds needing a tournaments upsert
   participants: Set<string>; // tournamentIds needing an entries refresh
   events: Set<string>; // tournamentIds needing an events refresh
+  draws: Map<string, string>; // drawId → tournamentId (draw + its structures re-project)
   seeds: Map<string, string>; // structureId → tournamentId (seeds re-project per structure)
   matchUpResults: Map<string, { tournamentId: string; matchUp: any }>; // matchUpId → latest
   venues: Map<string, { tournamentId: string; venue: any }>; // venueId → venue
@@ -67,6 +72,7 @@ function group(intents: ProjectionIntent[], records: Record<string, any>): Group
     touched: new Set(),
     participants: new Set(),
     events: new Set(),
+    draws: new Map(),
     seeds: new Map(),
     matchUpResults: new Map(),
     venues: new Map(),
@@ -107,6 +113,9 @@ function group(intents: ProjectionIntent[], records: Record<string, any>): Group
         break;
       case 'events':
         g.events.add(intent.tournamentId);
+        break;
+      case 'draw':
+        g.draws.set(intent.drawId, intent.tournamentId);
         break;
       case 'seeds':
         g.seeds.set(intent.structureId, intent.tournamentId);
@@ -317,6 +326,41 @@ function findStructureContext(
   return undefined;
 }
 
+// Locate a draw + its owning event in the final record (a draw intent carries only drawId).
+function findDrawContext(record: any, drawId: string): { eventId: string; draw: any } | undefined {
+  for (const event of record?.events ?? []) {
+    for (const draw of event.drawDefinitions ?? []) {
+      if (draw?.drawId === drawId) return { eventId: event.eventId, draw };
+    }
+  }
+  return undefined;
+}
+
+// Per draw: upsert the draw row, then delete-by-draw + re-insert its top-level
+// structures (a structure can be added/removed within a draw). The draw upsert
+// precedes its structures (structures FK → draws), and the structures delete
+// precedes their re-inserts (array = apply order).
+function drawDeltas(g: Grouped, records: Record<string, any>): ProjectionDelta[] {
+  const deltas: ProjectionDelta[] = [];
+  for (const [drawId, tournamentId] of g.draws) {
+    const record = records?.[tournamentId];
+    if (!record) continue;
+    const found = findDrawContext(record, drawId);
+    if (!found) continue; // draw gone (deleted) → its delete deltas handle removal
+    const providerId = providerIdOf(records, tournamentId);
+    const drawRowData = drawRow(found.draw, tournamentId, found.eventId, providerId);
+    deltas.push(upsert(tournamentId, TABLE_DRAWS, { draw_id: drawId }, drawRowData, 'draw'));
+    deltas.push(del(tournamentId, TABLE_STRUCTURES, { draw_id: drawId }, 'draw'));
+    for (const structure of found.draw.structures ?? []) {
+      if (!structure?.structureId) continue;
+      const sctx = { tournamentId, eventId: found.eventId, drawId, providerId };
+      const row = structureRow(structure, sctx);
+      deltas.push(upsert(tournamentId, TABLE_STRUCTURES, { structure_id: row.structure_id }, row, 'draw'));
+    }
+  }
+  return deltas;
+}
+
 // Seeds re-project PER STRUCTURE as delete-by-structure THEN re-insert: a seed set
 // can SHRINK (a cleared seed), which an upsert-only refresh would leave stale. The
 // delete is emitted before its upserts (array order = apply order), so on a rebuild
@@ -387,7 +431,8 @@ function deleteDeltas(g: Grouped, coveredMatchUpIds: Set<string>): ProjectionDel
   }
   for (const { tournamentId, drawId } of g.deleteDraws) {
     deltas.push(del(tournamentId, TABLE_MATCH_UPS, { draw_id: drawId }, 'deleteDraw')); // competitors cascade
-    deltas.push(del(tournamentId, TABLE_SEEDS, { draw_id: drawId }, 'deleteDraw')); // no structures table to cascade from
+    deltas.push(del(tournamentId, TABLE_SEEDS, { draw_id: drawId }, 'deleteDraw')); // seeds don't FK a structures table
+    deltas.push(del(tournamentId, TABLE_DRAWS, { draw_id: drawId }, 'deleteDraw')); // structures cascade via draws FK
   }
   // Individual matchUp removals. A matchUp that was ALSO (re)built this cycle is in
   // coveredMatchUpIds — skip it, else the delete (emitted last) would undo the upsert
@@ -401,6 +446,7 @@ function deleteDeltas(g: Grouped, coveredMatchUpIds: Set<string>): ProjectionDel
     deltas.push(del(tournamentId, TABLE_MATCH_UPS, { event_id: eventId }, 'deleteEvent'));
     deltas.push(del(tournamentId, TABLE_ENTRIES, { tournament_id: tournamentId, event_id: eventId }, 'deleteEvent'));
     deltas.push(del(tournamentId, TABLE_SEEDS, { event_id: eventId }, 'deleteEvent'));
+    deltas.push(del(tournamentId, TABLE_DRAWS, { event_id: eventId }, 'deleteEvent')); // structures cascade via draws FK
   }
   for (const { tournamentId, participantIds } of g.deleteParticipants) {
     for (const participantId of participantIds) {
@@ -432,6 +478,7 @@ export async function buildProjectionDeltas(args: BuildDeltasArgs): Promise<Proj
   return [
     ...tournamentDeltas(g, args.tournamentRecords),
     ...eventDeltas(g, args.tournamentRecords),
+    ...drawDeltas(g, args.tournamentRecords),
     ...seedDeltas(g, args.tournamentRecords),
     ...venueDeltas(g),
     ...flatten,

--- a/src/modules/factory/projection/deltaBuffer.spec.ts
+++ b/src/modules/factory/projection/deltaBuffer.spec.ts
@@ -4,6 +4,7 @@ import {
   recordAddMatchUps,
   recordDeleteDraw,
   recordDeleteEvent,
+  recordDraw,
   recordDeleteMatchUps,
   recordEntries,
   recordEvents,
@@ -97,6 +98,13 @@ describe('deltaBuffer recorders', () => {
       recordEvents(undefined, [{ tournamentId: 't-1' }]);
       recordDeleteEvent(undefined, [{ tournamentId: 't-1', eventIds: ['e1'] }]);
     }).not.toThrow();
+  });
+
+  it('recordDraw records a draw intent from drawDefinition.drawId (falls back to sole tournamentId)', () => {
+    const buffer = createDeltaBuffer(['t-1']);
+    recordDraw(buffer, [{ drawDefinition: { drawId: 'd1' } }]); // payload omits tournamentId
+    expect(buffer.intents).toContainEqual({ kind: 'draw', tournamentId: 't-1', drawId: 'd1' });
+    expect(() => recordDraw(undefined, [{ drawDefinition: { drawId: 'd1' } }])).not.toThrow();
   });
 
   it('recordSeeds records a seeds intent per structure (falls back to sole tournamentId)', () => {

--- a/src/modules/factory/projection/deltaBuffer.ts
+++ b/src/modules/factory/projection/deltaBuffer.ts
@@ -117,6 +117,19 @@ export function recordEntries(buffer: DeltaBuffer | undefined, params: any[]): v
   }
 }
 
+/** ADD_DRAW_DEFINITION `{ drawDefinition, tournamentId, eventId }` / MODIFY_DRAW_DEFINITION
+ *  `{ tournamentId, eventId, drawDefinition }`. Re-project the draw + its top-level
+ *  structures. (ADD_DRAW_DEFINITION also flattens matchUps via recordAddDraw — this is
+ *  additive.) */
+export function recordDraw(buffer: DeltaBuffer | undefined, params: any[]): void {
+  if (!buffer || !Array.isArray(params)) return;
+  for (const item of params) {
+    const tournamentId = tidOf(buffer, item?.tournamentId);
+    const drawId = item?.drawDefinition?.drawId ?? item?.drawId;
+    if (tournamentId && drawId) push(buffer, { kind: 'draw', tournamentId, drawId });
+  }
+}
+
 /** MODIFY_SEED_ASSIGNMENTS: `{ tournamentId, eventId, drawId, structureId, seedAssignments }`.
  *  A structure's seeds changed → re-project the seeds fact for that structure. Keyed
  *  by structureId so the builder does a delete-by-structure + re-insert (a cleared

--- a/src/modules/factory/projection/projection-conformance.spec.ts
+++ b/src/modules/factory/projection/projection-conformance.spec.ts
@@ -11,6 +11,8 @@ import { ProjectionDelta } from 'src/storage/interfaces/projection-outbox-storag
 const PK: Record<string, string[]> = {
   tournaments: ['tournament_id'],
   events: ['event_id'],
+  draws: ['draw_id'],
+  structures: ['structure_id'],
   seeds: ['structure_id', 'seed_number'],
   match_ups: ['match_up_id'],
   match_up_competitors: ['match_up_id', 'side_number', 'competitor_index'],
@@ -218,6 +220,8 @@ describe('projection conformance — incremental path ≡ rebuild path (byte-ide
     for (const table of [
       'tournaments',
       'events',
+      'draws',
+      'structures',
       'seeds',
       'match_ups',
       'match_up_competitors',
@@ -228,6 +232,8 @@ describe('projection conformance — incremental path ≡ rebuild path (byte-ide
       expect(snapshot(rebuilt, table)).toEqual(castSnapshot(table));
     }
     expect(castSnapshot('seeds').length).toBeGreaterThan(0); // seedsCount:4 above must produce rows
+    expect(castSnapshot('draws').length).toBeGreaterThan(0);
+    expect(castSnapshot('structures').length).toBeGreaterThan(0);
     expect(castSnapshot('match_ups').length).toBeGreaterThan(0);
     expect(castSnapshot('tournament_venues')).toEqual([{ tournament_id: tournamentId, venue_id: 'v1' }]);
   });

--- a/src/modules/factory/projection/projectionConstants.ts
+++ b/src/modules/factory/projection/projectionConstants.ts
@@ -2,6 +2,8 @@
 // in 001-read-model-tables.sql). row_data keys mirror those column names.
 export const TABLE_TOURNAMENTS = 'tournaments';
 export const TABLE_EVENTS = 'events';
+export const TABLE_DRAWS = 'draws';
+export const TABLE_STRUCTURES = 'structures';
 export const TABLE_SEEDS = 'seeds';
 export const TABLE_MATCH_UPS = 'match_ups';
 export const TABLE_MATCH_UP_COMPETITORS = 'match_up_competitors';

--- a/src/modules/factory/projection/projectionTypes.ts
+++ b/src/modules/factory/projection/projectionTypes.ts
@@ -13,6 +13,7 @@ export type ProjectionIntent =
   | { kind: 'participants'; tournamentId: string }
   | { kind: 'entries'; tournamentId: string }
   | { kind: 'events'; tournamentId: string }
+  | { kind: 'draw'; tournamentId: string; drawId: string }
   | { kind: 'seeds'; tournamentId: string; structureId: string }
   | { kind: 'venue'; tournamentId: string; venue: any }
   | { kind: 'deleteVenue'; tournamentId: string; venueId: string }

--- a/src/modules/factory/projection/rebuild.ts
+++ b/src/modules/factory/projection/rebuild.ts
@@ -26,7 +26,10 @@ export function buildRebuildIntents(record: any): ProjectionIntent[] {
 
   for (const event of record?.events ?? []) {
     for (const draw of event?.drawDefinitions ?? []) {
-      if (draw?.drawId) intents.push({ kind: 'flattenDraw', tournamentId, drawId: draw.drawId });
+      if (draw?.drawId) {
+        intents.push({ kind: 'flattenDraw', tournamentId, drawId: draw.drawId });
+        intents.push({ kind: 'draw', tournamentId, drawId: draw.drawId });
+      }
       for (const structure of draw?.structures ?? []) {
         if (structure?.structureId) intents.push({ kind: 'seeds', tournamentId, structureId: structure.structureId });
       }


### PR DESCRIPTION
## What

Adds **draws** + **structures** dimensions (one row/draw, one row/top-level structure), fed by `ADD_DRAW_DEFINITION` / `MODIFY_DRAW_DEFINITION`. Completes the core "complete the Query model" set.

> **Stacked on #855** (seeds) → #854 → #853 → #852. **Depends on a factory release** exposing `readModel.drawRow` / `structureRow` + the draws/structures `cast()` tables (factory master `5c6e9ad53`).

## Change

- `draw` projection intent (per drawId) + `recordDraw` recorder.
- `drawDeltas`: upsert the draw row, then **delete-by-draw + re-insert** its top-level structures (a structure can be added/removed within a draw). Draw upsert precedes structures (FK); structures delete precedes their re-inserts. Rows via the factory `readModel.drawRow` / `structureRow` builders → byte-identical to a rebuild.
- `deleteDraw` / `deleteEvent` drop the draw row; **structures cascade via the draws FK**.
- `ADD_DRAW_DEFINITION` now records both the flatten (matchUps) and the draw rows; subscribes `MODIFY_DRAW_DEFINITION`; `buildRebuildIntents` emits a draw intent per draw.

## Test

The **conformance capstone now asserts `draws` + `structures`** — CFS rebuild ≡ factory `cast()` across all **10** tables. Factory module suite 208 → 211; projection specs 39 → 42. check-types + lint clean. Additive + flag-gated.

Nested RR-group sub-structures are not projected (known limitation shared with the seeds table; playoff/qualifying structures are top-level and covered).

## Companion

courthive-query PR: `query_draws` + `query_structures` migration + tableMeta.