### PR TITLE
feat(projection): project a courts read-model table under venues

### DIFF
--- a/src/modules/factory/projection/buildProjectionDeltas.spec.ts
+++ b/src/modules/factory/projection/buildProjectionDeltas.spec.ts
@@ -84,11 +84,30 @@ describe('buildProjectionDeltas', () => {
     expect(deltas.find((d) => d.table === 'match_ups')?.topic).toBe('flattenDraw');
   });
 
-  it('venue → venues + tournament_venues upserts', async () => {
-    const deltas = await build([{ kind: 'venue', tournamentId: 't-1', venue: { venueId: 'v1', venueName: 'Center' } }]);
+  it('venue → venues + tournament_venues upserts, plus delete-by-venue + re-insert of courts', async () => {
+    const deltas = await build([
+      {
+        kind: 'venue',
+        tournamentId: 't-1',
+        venue: {
+          venueId: 'v1',
+          venueName: 'Center',
+          courts: [
+            { courtId: 'c1', courtName: 'Court 1', indoorOutdoor: 'INDOOR' },
+            { courtId: 'c2', courtName: 'Court 2' },
+          ],
+        },
+      },
+    ]);
     const tables = deltas.map((d) => `${d.op}:${d.table}`);
     expect(tables).toContain('upsert:venues');
     expect(tables).toContain('upsert:tournament_venues');
+    const courtOps = deltas.filter((d) => d.table === 'courts');
+    expect(courtOps[0]).toMatchObject({ op: 'delete', key: { venue_id: 'v1' } });
+    expect(courtOps.slice(1).map((d) => d.key)).toEqual([{ court_id: 'c1' }, { court_id: 'c2' }]);
+    expect(courtOps[1].row).toMatchObject({ venue_id: 'v1', court_name: 'Court 1', indoor_outdoor: 'INDOOR' });
+    // venue upserted before courts (FK parent)
+    expect(deltas.findIndex((d) => d.table === 'venues')).toBeLessThan(deltas.findIndex((d) => d.table === 'courts'));
   });
 
   it('delete intents → delete deltas with WHERE-clause keys', async () => {

--- a/src/modules/factory/projection/buildProjectionDeltas.ts
+++ b/src/modules/factory/projection/buildProjectionDeltas.ts
@@ -13,6 +13,7 @@ import {
   TABLE_MATCH_UP_COMPETITORS,
   TABLE_ENTRIES,
   TABLE_VENUES,
+  TABLE_COURTS,
   TABLE_TOURNAMENT_VENUES,
   LINK_CANONICAL,
 } from './projectionConstants';
@@ -30,6 +31,7 @@ const {
   matchUpRowSet,
   tournamentRow,
   venueRow,
+  courtRow,
   resolveMatchUpPublishState,
   getEventPublishStatus,
 } = readModel;
@@ -404,7 +406,7 @@ function entryDeltas(g: Grouped, records: Record<string, any>): ProjectionDelta[
   return deltas;
 }
 
-function venueDeltas(g: Grouped): ProjectionDelta[] {
+function venueDeltas(g: Grouped, records: Record<string, any>): ProjectionDelta[] {
   const deltas: ProjectionDelta[] = [];
   for (const { tournamentId, venue } of g.venues.values()) {
     const row = venueRow(venue);
@@ -418,6 +420,15 @@ function venueDeltas(g: Grouped): ProjectionDelta[] {
         'venue',
       ),
     );
+    // courts nest under the venue: delete-by-venue + re-insert (a court can be
+    // added/removed within a venue). The venue upsert precedes them (courts FK → venues).
+    const providerId = providerIdOf(records, tournamentId);
+    deltas.push(del(tournamentId, TABLE_COURTS, { venue_id: row.venue_id }, 'venue'));
+    for (const court of venue.courts ?? []) {
+      if (!court?.courtId) continue;
+      const courtRowData = courtRow(court, { venueId: row.venue_id, tournamentId, providerId });
+      deltas.push(upsert(tournamentId, TABLE_COURTS, { court_id: courtRowData.court_id }, courtRowData, 'venue'));
+    }
   }
   return deltas;
 }
@@ -480,7 +491,7 @@ export async function buildProjectionDeltas(args: BuildDeltasArgs): Promise<Proj
     ...eventDeltas(g, args.tournamentRecords),
     ...drawDeltas(g, args.tournamentRecords),
     ...seedDeltas(g, args.tournamentRecords),
-    ...venueDeltas(g),
+    ...venueDeltas(g, args.tournamentRecords),
     ...flatten,
     ...resultDeltas(g, args.tournamentRecords, coveredMatchUpIds),
     ...entryDeltas(g, args.tournamentRecords),

--- a/src/modules/factory/projection/projection-conformance.spec.ts
+++ b/src/modules/factory/projection/projection-conformance.spec.ts
@@ -18,6 +18,7 @@ const PK: Record<string, string[]> = {
   match_up_competitors: ['match_up_id', 'side_number', 'competitor_index'],
   entries: ['tournament_id', 'event_id', 'participant_id'],
   venues: ['venue_id'],
+  courts: ['court_id'],
   tournament_venues: ['tournament_id', 'venue_id'],
 };
 
@@ -227,6 +228,7 @@ describe('projection conformance — incremental path ≡ rebuild path (byte-ide
       'match_up_competitors',
       'entries',
       'venues',
+      'courts',
       'tournament_venues',
     ]) {
       expect(snapshot(rebuilt, table)).toEqual(castSnapshot(table));
@@ -234,6 +236,7 @@ describe('projection conformance — incremental path ≡ rebuild path (byte-ide
     expect(castSnapshot('seeds').length).toBeGreaterThan(0); // seedsCount:4 above must produce rows
     expect(castSnapshot('draws').length).toBeGreaterThan(0);
     expect(castSnapshot('structures').length).toBeGreaterThan(0);
+    expect(castSnapshot('courts').length).toBeGreaterThan(0); // venueProfiles courtsCount:4 above
     expect(castSnapshot('match_ups').length).toBeGreaterThan(0);
     expect(castSnapshot('tournament_venues')).toEqual([{ tournament_id: tournamentId, venue_id: 'v1' }]);
   });

--- a/src/modules/factory/projection/projectionConstants.ts
+++ b/src/modules/factory/projection/projectionConstants.ts
@@ -9,6 +9,7 @@ export const TABLE_MATCH_UPS = 'match_ups';
 export const TABLE_MATCH_UP_COMPETITORS = 'match_up_competitors';
 export const TABLE_ENTRIES = 'entries';
 export const TABLE_VENUES = 'venues';
+export const TABLE_COURTS = 'courts';
 export const TABLE_TOURNAMENT_VENUES = 'tournament_venues';
 
 // match_up_competitors.link_source


### PR DESCRIPTION
## What

Adds a **courts** dimension (one row/court of a placed venue), fed by the existing venue projection.

> **Stacked on #856** (draws/structures) → #855 → #854 → #853 → #852. **Depends on a factory release** exposing `readModel.courtRow` + the courts `cast()` table (factory master `e891ccec4`).

## Change

- `venueDeltas` now also projects courts per venue: **delete-by-venue + re-insert** (a court can be added/removed within a venue). The venue upsert precedes courts (courts FK → venues). Rows via the factory `readModel.courtRow` builder → byte-identical to a rebuild. **No new intent** — `recordVenue` already fires on `ADD_VENUE` / `MODIFY_VENUE`.

## Test

The **conformance capstone now asserts `courts`** (venueProfiles `courtsCount:4`) — CFS rebuild ≡ factory `cast()` across all **11** tables. Factory module suite green (211). Additive + flag-gated.

## Companion

courthive-query PR: `query_courts` migration + tableMeta.