### PR TITLE
fix(projection): subscribe event-seeding publish topics (query_events.published no longer stale)

### DIFF
--- a/src/modules/factory/engines/getMutationEngine.spec.ts
+++ b/src/modules/factory/engines/getMutationEngine.spec.ts
@@ -1,0 +1,36 @@
+import { globalState, topicConstants } from 'tods-competition-factory';
+
+import { createDeltaBuffer } from '../projection/deltaBuffer';
+import { getMutationEngine } from './getMutationEngine';
+
+// getMutationEngine registers its topic→recorder map via globalState.setSubscriptions.
+// Spy on that call to capture the map, then invoke a handler directly with a fake notice
+// payload + a real delta buffer, asserting the intended projection intent is recorded.
+// This guards the SUBSCRIPTION WIRING itself (a missing/removed subscribe line fails here),
+// which the buildProjectionDeltas / conformance specs — fed intents directly — cannot catch.
+describe('getMutationEngine — projection subscription wiring', () => {
+  function captureSubscriptions(deltaBuffer: ReturnType<typeof createDeltaBuffer>): Record<string, any> {
+    const spy = jest.spyOn(globalState, 'setSubscriptions');
+    getMutationEngine(undefined, [], deltaBuffer);
+    const calls = spy.mock.calls;
+    const call = calls[calls.length - 1][0] as any;
+    spy.mockRestore();
+    return call.subscriptions;
+  }
+
+  it('PUBLISH_EVENT_SEEDING is subscribed and records an events intent', () => {
+    const buffer = createDeltaBuffer(['t1']);
+    const subs = captureSubscriptions(buffer);
+    expect(typeof subs[topicConstants.PUBLISH_EVENT_SEEDING]).toBe('function');
+    subs[topicConstants.PUBLISH_EVENT_SEEDING]([{ tournamentId: 't1', eventId: 'e1' }]);
+    expect(buffer.intents).toContainEqual({ kind: 'events', tournamentId: 't1' });
+  });
+
+  it('UNPUBLISH_EVENT_SEEDING is subscribed and records an events intent', () => {
+    const buffer = createDeltaBuffer(['t1']);
+    const subs = captureSubscriptions(buffer);
+    expect(typeof subs[topicConstants.UNPUBLISH_EVENT_SEEDING]).toBe('function');
+    subs[topicConstants.UNPUBLISH_EVENT_SEEDING]([{ tournamentId: 't1', eventId: 'e1' }]);
+    expect(buffer.intents).toContainEqual({ kind: 'events', tournamentId: 't1' });
+  });
+});

--- a/src/modules/factory/engines/getMutationEngine.ts
+++ b/src/modules/factory/engines/getMutationEngine.ts
@@ -282,6 +282,11 @@ export function getMutationEngine(services?, publicNotices?: any[], deltaBuffer?
       [topicConstants.ADD_EVENT]: (params) => recordEvents(deltaBuffer, params),
       [topicConstants.MODIFY_EVENT]: (params) => recordEvents(deltaBuffer, params),
       [topicConstants.DELETE_EVENT]: (params) => recordDeleteEvent(deltaBuffer, params),
+      // publishing/un-publishing event seeding flips the event's publish status
+      // (getEventPublishStatus, which drives events.published in cast) — re-cast the
+      // events rows so query_events.published does not go stale on a seeding publish.
+      [topicConstants.PUBLISH_EVENT_SEEDING]: (params) => recordEvents(deltaBuffer, params),
+      [topicConstants.UNPUBLISH_EVENT_SEEDING]: (params) => recordEvents(deltaBuffer, params),
       [topicConstants.MODIFY_EVENT_ENTRIES]: (params) => recordEntries(deltaBuffer, params),
       [topicConstants.MODIFY_DRAW_ENTRIES]: (params) => recordEntries(deltaBuffer, params),
       [topicConstants.MODIFY_SEED_ASSIGNMENTS]: (params) => recordSeeds(deltaBuffer, params),

--- a/src/modules/factory/projection/projection-conformance.spec.ts
+++ b/src/modules/factory/projection/projection-conformance.spec.ts
@@ -327,4 +327,39 @@ describe('projection conformance — incremental path ≡ rebuild path (byte-ide
     expect(entries.length).toBe(initialEntryCount - 1);
     expect(entries.some((r) => r.participant_id === removed.participantId)).toBe(false);
   });
+
+  // Publishing event seeding flips getEventPublishStatus → cast() marks events.published
+  // true, but publishEventSeeding dispatches only PUBLISH_EVENT_SEEDING. That topic is now
+  // subscribed to recordEvents; this asserts the incremental events row matches cast() for
+  // the seeding-published state (an unsubscribed topic would leave query_events.published stale).
+  it('publishEventSeeding → incremental events.published matches cast() (seeding topic projects)', async () => {
+    const { tournamentRecord } = mocksEngine.generateTournamentRecord({
+      drawProfiles: [{ drawSize: 8, seedsCount: 4, eventName: 'Singles' }],
+    });
+    const tournamentId = tournamentRecord.tournamentId;
+    const eventId = tournamentRecord.events[0].eventId;
+    const noFlatten = async () => [];
+
+    // baseline: an unpublished event projects published:false (incremental == cast).
+    const castEvents = (rec: any): any[] => (readModel.cast({ tournamentRecord: rec }).rows as any).events;
+    expect(castEvents(tournamentRecord)[0].published).toBe(false);
+
+    // publish seeding via the engine (writes the real PUBLISH.STATUS timeItem).
+    await tournamentEngineAsync.setState(tournamentRecord);
+    const pub: any = await tournamentEngineAsync.publishEventSeeding({ eventId });
+    expect(pub.success).toBe(true);
+    const mutated: any = (await tournamentEngineAsync.getState()).tournamentRecords[tournamentId];
+
+    // cast() (the oracle) now reports published:true.
+    expect(castEvents(mutated)[0].published).toBe(true);
+
+    // the incremental events intent (fired by the newly-subscribed PUBLISH_EVENT_SEEDING) must agree.
+    const deltas = await buildProjectionDeltas({
+      intents: [{ kind: 'events', tournamentId }],
+      tournamentRecords: { [tournamentId]: mutated },
+      flattenDraw: noFlatten,
+    });
+    const eventRow = deltas.find((d) => d.table === 'events' && d.row?.event_id === eventId);
+    expect(eventRow?.row?.published).toBe(true);
+  });
 });


### PR DESCRIPTION
Slice 2 (gap #8) of the read-model adversarial full-coverage challenge. Independent of the factory #7 change — `publishEventSeeding` already dispatches `PUBLISH_EVENT_SEEDING` in the pinned factory.

`publishEventSeeding` flips `getEventPublishStatus` (which drives `events.published` in `cast()`) but dispatches only `PUBLISH_EVENT_SEEDING`, a topic the projection did not subscribe. Publishing seeding on an otherwise-unpublished event left `query_events.published` stale at `false` while `cast()` reported `true`.

Subscribe `PUBLISH_EVENT_SEEDING` / `UNPUBLISH_EVENT_SEEDING` → `recordEvents`. Adds a conformance case (seeding publish converges `events.published` to `cast()`) and a subscription-wiring spec (captures the registered handler map and invokes the handlers directly — guards the wiring the intent-fed specs cannot).

Tests: 52 CFS projection + engines specs green; lint + check-types clean.