### PR TITLE
feat(projection): project nested round-robin group structures

### DIFF
--- a/src/modules/factory/projection/buildProjectionDeltas.ts
+++ b/src/modules/factory/projection/buildProjectionDeltas.ts
@@ -335,17 +335,25 @@ function eventDeltas(g: Grouped, records: Record<string, any>): ProjectionDelta[
 
 // Locate a structure + its owning event/draw in the final record (for a seeds
 // re-projection, the intent carries only the structureId).
+// Depth-first search for a structure by id, including nested round-robin group
+// sub-structures (a MODIFY_SEED_ASSIGNMENTS notice can carry a group's structureId).
+function findNestedStructure(structureList: any[], structureId: string): any {
+  for (const structure of structureList ?? []) {
+    if (structure?.structureId === structureId) return structure;
+    const nested = findNestedStructure(structure?.structures, structureId);
+    if (nested) return nested;
+  }
+  return undefined;
+}
+
 function findStructureContext(
   record: any,
   structureId: string,
 ): { eventId: string; drawId: string; structure: any } | undefined {
   for (const event of record?.events ?? []) {
     for (const draw of event.drawDefinitions ?? []) {
-      for (const structure of draw.structures ?? []) {
-        if (structure?.structureId === structureId) {
-          return { eventId: event.eventId, drawId: draw.drawId, structure };
-        }
-      }
+      const structure = findNestedStructure(draw.structures, structureId);
+      if (structure) return { eventId: event.eventId, drawId: draw.drawId, structure };
     }
   }
   return undefined;
@@ -376,14 +384,29 @@ function drawDeltas(g: Grouped, records: Record<string, any>): ProjectionDelta[]
     const drawRowData = drawRow(found.draw, tournamentId, found.eventId, providerId);
     deltas.push(upsert(tournamentId, TABLE_DRAWS, { draw_id: drawId }, drawRowData, 'draw'));
     deltas.push(del(tournamentId, TABLE_STRUCTURES, { draw_id: drawId }, 'draw'));
-    for (const structure of found.draw.structures ?? []) {
-      if (!structure?.structureId) continue;
-      const sctx = { tournamentId, eventId: found.eventId, drawId, providerId };
-      const row = structureRow(structure, sctx);
-      deltas.push(upsert(tournamentId, TABLE_STRUCTURES, { structure_id: row.structure_id }, row, 'draw'));
-    }
+    const ctxBase = { tournamentId, eventId: found.eventId, drawId, providerId };
+    collectStructureDeltas(found.draw.structures, ctxBase, null, tournamentId, deltas);
   }
   return deltas;
+}
+
+// Emit a structures upsert for each structure and its nested round-robin group
+// sub-structures (mirrors cast's collectStructures). `parentStructureId` = the
+// owning CONTAINER for a nested group (null at the top level), so a matchUp's
+// structure_id — which points at the GROUP — resolves to a structures row.
+function collectStructureDeltas(
+  structureList: any[],
+  ctxBase: { tournamentId: string; eventId: string; drawId: string; providerId: string | undefined },
+  parentStructureId: string | null,
+  tournamentId: string,
+  deltas: ProjectionDelta[],
+): void {
+  for (const structure of structureList ?? []) {
+    if (!structure?.structureId) continue;
+    const row = structureRow(structure, { ...ctxBase, parentStructureId });
+    deltas.push(upsert(tournamentId, TABLE_STRUCTURES, { structure_id: row.structure_id }, row, 'draw'));
+    collectStructureDeltas(structure.structures, ctxBase, structure.structureId, tournamentId, deltas);
+  }
 }
 
 // Seeds re-project PER STRUCTURE as delete-by-structure THEN re-insert: a seed set

--- a/src/modules/factory/projection/projection-conformance.spec.ts
+++ b/src/modules/factory/projection/projection-conformance.spec.ts
@@ -403,4 +403,39 @@ describe('projection conformance — incremental path ≡ rebuild path (byte-ide
     expect(beyond.length).toBeGreaterThan(0);
     expect(beyond.every((r: any) => r.published === false)).toBe(true);
   });
+
+  // Round-robin nested group sub-structures: the producer now walks nested
+  // structures so every matchUp's structure_id (a GROUP) resolves to a structures
+  // row, and rebuild stays byte-identical to cast().
+  it('round-robin nested structures: rebuild ≡ cast + no orphaned match_up structure_id', async () => {
+    const { tournamentRecord } = mocksEngine.generateTournamentRecord({
+      drawProfiles: [{ drawSize: 8, drawType: 'ROUND_ROBIN', eventName: 'RR' }],
+      completeAllMatchUps: true,
+    });
+    const tournamentId = tournamentRecord.tournamentId;
+    const flattenDraw = await flattenDrawOf(tournamentRecord);
+    const rebuiltDeltas = await buildProjectionDeltas({
+      intents: buildRebuildIntents(tournamentRecord),
+      tournamentRecords: { [tournamentId]: tournamentRecord },
+      flattenDraw,
+    });
+    const rebuilt = applyDeltas(rebuiltDeltas);
+    const castRows: any = readModel.cast({ tournamentRecord }).rows;
+    const castSort = (table: string) =>
+      [...(castRows[table] ?? [])].sort((a: any, b: any) => keyString(table, a).localeCompare(keyString(table, b)));
+
+    for (const table of ['structures', 'match_ups']) {
+      expect(snapshot(rebuilt, table)).toEqual(castSort(table));
+    }
+
+    const structureIds = new Set(snapshot(rebuilt, 'structures').map((s: any) => s.structure_id));
+    const muStructureIds = [...new Set(snapshot(rebuilt, 'match_ups').map((s: any) => s.structure_id))];
+    expect(muStructureIds.length).toBeGreaterThan(0);
+    expect(muStructureIds.every((id) => structureIds.has(id))).toBe(true); // no orphaned join
+
+    const container = snapshot(rebuilt, 'structures').find((s: any) => s.structure_type === 'CONTAINER');
+    expect(container).toBeDefined();
+    const groups = snapshot(rebuilt, 'structures').filter((s: any) => s.parent_structure_id === container.structure_id);
+    expect(groups.length).toBeGreaterThanOrEqual(2);
+  });
 });

--- a/src/modules/factory/projection/rebuild.ts
+++ b/src/modules/factory/projection/rebuild.ts
@@ -29,15 +29,22 @@ export function buildRebuildIntents(record: any): ProjectionIntent[] {
     { kind: 'schedulingProfile', tournamentId, schedulingProfile: record?.scheduling?.profile ?? [] },
   ];
 
+  // seeds re-project per structure, including nested round-robin group sub-structures
+  // (the `draw` intent already re-projects the draw + all its structures recursively).
+  const pushSeedIntents = (structureList: any[]) => {
+    for (const structure of structureList ?? []) {
+      if (structure?.structureId) intents.push({ kind: 'seeds', tournamentId, structureId: structure.structureId });
+      pushSeedIntents(structure?.structures);
+    }
+  };
+
   for (const event of record?.events ?? []) {
     for (const draw of event?.drawDefinitions ?? []) {
       if (draw?.drawId) {
         intents.push({ kind: 'flattenDraw', tournamentId, drawId: draw.drawId });
         intents.push({ kind: 'draw', tournamentId, drawId: draw.drawId });
       }
-      for (const structure of draw?.structures ?? []) {
-        if (structure?.structureId) intents.push({ kind: 'seeds', tournamentId, structureId: structure.structureId });
-      }
+      pushSeedIntents(draw?.structures);
     }
   }
 


### PR DESCRIPTION
**DRAFT — coupled to the factory publish** (its RR conformance case asserts nested structures that only exist once the factory pin includes the nested-structure change). Mirrors the factory recursion in drawDeltas + rebuild + findStructureContext, emitting a structures row per RR group with parent_structure_id. Merge order: factory releases → bump CFS pin → mark ready → merge. Pairs with factory + courthive-query PRs.