### PR TITLE
feat(projection): project participant-publish + tournaments.published

### DIFF
--- a/src/modules/factory/engines/getMutationEngine.ts
+++ b/src/modules/factory/engines/getMutationEngine.ts
@@ -13,6 +13,7 @@ import {
   recordEntries,
   recordEvents,
   recordOrderOfPlay,
+  recordParticipantPublish,
   recordSchedulingProfile,
   recordMatchUpResult,
   recordParticipants,
@@ -155,6 +156,7 @@ export function getMutationEngine(services?, publicNotices?: any[], deltaBuffer?
             services?.cacheManager?.del(key);
           }
           clearCache(item.tournamentId);
+          recordTouchTournament(deltaBuffer, item.tournamentId); // refresh tournaments.published
           publicNotices?.push({
             topic: topicConstants.UNPUBLISH_ORDER_OF_PLAY,
             tournamentId: item.tournamentId,
@@ -165,6 +167,7 @@ export function getMutationEngine(services?, publicNotices?: any[], deltaBuffer?
         recordOrderOfPlay(deltaBuffer, params); // order-of-play publication state
         for (const item of params) {
           clearCache(item.tournamentId);
+          recordTouchTournament(deltaBuffer, item.tournamentId); // refresh tournaments.published
           publicNotices?.push({
             topic: topicConstants.PUBLISH_ORDER_OF_PLAY,
             tournamentId: item.tournamentId,
@@ -172,8 +175,10 @@ export function getMutationEngine(services?, publicNotices?: any[], deltaBuffer?
         }
       },
       [topicConstants.PUBLISH_PARTICIPANTS]: (params) => {
+        recordParticipantPublish(deltaBuffer, params); // participant-list publish state
         for (const item of params) {
           clearCache(item.tournamentId);
+          recordTouchTournament(deltaBuffer, item.tournamentId); // refresh tournaments.published
           publicNotices?.push({
             topic: topicConstants.PUBLISH_PARTICIPANTS,
             tournamentId: item.tournamentId,
@@ -181,17 +186,22 @@ export function getMutationEngine(services?, publicNotices?: any[], deltaBuffer?
         }
       },
       [topicConstants.UNPUBLISH_PARTICIPANTS]: (params) => {
+        recordParticipantPublish(deltaBuffer, params);
         for (const item of params) {
           clearCache(item.tournamentId);
+          recordTouchTournament(deltaBuffer, item.tournamentId);
           publicNotices?.push({
             topic: topicConstants.UNPUBLISH_PARTICIPANTS,
             tournamentId: item.tournamentId,
           });
         }
       },
+      // the tournament went dark (neither order-of-play nor participants published)
+      // → refresh the aggregate tournaments.published flag.
       [topicConstants.UNPUBLISH_TOURNAMENT]: (params) => {
         for (const item of params) {
           clearCache(item.tournamentId);
+          recordTouchTournament(deltaBuffer, item.tournamentId);
         }
       },
       [topicConstants.AUDIT]: (params) => {

--- a/src/modules/factory/projection/buildProjectionDeltas.spec.ts
+++ b/src/modules/factory/projection/buildProjectionDeltas.spec.ts
@@ -361,6 +361,28 @@ describe('buildProjectionDeltas', () => {
     expect(down.find((d) => d.table === 'order_of_play')).toMatchObject({ op: 'delete', key: { tournament_id: 't-1' } });
   });
 
+  it('participantPublish intent → upsert when published, delete when not', async () => {
+    const published = {
+      't-1': {
+        ...RECORD,
+        timeItems: [{ itemType: 'PUBLISH.STATUS', itemValue: { PUBLIC: { participants: { published: true, embargo: '2025-01-04' } } } }],
+      },
+    };
+    const up = await buildProjectionDeltas({
+      intents: [{ kind: 'participantPublish', tournamentId: 't-1' }],
+      tournamentRecords: published,
+      flattenDraw: jest.fn(),
+    });
+    expect(up.find((d) => d.table === 'participant_publish')).toMatchObject({
+      op: 'upsert',
+      key: { tournament_id: 't-1' },
+      row: { published: true, embargo: '2025-01-04' },
+    });
+
+    const down = await build([{ kind: 'participantPublish', tournamentId: 't-1' }]);
+    expect(down.find((d) => d.table === 'participant_publish')).toMatchObject({ op: 'delete', key: { tournament_id: 't-1' } });
+  });
+
   it('schedulingProfile intent → delete-by-tournament THEN one upsert per (date, venue, round)', async () => {
     const profile = [
       { scheduleDate: '2025-01-05', venues: [{ venueId: 'v1', rounds: [{ drawId: 'd1', roundNumber: 1 }, { drawId: 'd1', roundNumber: 2 }] }] },

--- a/src/modules/factory/projection/buildProjectionDeltas.ts
+++ b/src/modules/factory/projection/buildProjectionDeltas.ts
@@ -16,6 +16,7 @@ import {
   TABLE_COURTS,
   TABLE_ORDER_OF_PLAY,
   TABLE_SCHEDULING_PROFILE,
+  TABLE_PARTICIPANT_PUBLISH,
   TABLE_TOURNAMENT_VENUES,
   LINK_CANONICAL,
 } from './projectionConstants';
@@ -36,6 +37,7 @@ const {
   courtRow,
   orderOfPlayRow,
   schedulingProfileRows,
+  participantPublishRow,
   resolveMatchUpPublishState,
   getEventPublishStatus,
   getTournamentPublishStatus,
@@ -61,6 +63,7 @@ interface Grouped {
   seeds: Map<string, string>; // structureId → tournamentId (seeds re-project per structure)
   orderOfPlay: Set<string>; // tournamentIds needing an order-of-play publish-state refresh
   schedulingProfiles: Map<string, any[]>; // tournamentId → the scheduling plan to re-project
+  participantPublish: Set<string>; // tournamentIds needing a participant-list publish-state refresh
   matchUpResults: Map<string, { tournamentId: string; matchUp: any }>; // matchUpId → latest
   venues: Map<string, { tournamentId: string; venue: any }>; // venueId → venue
   deleteVenues: { tournamentId: string; venueId: string }[];
@@ -85,6 +88,7 @@ function group(intents: ProjectionIntent[], records: Record<string, any>): Group
     seeds: new Map(),
     orderOfPlay: new Set(),
     schedulingProfiles: new Map(),
+    participantPublish: new Set(),
     matchUpResults: new Map(),
     venues: new Map(),
     deleteVenues: [],
@@ -136,6 +140,9 @@ function group(intents: ProjectionIntent[], records: Record<string, any>): Group
         break;
       case 'schedulingProfile':
         g.schedulingProfiles.set(intent.tournamentId, intent.schedulingProfile);
+        break;
+      case 'participantPublish':
+        g.participantPublish.add(intent.tournamentId);
         break;
       case 'venue':
         g.venues.set(intent.venue.venueId, { tournamentId: intent.tournamentId, venue: intent.venue });
@@ -421,6 +428,24 @@ function orderOfPlayDeltas(g: Grouped, records: Record<string, any>): Projection
   return deltas;
 }
 
+// Participant-list PUBLICATION state: one row when published, resolved from the final
+// record; an unpublish deletes the row (mirrors orderOfPlayDeltas).
+function participantPublishDeltas(g: Grouped, records: Record<string, any>): ProjectionDelta[] {
+  const deltas: ProjectionDelta[] = [];
+  for (const tournamentId of g.participantPublish) {
+    const record = records?.[tournamentId];
+    if (!record) continue;
+    const participants = getTournamentPublishStatus({ tournamentRecord: record })?.participants;
+    if (participants?.published) {
+      const row = participantPublishRow(tournamentId, participants);
+      deltas.push(upsert(tournamentId, TABLE_PARTICIPANT_PUBLISH, { tournament_id: tournamentId }, row, 'participantPublish'));
+    } else {
+      deltas.push(del(tournamentId, TABLE_PARTICIPANT_PUBLISH, { tournament_id: tournamentId }, 'participantPublish'));
+    }
+  }
+  return deltas;
+}
+
 // The scheduling PLAN: delete-by-tournament + re-insert the flattened rows (the plan
 // can shrink). Projected from the intent's profile (byte-identical to cast, which reads
 // the same stored profile).
@@ -553,6 +578,7 @@ export async function buildProjectionDeltas(args: BuildDeltasArgs): Promise<Proj
     ...seedDeltas(g, args.tournamentRecords),
     ...orderOfPlayDeltas(g, args.tournamentRecords),
     ...schedulingProfileDeltas(g),
+    ...participantPublishDeltas(g, args.tournamentRecords),
     ...venueDeltas(g, args.tournamentRecords),
     ...flatten,
     ...resultDeltas(g, args.tournamentRecords, coveredMatchUpIds),

--- a/src/modules/factory/projection/deltaBuffer.spec.ts
+++ b/src/modules/factory/projection/deltaBuffer.spec.ts
@@ -9,6 +9,7 @@ import {
   recordEntries,
   recordEvents,
   recordOrderOfPlay,
+  recordParticipantPublish,
   recordSchedulingProfile,
   recordSeeds,
   recordMatchUpResult,
@@ -114,6 +115,15 @@ describe('deltaBuffer recorders', () => {
     recordOrderOfPlay(buffer, [{ tournamentId: 't-1', scheduledDates: ['2025-01-05'] }, { tournamentId: 't-1' }]);
     expect(buffer.intents.filter((i) => i.kind === 'orderOfPlay')).toEqual([{ kind: 'orderOfPlay', tournamentId: 't-1' }]);
     expect(() => recordOrderOfPlay(undefined, [{ tournamentId: 't-1' }])).not.toThrow();
+  });
+
+  it('recordParticipantPublish records one participantPublish intent per tournament (deduped)', () => {
+    const buffer = createDeltaBuffer(['t-1']);
+    recordParticipantPublish(buffer, [{ tournamentId: 't-1' }, { tournamentId: 't-1' }]);
+    expect(buffer.intents.filter((i) => i.kind === 'participantPublish')).toEqual([
+      { kind: 'participantPublish', tournamentId: 't-1' },
+    ]);
+    expect(() => recordParticipantPublish(undefined, [{ tournamentId: 't-1' }])).not.toThrow();
   });
 
   it('recordSchedulingProfile carries the profile in the intent', () => {

--- a/src/modules/factory/projection/deltaBuffer.ts
+++ b/src/modules/factory/projection/deltaBuffer.ts
@@ -145,6 +145,20 @@ export function recordOrderOfPlay(buffer: DeltaBuffer | undefined, params: any[]
   }
 }
 
+/** PUBLISH_PARTICIPANTS / UNPUBLISH_PARTICIPANTS: `{ tournamentId }`. Re-project the
+ *  participant-list publication state (published → upsert; unpublished → delete). */
+export function recordParticipantPublish(buffer: DeltaBuffer | undefined, params: any[]): void {
+  if (!buffer || !Array.isArray(params)) return;
+  const seen = new Set<string>();
+  for (const item of params) {
+    const tournamentId = tidOf(buffer, item?.tournamentId);
+    if (tournamentId && !seen.has(tournamentId)) {
+      seen.add(tournamentId);
+      push(buffer, { kind: 'participantPublish', tournamentId });
+    }
+  }
+}
+
 /** MODIFY_SCHEDULING_PROFILE: `{ tournamentId, schedulingProfile }`. Carry the profile in
  *  the intent so the flat plan is projected from exactly what was set (delete-by-tournament
  *  + re-insert; the plan can shrink). */

--- a/src/modules/factory/projection/projection-conformance.spec.ts
+++ b/src/modules/factory/projection/projection-conformance.spec.ts
@@ -21,6 +21,7 @@ const PK: Record<string, string[]> = {
   courts: ['court_id'],
   order_of_play: ['tournament_id'],
   scheduling_profile: ['tournament_id', 'schedule_date', 'venue_id', 'round_order'],
+  participant_publish: ['tournament_id'],
   tournament_venues: ['tournament_id', 'venue_id'],
 };
 
@@ -209,7 +210,10 @@ describe('projection conformance — incremental path ≡ rebuild path (byte-ide
     // publish the order of play + set a scheduling plan so both schedule tables are exercised
     const draw = tournamentRecord.events[0].drawDefinitions[0];
     tournamentRecord.timeItems = [
-      { itemType: 'PUBLISH.STATUS', itemValue: { PUBLIC: { orderOfPlay: { published: true, scheduledDates: ['2025-01-05'] } } } },
+      {
+        itemType: 'PUBLISH.STATUS',
+        itemValue: { PUBLIC: { orderOfPlay: { published: true, scheduledDates: ['2025-01-05'] }, participants: { published: true } } },
+      },
     ];
     tournamentRecord.scheduling = {
       profile: [
@@ -253,6 +257,7 @@ describe('projection conformance — incremental path ≡ rebuild path (byte-ide
       'courts',
       'order_of_play',
       'scheduling_profile',
+      'participant_publish',
       'tournament_venues',
     ]) {
       expect(snapshot(rebuilt, table)).toEqual(castSnapshot(table));
@@ -261,6 +266,8 @@ describe('projection conformance — incremental path ≡ rebuild path (byte-ide
     expect(castSnapshot('draws').length).toBeGreaterThan(0);
     expect(castSnapshot('structures').length).toBeGreaterThan(0);
     expect(castSnapshot('courts').length).toBeGreaterThan(0); // venueProfiles courtsCount:4 above
+    expect(castSnapshot('participant_publish')).toEqual([{ tournament_id: tournamentId, published: true, embargo: null }]);
+    expect(castSnapshot('tournaments')[0].published).toBe(true); // OoP + participants published above
     expect(castSnapshot('order_of_play')).toEqual([
       { tournament_id: tournamentId, published: true, scheduled_dates: ['2025-01-05'], event_ids: null, embargo: null },
     ]);

--- a/src/modules/factory/projection/projectionConstants.ts
+++ b/src/modules/factory/projection/projectionConstants.ts
@@ -7,6 +7,7 @@ export const TABLE_STRUCTURES = 'structures';
 export const TABLE_SEEDS = 'seeds';
 export const TABLE_ORDER_OF_PLAY = 'order_of_play';
 export const TABLE_SCHEDULING_PROFILE = 'scheduling_profile';
+export const TABLE_PARTICIPANT_PUBLISH = 'participant_publish';
 export const TABLE_MATCH_UPS = 'match_ups';
 export const TABLE_MATCH_UP_COMPETITORS = 'match_up_competitors';
 export const TABLE_ENTRIES = 'entries';

--- a/src/modules/factory/projection/projectionTypes.ts
+++ b/src/modules/factory/projection/projectionTypes.ts
@@ -17,6 +17,7 @@ export type ProjectionIntent =
   | { kind: 'seeds'; tournamentId: string; structureId: string }
   | { kind: 'orderOfPlay'; tournamentId: string }
   | { kind: 'schedulingProfile'; tournamentId: string; schedulingProfile: any[] }
+  | { kind: 'participantPublish'; tournamentId: string }
   | { kind: 'venue'; tournamentId: string; venue: any }
   | { kind: 'deleteVenue'; tournamentId: string; venueId: string }
   | { kind: 'deleteDraw'; tournamentId: string; drawId: string }

--- a/src/modules/factory/projection/rebuild.ts
+++ b/src/modules/factory/projection/rebuild.ts
@@ -23,6 +23,7 @@ export function buildRebuildIntents(record: any): ProjectionIntent[] {
     { kind: 'participants', tournamentId },
     { kind: 'events', tournamentId },
     { kind: 'orderOfPlay', tournamentId },
+    { kind: 'participantPublish', tournamentId },
     // the stored scheduling plan (NATIVE `scheduling.profile`; LEGACY extension records
     // do not surface here, matching cast's NATIVE-first read on the same records)
     { kind: 'schedulingProfile', tournamentId, schedulingProfile: record?.scheduling?.profile ?? [] },


### PR DESCRIPTION
## What

Wires the **last two subscribed-but-unprojected publish-state topics** — participant-list publication and the tournament tombstone. Closes the "consume all subscriptions" set.

> **Stacked on #858** (schedule) → … → #852. **Depends on a factory release** exposing `readModel.participantPublishRow` + `tournaments.published` (factory master, pending merge `f261e8f6d`).

## Change

- **participant_publish** — `recordParticipantPublish` on publish/unpublish-participants; the delta resolves the record's participants publish status (published → upsert one row with embargo, unpublished → delete). Mirrors order_of_play.
- **tournaments.published** (aggregate = order-of-play OR participants published) — the factory `tournamentRow` now carries it, so publish/unpublish-order-of-play, publish/unpublish-participants, and **unpublish-tournament** all `recordTouchTournament` to refresh the tournaments row. **UNPUBLISH_TOURNAMENT** (the went-dark signal) now has a projection effect (flip `published` false) instead of cache-eviction only.
- `buildRebuildIntents` emits the participantPublish intent.

## Test

The **conformance capstone now publishes participants + asserts `participant_publish` and `tournaments.published`** — CFS rebuild ≡ factory `cast()` across all **13** tables. Factory module suite 215 → 217; projection specs 46 → 48. Additive + flag-gated.

## Companion

courthive-query PR: `query_tournaments.published` + `query_participant_publish`.